### PR TITLE
Initial add simple prod ready Dockerfile refs #57

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.6 as build
+
+ARG VERSION=0.11
+RUN pip install datasette==$VERSION
+
+FROM python:3.6-slim
+
+COPY --from=build /usr/local/lib/python3.6/site-packages /usr/local/lib/python3.6/site-packages
+COPY --from=build /usr/local/bin /usr/local/bin
+
+EXPOSE 8001
+CMD ["datasette"]


### PR DESCRIPTION
Multi-stage build based off official python:3.6-slim

Example usage:
```
docker run --rm -t -i -p 9000:8001 -v $(pwd)/db:/db datasette datasette serve /db/chinook.db
```