### PR TITLE
If metadata exists, add it to heroku launch command

### DIFF
--- a/datasette/utils.py
+++ b/datasette/utils.py
@@ -264,6 +264,8 @@ def temporary_heroku_directory(files, name, metadata, extra_options, branch, tem
                 os.path.join(tmp.name, 'templates')
             )
             extras.extend(['--template-dir', 'templates/'])
+        if metadata:
+            extras.extend(['--metadata', 'metadata.json'])
         for mount_point, path in static:
             link_or_copy_directory(
                 os.path.join(saved_cwd, path),


### PR DESCRIPTION
The heroku build does seem to make use of any provided `metadata.json` file.

Add the `--metadata` switch to the Heroku web launch command if a `metadata.json` file is available.

Addresses: https://github.com/simonw/datasette/issues/177