### PR TITLE
 Don't duplicate simple primary keys in the link column

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -524,10 +524,11 @@ class RowTableShared(BaseView):
                 cells.append({
                     'column': 'Link',
                     'value': jinja2.Markup(
-                        '<a href="/{database}/{table}/{flat_pks}">{flat_pks}</a>'.format(
+                        '<a href="/{database}/{table}/{flat_pks_quoted}">{flat_pks}</a>'.format(
                             database=database,
                             table=urllib.parse.quote_plus(table),
-                            flat_pks=path_from_row_pks(row, pks, not pks),
+                            flat_pks=str(jinja2.escape(path_from_row_pks(row, pks, not pks, False))),
+                            flat_pks_quoted=path_from_row_pks(row, pks, not pks)
                         )
                     ),
                 })

--- a/datasette/app.py
+++ b/datasette/app.py
@@ -532,8 +532,13 @@ class RowTableShared(BaseView):
                         )
                     ),
                 })
+
             for value, column_dict in zip(row, columns):
                 column = column_dict['name']
+                if link_column and len(pks) == 1 and column == pks[0]:
+                    # If there's a simple primary key, don't repeat the value as it's
+                    # already shown in the link column.
+                    continue
                 if (column, value) in labeled_fks:
                     other_table, label = labeled_fks[(column, value)]
                     display_value = jinja2.Markup(
@@ -560,17 +565,17 @@ class RowTableShared(BaseView):
                             url=jinja2.escape(value.strip())
                         )
                     )
+                elif column in table_metadata.get('units', {}) and value != '':
+                    # Interpret units using pint
+                    value = value * ureg(table_metadata['units'][column])
+                    # Pint uses floating point which sometimes introduces errors in the compact
+                    # representation, which we have to round off to avoid ugliness. In the vast
+                    # majority of cases this rounding will be inconsequential. I hope.
+                    value = round(value.to_compact(), 6)
+                    display_value = jinja2.Markup('{:~P}'.format(value).replace(' ', '&nbsp;'))
                 else:
-                    if column in table_metadata.get('units', {}) and value != '':
-                        # Interpret units using pint
-                        value = value * ureg(table_metadata['units'][column])
-                        # Pint uses floating point which sometimes introduces errors in the compact
-                        # representation, which we have to round off to avoid ugliness. In the vast
-                        # majority of cases this rounding will be inconsequential. I hope.
-                        value = round(value.to_compact(), 6)
-                        display_value = jinja2.Markup('{:~P}'.format(value).replace(' ', '&nbsp;'))
-                    else:
-                        display_value = str(value)
+                    display_value = str(value)
+
                 cells.append({
                     'column': column,
                     'value': display_value,
@@ -578,9 +583,15 @@ class RowTableShared(BaseView):
             cell_rows.append(cells)
 
         if link_column:
+            # Add the link column header.
+            # If it's a simple primary key, we have to remove and re-add that column name at
+            # the beginning of the header row.
+            if len(pks) == 1:
+                columns = [col for col in columns if col['name'] != pks[0]]
+
             columns = [{
-                'name': 'Link',
-                'sortable': False,
+                'name': pks[0] if len(pks) == 1 else 'Link',
+                'sortable': len(pks) == 1,
             }] + columns
         return columns, cell_rows
 

--- a/datasette/static/app.css
+++ b/datasette/static/app.css
@@ -17,6 +17,9 @@ td {
     padding: 4px;
     vertical-align: top;
 }
+td.col-link {
+    font-weight: bold;
+}
 td em {
     font-style: normal;
     font-size: 0.8em;

--- a/datasette/templates/_rows_and_columns.html
+++ b/datasette/templates/_rows_and_columns.html
@@ -20,7 +20,7 @@
     {% for row in display_rows %}
         <tr>
             {% for cell in row %}
-                <td>{{ cell.value }}</td>
+                <td class="col-{{ cell.column|lower }}">{{ cell.value }}</td>
             {% endfor %}
         </tr>
     {% endfor %}

--- a/datasette/utils.py
+++ b/datasette/utils.py
@@ -38,14 +38,19 @@ def urlsafe_components(token):
     ]
 
 
-def path_from_row_pks(row, pks, use_rowid):
+def path_from_row_pks(row, pks, use_rowid, quote=True):
+    """ Generate an optionally URL-quoted unique identifier
+        for a row from its primary keys."""
     if use_rowid:
-        return urllib.parse.quote_plus(str(row['rowid']))
-    bits = []
-    for pk in pks:
-        bits.append(
-            urllib.parse.quote_plus(str(row[pk]))
-        )
+        bits = [row['rowid']]
+    else:
+        bits = [row[pk] for pk in pks]
+
+    if quote:
+        bits = [urllib.parse.quote_plus(str(bit)) for bit in bits]
+    else:
+        bits = [str(bit) for bit in bits]
+
     return ','.join(bits)
 
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -163,16 +163,18 @@ def test_sort_by_desc_redirects(app_client):
 ])
 def test_css_classes_on_body(app_client, path, expected_classes):
     response = app_client.get(path, gather_request=False)
+    assert response.status == 200
     classes = re.search(r'<body class="(.*)">', response.text).group(1).split()
     assert classes == expected_classes
 
 
 def test_table_html_simple_primary_key(app_client):
     response = app_client.get('/test_tables/simple_primary_key', gather_request=False)
+    assert response.status == 200
     table = Soup(response.body, 'html.parser').find('table')
     ths = table.findAll('th')
-    assert 'Link' == ths[0].string.strip()
-    for expected_col, th in zip(('id', 'content'), ths[1:]):
+    assert 'id' == ths[0].find('a').string.strip()
+    for expected_col, th in zip(('content',), ths[1:]):
         a = th.find('a')
         assert expected_col == a.string
         assert a['href'].endswith('/simple_primary_key?_sort={}'.format(
@@ -182,15 +184,12 @@ def test_table_html_simple_primary_key(app_client):
     assert [
         [
             '<td><a href="/test_tables/simple_primary_key/1">1</a></td>',
-            '<td>1</td>',
             '<td>hello</td>'
         ], [
             '<td><a href="/test_tables/simple_primary_key/2">2</a></td>',
-            '<td>2</td>',
             '<td>world</td>'
         ], [
             '<td><a href="/test_tables/simple_primary_key/3">3</a></td>',
-            '<td>3</td>',
             '<td></td>'
         ]
     ] == [[str(td) for td in tr.select('td')] for tr in table.select('tbody tr')]
@@ -198,6 +197,7 @@ def test_table_html_simple_primary_key(app_client):
 
 def test_row_html_simple_primary_key(app_client):
     response = app_client.get('/test_tables/simple_primary_key/1', gather_request=False)
+    assert response.status == 200
     table = Soup(response.body, 'html.parser').find('table')
     assert [
         'id', 'content'
@@ -218,6 +218,7 @@ def test_table_not_exists(app_client):
 
 def test_table_html_no_primary_key(app_client):
     response = app_client.get('/test_tables/no_primary_key', gather_request=False)
+    assert response.status == 200
     table = Soup(response.body, 'html.parser').find('table')
     # We have disabled sorting for this table using metadata.json
     assert [
@@ -238,6 +239,7 @@ def test_table_html_no_primary_key(app_client):
 
 def test_row_html_no_primary_key(app_client):
     response = app_client.get('/test_tables/no_primary_key/1', gather_request=False)
+    assert response.status == 200
     table = Soup(response.body, 'html.parser').find('table')
     assert [
         'rowid', 'content', 'a', 'b', 'c'
@@ -256,6 +258,7 @@ def test_row_html_no_primary_key(app_client):
 
 def test_table_html_compound_primary_key(app_client):
     response = app_client.get('/test_tables/compound_primary_key', gather_request=False)
+    assert response.status == 200
     table = Soup(response.body, 'html.parser').find('table')
     ths = table.findAll('th')
     assert 'Link' == ths[0].string.strip()
@@ -278,11 +281,11 @@ def test_table_html_compound_primary_key(app_client):
 
 def test_table_html_foreign_key_links(app_client):
     response = app_client.get('/test_tables/foreign_key_references', gather_request=False)
+    assert response.status == 200
     table = Soup(response.body, 'html.parser').find('table')
     expected = [
         [
             '<td><a href="/test_tables/foreign_key_references/1">1</a></td>',
-            '<td>1</td>',
             '<td><a href="/test_tables/simple_primary_key/1">hello</a>\xa0<em>1</em></td>',
             '<td><a href="/test_tables/primary_key_multiple_columns/1">1</a></td>'
         ]
@@ -292,6 +295,7 @@ def test_table_html_foreign_key_links(app_client):
 
 def test_row_html_compound_primary_key(app_client):
     response = app_client.get('/test_tables/compound_primary_key/a,b', gather_request=False)
+    assert response.status == 200
     table = Soup(response.body, 'html.parser').find('table')
     assert [
         'pk1', 'pk2', 'content'
@@ -308,6 +312,7 @@ def test_row_html_compound_primary_key(app_client):
 
 def test_view_html(app_client):
     response = app_client.get('/test_tables/simple_view', gather_request=False)
+    assert response.status == 200
     table = Soup(response.body, 'html.parser').find('table')
     assert [
         'content', 'upper_content'
@@ -329,6 +334,7 @@ def test_view_html(app_client):
 
 def test_index_metadata(app_client):
     response = app_client.get('/', gather_request=False)
+    assert response.status == 200
     soup = Soup(response.body, 'html.parser')
     assert 'Datasette Title' == soup.find('h1').text
     assert 'Datasette Description' == inner_html(
@@ -339,6 +345,7 @@ def test_index_metadata(app_client):
 
 def test_database_metadata(app_client):
     response = app_client.get('/test_tables', gather_request=False)
+    assert response.status == 200
     soup = Soup(response.body, 'html.parser')
     # Page title should be the default
     assert 'test_tables' == soup.find('h1').text
@@ -352,6 +359,7 @@ def test_database_metadata(app_client):
 
 def test_table_metadata(app_client):
     response = app_client.get('/test_tables/simple_primary_key', gather_request=False)
+    assert response.status == 200
     soup = Soup(response.body, 'html.parser')
     # Page title should be custom and should be HTML escaped
     assert 'This &lt;em&gt;HTML&lt;/em&gt; is escaped' == inner_html(soup.find('h1'))

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -183,14 +183,14 @@ def test_table_html_simple_primary_key(app_client):
         assert ['nofollow'] == a['rel']
     assert [
         [
-            '<td><a href="/test_tables/simple_primary_key/1">1</a></td>',
-            '<td>hello</td>'
+            '<td class="col-link"><a href="/test_tables/simple_primary_key/1">1</a></td>',
+            '<td class="col-content">hello</td>'
         ], [
-            '<td><a href="/test_tables/simple_primary_key/2">2</a></td>',
-            '<td>world</td>'
+            '<td class="col-link"><a href="/test_tables/simple_primary_key/2">2</a></td>',
+            '<td class="col-content">world</td>'
         ], [
-            '<td><a href="/test_tables/simple_primary_key/3">3</a></td>',
-            '<td></td>'
+            '<td class="col-link"><a href="/test_tables/simple_primary_key/3">3</a></td>',
+            '<td class="col-content"></td>'
         ]
     ] == [[str(td) for td in tr.select('td')] for tr in table.select('tbody tr')]
 
@@ -204,8 +204,8 @@ def test_row_html_simple_primary_key(app_client):
     ] == [th.string.strip() for th in table.select('thead th')]
     assert [
         [
-            '<td>1</td>',
-            '<td>hello</td>'
+            '<td class="col-id">1</td>',
+            '<td class="col-content">hello</td>'
         ]
     ] == [[str(td) for td in tr.select('td')] for tr in table.select('tbody tr')]
 
@@ -226,12 +226,12 @@ def test_table_html_no_primary_key(app_client):
     ] == [th.string.strip() for th in table.select('thead th')[2:]]
     expected = [
         [
-            '<td><a href="/test_tables/no_primary_key/{}">{}</a></td>'.format(i, i),
-            '<td>{}</td>'.format(i),
-            '<td>{}</td>'.format(i),
-            '<td>a{}</td>'.format(i),
-            '<td>b{}</td>'.format(i),
-            '<td>c{}</td>'.format(i),
+            '<td class="col-link"><a href="/test_tables/no_primary_key/{}">{}</a></td>'.format(i, i),
+            '<td class="col-rowid">{}</td>'.format(i),
+            '<td class="col-content">{}</td>'.format(i),
+            '<td class="col-a">a{}</td>'.format(i),
+            '<td class="col-b">b{}</td>'.format(i),
+            '<td class="col-c">c{}</td>'.format(i),
         ] for i in range(1, 51)
     ]
     assert expected == [[str(td) for td in tr.select('td')] for tr in table.select('tbody tr')]
@@ -246,11 +246,11 @@ def test_row_html_no_primary_key(app_client):
     ] == [th.string.strip() for th in table.select('thead th')]
     expected = [
         [
-            '<td>1</td>',
-            '<td>1</td>',
-            '<td>a1</td>',
-            '<td>b1</td>',
-            '<td>c1</td>',
+            '<td class="col-rowid">1</td>',
+            '<td class="col-content">1</td>',
+            '<td class="col-a">a1</td>',
+            '<td class="col-b">b1</td>',
+            '<td class="col-c">c1</td>',
         ]
     ]
     assert expected == [[str(td) for td in tr.select('td')] for tr in table.select('tbody tr')]
@@ -270,10 +270,10 @@ def test_table_html_compound_primary_key(app_client):
         ))
     expected = [
         [
-            '<td><a href="/test_tables/compound_primary_key/a,b">a,b</a></td>',
-            '<td>a</td>',
-            '<td>b</td>',
-            '<td>c</td>',
+            '<td class="col-link"><a href="/test_tables/compound_primary_key/a,b">a,b</a></td>',
+            '<td class="col-pk1">a</td>',
+            '<td class="col-pk2">b</td>',
+            '<td class="col-content">c</td>',
         ]
     ]
     assert expected == [[str(td) for td in tr.select('td')] for tr in table.select('tbody tr')]
@@ -285,9 +285,9 @@ def test_table_html_foreign_key_links(app_client):
     table = Soup(response.body, 'html.parser').find('table')
     expected = [
         [
-            '<td><a href="/test_tables/foreign_key_references/1">1</a></td>',
-            '<td><a href="/test_tables/simple_primary_key/1">hello</a>\xa0<em>1</em></td>',
-            '<td><a href="/test_tables/primary_key_multiple_columns/1">1</a></td>'
+            '<td class="col-link"><a href="/test_tables/foreign_key_references/1">1</a></td>',
+            '<td class="col-foreign_key_with_label"><a href="/test_tables/simple_primary_key/1">hello</a>\xa0<em>1</em></td>',
+            '<td class="col-foreign_key_with_no_label"><a href="/test_tables/primary_key_multiple_columns/1">1</a></td>'
         ]
     ]
     assert expected == [[str(td) for td in tr.select('td')] for tr in table.select('tbody tr')]
@@ -302,9 +302,9 @@ def test_row_html_compound_primary_key(app_client):
     ] == [th.string.strip() for th in table.select('thead th')]
     expected = [
         [
-            '<td>a</td>',
-            '<td>b</td>',
-            '<td>c</td>',
+            '<td class="col-pk1">a</td>',
+            '<td class="col-pk2">b</td>',
+            '<td class="col-content">c</td>',
         ]
     ]
     assert expected == [[str(td) for td in tr.select('td')] for tr in table.select('tbody tr')]
@@ -319,14 +319,14 @@ def test_view_html(app_client):
     ] == [th.string.strip() for th in table.select('thead th')]
     expected = [
         [
-            '<td>hello</td>',
-            '<td>HELLO</td>'
+            '<td class="col-content">hello</td>',
+            '<td class="col-upper_content">HELLO</td>'
         ], [
-            '<td>world</td>',
-            '<td>WORLD</td>'
+            '<td class="col-content">world</td>',
+            '<td class="col-upper_content">WORLD</td>'
         ], [
-            '<td></td>',
-            '<td></td>'
+            '<td class="col-content"></td>',
+            '<td class="col-upper_content"></td>'
         ]
     ]
     assert expected == [[str(td) for td in tr.select('td')] for tr in table.select('tbody tr')]


### PR DESCRIPTION
When there's a simple (single-column) primary key, it looks weird to duplicate it in the link column.

This change removes the second PK column and treats the link column as if it were the PK column from a header/sorting perspective. 

This might make it a bit more difficult to tell what the link for the row is, I'm not sure yet. I feel like the alternative is to change the link column to just have the text "view" or something, instead of repeating the PK. (I doubt it makes much more sense with compound PKs.)

Bonus change in this PR: fix urlencoding of links in the displayed HTML.

Before:
![image](https://user-images.githubusercontent.com/45057/38783830-e2ababb4-40ff-11e8-97fb-25e286a8c920.png)

After:
![image](https://user-images.githubusercontent.com/45057/38783835-ebf6b48e-40ff-11e8-8c47-6a864cf21ccc.png)