### PR TITLE
Support filtering with units and more

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -647,7 +647,9 @@ class TableView(RowTableShared):
                 forward_querystring=False
             )
 
-        filters = Filters(sorted(other_args.items()))
+        units = self.table_metadata(name, table).get('units', {})
+
+        filters = Filters(sorted(other_args.items()), units, ureg)
         where_clauses, params = filters.build_where_clauses()
 
         # _search support:
@@ -891,7 +893,7 @@ class TableView(RowTableShared):
             'filtered_table_rows_count': filtered_table_rows_count,
             'columns': columns,
             'primary_keys': pks,
-            'units': self.table_metadata(name, table).get('units', {}),
+            'units': units,
             'query': {
                 'sql': sql,
                 'params': params,

--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -160,6 +160,7 @@ def skeleton(files, metadata, sqlite_extensions):
                     'license_url': None,
                     'source': None,
                     'source_url': None,
+                    'units': {}
                 } for table_name in (info.get('tables') or {})
             }
         }

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -55,6 +55,35 @@ You can also provide metadata at the per-database or per-table level, like this:
 
 Each of the top-level metadata fields can be used at the database and table level.
 
+Specifying units for a column
+-----------------------------
+
+Datasette supports attaching units to a column, which will be used when displaying
+values from that column. SI prefixes will be used where appropriate.
+
+Column units are configured in the metadata like so::
+
+    {
+        "databases": {
+            "database1": {
+                "tables": {
+                    "example_table": {
+                        "units": {
+                            "column1": "metres",
+                            "column2": "Hz"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+Units are interpreted using Pint_, and you can see the full list of available units in
+Pint's `unit registry`_.
+
+.. _Pint: https://pint.readthedocs.io/
+.. _unit registry: https://github.com/hgrecco/pint/blob/master/pint/default_en.txt
+
 Setting which columns can be used for sorting
 ---------------------------------------------
 
@@ -119,7 +148,8 @@ This will create a ``metadata.json`` file looking something like this::
                         "license": null,
                         "license_url": null,
                         "source": null,
-                        "source_url": null
+                        "source_url": null,
+                        "units": {}
                     }
                 }
             },


### PR DESCRIPTION
The first commit:
* Adds units to exported JSON
* Adds units key to metadata skeleton
* Adds some docs for units

The second commit adds filtering by units by the first method I mentioned in #203:
![image](https://user-images.githubusercontent.com/45057/38767463-7193be16-3fd9-11e8-8a5f-ac4159415c6d.png)

I think it integrates pretty neatly.
