### PR TITLE
Add spatialite, switch to debian and local build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
-FROM python:3.6 as build
+FROM python:3.6-slim-stretch as build
 
-ARG VERSION=0.11
-RUN pip install datasette==$VERSION
+# Setup build dependencies
+RUN apt update
+RUN apt install -y python-dev gcc libsqlite3-mod-spatialite
+# Add local code to the image instead of fetching from pypi.
+ADD . /datasette
 
-FROM python:3.6-slim
+RUN pip install /datasette
 
+FROM python:3.6-slim-stretch
+
+# Copy python dependencies
 COPY --from=build /usr/local/lib/python3.6/site-packages /usr/local/lib/python3.6/site-packages
+# Copy executables
 COPY --from=build /usr/local/bin /usr/local/bin
+# Copy spatial extensions
+COPY --from=build /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
 
 EXPOSE 8001
 CMD ["datasette"]


### PR DESCRIPTION
Improves the Dockerfile to support spatial datasets, work with the local datasette code (Friendly with git tags and Dockerhub) and moves to slim debian, a small image easy to extend via apt packages for sqlite.