### PR TITLE
Return HTTP 405 on InvalidUsage rather than 500

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -1,6 +1,6 @@
 from sanic import Sanic
 from sanic import response
-from sanic.exceptions import NotFound
+from sanic.exceptions import NotFound, InvalidUsage
 from sanic.views import HTTPMethodView
 from sanic.request import RequestParameters
 from jinja2 import Environment, FileSystemLoader, ChoiceLoader, PrefixLoader
@@ -1256,6 +1256,10 @@ class Datasette:
             title = None
             if isinstance(exception, NotFound):
                 status = 404
+                info = {}
+                message = exception.args[0]
+            elif isinstance(exception, InvalidUsage):
+                status = 405
                 info = {}
                 message = exception.args[0]
             elif isinstance(exception, DatasetteError):


### PR DESCRIPTION
This also stops it filling up the logs. This happens for HEAD requests at the moment - which perhaps should be handled better, but that's a different issue.