### PR TITLE
Add new metadata key persistent_urls which removes the hash from all database urls

### DIFF
--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -255,6 +255,7 @@ def skeleton(files, metadata, sqlite_extensions):
                 "license_url": None,
                 "source": None,
                 "source_url": None,
+                "persistent_urls": "false",
                 "databases": databases,
             },
             indent=4,

--- a/datasette/templates/database.html
+++ b/datasette/templates/database.html
@@ -16,7 +16,7 @@
 
 {% block description_source_license %}{% include "_description_source_license.html" %}{% endblock %}
 
-<form class="sql" action="/{{ database }}-{{ database_hash }}" method="get">
+<form class="sql" action="/{{ database_url }}" method="get">
     <h3>Custom SQL query</h3>
     <p><textarea name="sql">select * from {{ tables[0].name|escape_sqlite }}</textarea></p>
     <p><input type="submit" value="Run SQL"></p>
@@ -25,7 +25,7 @@
 {% for table in tables %}
 {% if show_hidden or not table.hidden %}
 <div class="db-table">
-    <h2><a href="/{{ database }}-{{ database_hash }}/{{ table.name|quote_plus }}">{{ table.name }}</a>{% if table.hidden %}<em> (hidden)</em>{% endif %}</h2>
+    <h2><a href="/{{ database_url }}/{{ table.name|quote_plus }}">{{ table.name }}</a>{% if table.hidden %}<em> (hidden)</em>{% endif %}</h2>
     <p><em>{% for column in table.columns[:9] %}{{ column }}{% if not loop.last %}, {% endif %}{% endfor %}{% if table.columns|length > 9 %}...{% endif %}</em></p>
     <p>{{ "{:,}".format(table.count) }} row{% if table.count == 1 %}{% else %}s{% endif %}</p>
 </div>
@@ -33,14 +33,14 @@
 {% endfor %}
 
 {% if hidden_count and not show_hidden %}
-    <p>... and <a href="/{{ database }}-{{ database_hash }}?_show_hidden=1">{{ "{:,}".format(hidden_count) }} hidden table{% if hidden_count == 1 %}{% else %}s{% endif %}</a></p>
+    <p>... and <a href="/{{ database_url }}?_show_hidden=1">{{ "{:,}".format(hidden_count) }} hidden table{% if hidden_count == 1 %}{% else %}s{% endif %}</a></p>
 {% endif %}
 
 {% if views %}
     <h2>Views</h2>
     <ul>
         {% for view in views %}
-            <li><a href="/{{ database }}-{{ database_hash }}/{{ view|urlencode }}">{{ view }}</a></li>
+            <li><a href="/{{ database_url }}/{{ view|urlencode }}">{{ view }}</a></li>
         {% endfor %}
     </ul>
 {% endif %}
@@ -49,12 +49,12 @@
     <h2>Queries</h2>
     <ul>
         {% for query in queries %}
-            <li><a href="/{{ database }}-{{ database_hash }}/{{ query.name|urlencode }}" title="{{ query.sql }}">{{ query.name }}</a></li>
+            <li><a href="/{{ database_url }}/{{ query.name|urlencode }}" title="{{ query.sql }}">{{ query.name }}</a></li>
         {% endfor %}
     </ul>
 {% endif %}
 
-<p>Download SQLite DB: <a href="/{{ database }}-{{ database_hash }}.db">{{ database }}.db</a></p>
+<p>Download SQLite DB: <a href="/{{ database_url }}.db">{{ database }}.db</a></p>
 
 {% include "_codemirror_foot.html" %}
 

--- a/datasette/templates/query.html
+++ b/datasette/templates/query.html
@@ -19,11 +19,11 @@
 {% block body_class %}query db-{{ database|to_css_class }}{% endblock %}
 
 {% block content %}
-<div class="hd"><a href="/">home</a> / <a href="/{{ database }}-{{ database_hash }}">{{ database }}</a></div>
+<div class="hd"><a href="/">home</a> / <a href="/{{ database_url }}">{{ database }}</a></div>
 
 <h1 style="padding-left: 10px; border-left: 10px solid #{{ database_hash[:6] }}">{{ database }}</h1>
 
-<form class="sql" action="/{{ database }}-{{ database_hash }}{% if canned_query %}/{{ canned_query }}{% endif %}" method="get">
+<form class="sql" action="/{{ database_url }}{% if canned_query %}/{{ canned_query }}{% endif %}" method="get">
     <h3>Custom SQL query{% if rows %} returning {% if truncated %}more than {% endif %}{{ "{:,}".format(rows|length) }} row{% if rows|length == 1 %}{% else %}s{% endif %}{% endif %}</h3>
     {% if editable %}
         <p><textarea name="sql">{% if query and query.sql %}{{ query.sql }}{% else %}select * from {{ tables[0].name|escape_sqlite }}{% endif %}</textarea></p>

--- a/datasette/templates/row.html
+++ b/datasette/templates/row.html
@@ -16,7 +16,7 @@
 {% block body_class %}row db-{{ database|to_css_class }} table-{{ table|to_css_class }}{% endblock %}
 
 {% block content %}
-<div class="hd"><a href="/">home</a> / <a href="/{{ database }}-{{ database_hash }}">{{ database }}</a> / <a href="/{{ database }}-{{ database_hash }}/{{ table|quote_plus }}">{{ table }}</a></div>
+<div class="hd"><a href="/">home</a> / <a href="/{{ database_url }}">{{ database }}</a> / <a href="/{{ database_url }}/{{ table|quote_plus }}">{{ table }}</a></div>
 
 <h1 style="padding-left: 10px; border-left: 10px solid #{{ database_hash[:6] }}">{{ table }}: {{ ', '.join(primary_key_values) }}</a></h1>
 
@@ -31,7 +31,7 @@
     <ul>
         {% for other in foreign_key_tables %}
             <li>
-                <a href="/{{ database }}-{{ database_hash }}/{{ other.other_table|quote_plus }}?{{ other.other_column }}={{ ', '.join(primary_key_values) }}">
+                <a href="/{{ database_url }}/{{ other.other_table|quote_plus }}?{{ other.other_column }}={{ ', '.join(primary_key_values) }}">
                     {{ "{:,}".format(other.count) }} row{% if other.count == 1 %}{% else %}s{% endif %}</a>
                 from {{ other.other_column }} in {{ other.other_table }}
             </li>

--- a/datasette/templates/table.html
+++ b/datasette/templates/table.html
@@ -17,7 +17,7 @@
 {% block body_class %}table db-{{ database|to_css_class }} table-{{ table|to_css_class }}{% endblock %}
 
 {% block content %}
-<div class="hd"><a href="/">home</a> / <a href="/{{ database }}-{{ database_hash }}">{{ database }}</a></div>
+<div class="hd"><a href="/">home</a> / <a href="/{{ database_url }}">{{ database }}</a></div>
 
 <h1 style="padding-left: 10px; border-left: 10px solid #{{ database_hash[:6] }}">{{ metadata.title or table }}{% if is_view %} (view){% endif %}</h1>
 
@@ -29,7 +29,7 @@
     </h3>
 {% endif %}
 
-<form class="filters" action="/{{ database }}-{{ database_hash }}/{{ table|quote_plus }}" method="get">
+<form class="filters" action="/{{ database_url }}/{{ table|quote_plus }}" method="get">
     {% if supports_search %}
         <div class="search-row"><label for="_search">Search:</label><input id="_search" type="search" name="_search" value="{{ search }}"></div>
     {% endif %}
@@ -86,7 +86,7 @@
 </form>
 
 {% if query.sql %}
-    <p><a class="not-underlined" title="{{ query.sql }}" href="/{{ database }}-{{ database_hash }}?{{ {'sql': query.sql}|urlencode|safe }}{% if query.params %}&amp;{{ query.params|urlencode|safe }}{% endif %}">&#x270e; <span class="underlined">View and edit SQL</span></a></p>
+    <p><a class="not-underlined" title="{{ query.sql }}" href="/{{ database_url }}?{{ {'sql': query.sql}|urlencode|safe }}{% if query.params %}&amp;{{ query.params|urlencode|safe }}{% endif %}">&#x270e; <span class="underlined">View and edit SQL</span></a></p>
 {% endif %}
 
 <p>This data as <a href="{{ url_json }}">.json</a></p>

--- a/datasette/views/base.py
+++ b/datasette/views/base.py
@@ -114,17 +114,18 @@ class BaseView(RenderMixin):
             raise NotFound("Database not found: {}".format(name))
 
         expected = info["hash"][:HASH_LENGTH]
-        if expected != hash:
-            should_redirect = "/{}-{}".format(name, expected)
-            if "table" in kwargs:
-                should_redirect += "/" + kwargs["table"]
-            if "pk_path" in kwargs:
-                should_redirect += "/" + kwargs["pk_path"]
-            if "as_json" in kwargs:
-                should_redirect += kwargs["as_json"]
-            if "as_db" in kwargs:
-                should_redirect += kwargs["as_db"]
-            return name, expected, should_redirect
+        if self.ds.metadata.get("persistent_urls", "false") == "false":
+            if expected != hash:
+                should_redirect = "/{}-{}".format(name, expected)
+                if "table" in kwargs:
+                    should_redirect += "/" + kwargs["table"]
+                if "pk_path" in kwargs:
+                    should_redirect += "/" + kwargs["pk_path"]
+                if "as_json" in kwargs:
+                    should_redirect += kwargs["as_json"]
+                if "as_db" in kwargs:
+                    should_redirect += kwargs["as_db"]
+                return name, expected, should_redirect
 
         return name, expected, None
 

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -31,6 +31,10 @@ class DatabaseView(BaseView):
             ],
         }, {
             "database_hash": hash,
+            "database_url": "{}".format(name)
+            if self.ds.metadata.get("persistent_urls", "false") == "true"
+            else "{}-{}".format(name, hash),
+            "persistent_urls": metadata.get("persistent_urls", "false"),
             "show_hidden": request.args.get("_show_hidden"),
             "editable": True,
             "metadata": metadata,

--- a/datasette/views/index.py
+++ b/datasette/views/index.py
@@ -24,7 +24,11 @@ class IndexView(RenderMixin):
             database = {
                 "name": key,
                 "hash": info["hash"],
-                "path": "{}-{}".format(key, info["hash"][:HASH_LENGTH]),
+                "persistent_urls":
+                    self.ds.metadata.get("persistent_urls", "false"),
+                "path": "{}".format(key)
+                if self.ds.metadata.get("persistent_urls", "false") == "true"
+                else "{}-{}".format(key, info["hash"][:HASH_LENGTH]),
                 "tables_truncated": sorted(
                     tables, key=lambda t: t["count"], reverse=True
                 )[

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -567,6 +567,9 @@ class TableView(RowTableShared):
 
         # human_description_en combines filters AND search, if provided
         human_description_en = filters.human_description_en(extra=search_descriptions)
+        database_url = "{}".format(name) \
+            if self.ds.metadata.get("persistent_urls","false") == "true" \
+            else "{}-{}".format(name, hash)
 
         if sort or sort_desc:
             sorted_by = "sorted by {}{}".format(
@@ -593,6 +596,9 @@ class TableView(RowTableShared):
             self.ds.update_with_inherited_metadata(metadata)
             return {
                 "database_hash": hash,
+                "database_url": database_url,
+                "persistent_urls":
+                    self.ds.metadata.get("persistent_urls", "false"),
                 "supports_search": bool(fts_table),
                 "search": search or "",
                 "use_rowid": use_rowid,
@@ -620,6 +626,9 @@ class TableView(RowTableShared):
 
         return {
             "database": name,
+            "database_url": database_url,
+            "persistent_urls":
+                self.ds.metadata.get("persistent_urls", "false"),
             "table": table,
             "is_view": is_view,
             "view_definition": view_definition,


### PR DESCRIPTION
Add new metadata key "persistent_urls" which removes the hash from all database urls when set to "true"

This PR is just to gauge if this, or something like it, is something you would consider merging?

I understand the reason why the substring of the hash is included in the url but
there are some use cases where the urls should persist across deployments. For bookmarks
for example or for scripts that use the JSON API.

This is the initial commit for this feature. Tests and documentation updates to follow.