### PR TITLE
Initial units support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Sanic==0.7.0',
         'Jinja2==2.10',
         'hupper==1.0',
+        'pint==0.8.1'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Add support for specifying units for a column in metadata.json and rendering them on display using [pint](https://pint.readthedocs.io/en/latest/).

Example table metadata:
```json
                "license_frequency": {
                    "units": {
                        "frequency": "Hz",
                        "channel_width": "Hz",
                        "height": "m",
                        "antenna_height": "m",
                        "azimuth": "degrees"
                    }
                }
```

[Example result](https://wtr-api.herokuapp.com/wtr-663ea99/license_frequency/1)

This works surprisingly well! I'd like to add support for using units when querying but this is PR is pretty usable as-is.

(Pint doesn't seem to support decibels though - it thinks they're decibytes - which is an annoying omission.)

(ref ticket #203)