### PR TITLE
Add keyboard shortcut to execute SQL query

### DIFF
--- a/datasette/templates/database.html
+++ b/datasette/templates/database.html
@@ -90,6 +90,11 @@
       mode: "text/x-sql",
       lineWrapping: true,
     });
+    editor.setOption("extraKeys", {
+      "Shift-Enter": function() {
+        document.getElementsByClassName("sql")[0].submit();
+      }
+    });
 </script>
 
 {% endblock %}


### PR DESCRIPTION
Very cool tool, thanks a lot!

This PR adds a `Shift-Enter` short cut to execute the SQL query. I used CodeMirrors keyboard handling.