### PR TITLE
Fix pytest version conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     ''',
     setup_requires=['pytest-runner'],
     tests_require=[
-        'pytest==3.2.3',
+        'pytest==3.2.1',
         'aiohttp==2.3.2',
     ],
     classifiers=[


### PR DESCRIPTION
https://travis-ci.org/simonw/datasette/jobs/305929426

    pkg_resources.VersionConflict: (pytest 3.2.1 (/home/travis/virtualenv/python3.5.3/lib/python3.5/site-packages), 
    Requirement.parse('pytest==3.2.3'))