### PR TITLE
Build Dockerfile with recent Sqlite + Spatialite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,41 @@
 FROM python:3.6-slim-stretch as build
 
 # Setup build dependencies
-RUN apt update
-RUN apt install -y python3-dev gcc libsqlite3-mod-spatialite
+RUN apt update \
+&& apt install -y python3-dev build-essential wget libxml2 libxml2-dev libproj-dev libgeos-dev libsqlite3-dev zlib1g-dev pkg-config unzip \
+ && apt clean
+
+
+RUN wget "https://www.sqlite.org/2018/sqlite-autoconf-3230100.tar.gz" && tar xzvf sqlite-autoconf-3230100.tar.gz \
+    && cd sqlite-autoconf-3230100 && ./configure --disable-static --enable-fts5 --enable-json1 CFLAGS="-g -O2 -DSQLITE_ENABLE_FTS3=1 -DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_RTREE=1" \
+    && make && make install
+
+RUN wget "https://www.gaia-gis.it/gaia-sins/freexl-1.0.5.tar.gz" && tar zxvf freexl-1.0.5.tar.gz && cd freexl-1.0.5 && ./configure && make && make install
+
+RUN wget "https://www.gaia-gis.it/gaia-sins/libspatialite-4.4.0-RC0.tar.gz" && tar zxvf libspatialite-4.4.0-RC0.tar.gz
+RUN cd libspatialite-4.4.0-RC0 && ./configure && make && make install
+
+RUN wget "https://www.gaia-gis.it/gaia-sins/readosm-1.1.0.tar.gz" && tar zxvf readosm-1.1.0.tar.gz && cd readosm-1.1.0 && ./configure && make && make install
+
+RUN wget "https://www.gaia-gis.it/gaia-sins/spatialite-tools-4.4.0-RC0.tar.gz" && tar zxvf spatialite-tools-4.4.0-RC0.tar.gz && cd spatialite-tools-4.4.0-RC0 && ./configure && make && make install
+
+
 # Add local code to the image instead of fetching from pypi.
 ADD . /datasette
 
 RUN pip install /datasette
 
+
 FROM python:3.6-slim-stretch
 
 # Copy python dependencies
-COPY --from=build /usr/local/lib/python3.6/site-packages /usr/local/lib/python3.6/site-packages
+COPY --from=build /usr/local/lib/ /usr/local/lib/
 # Copy executables
 COPY --from=build /usr/local/bin /usr/local/bin
 # Copy spatial extensions
 COPY --from=build /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
+
+ENV LD_LIBRARY_PATH=/usr/local/lib
 
 EXPOSE 8001
 CMD ["datasette"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,33 +2,34 @@ FROM python:3.6-slim-stretch as build
 
 # Setup build dependencies
 RUN apt update \
-&& apt install -y python3-dev build-essential wget libxml2 libxml2-dev libproj-dev libgeos-dev libsqlite3-dev zlib1g-dev pkg-config unzip \
+&& apt install -y python3-dev build-essential wget libxml2-dev libproj-dev libgeos-dev libsqlite3-dev zlib1g-dev pkg-config \
  && apt clean
 
 
-RUN wget "https://www.sqlite.org/2018/sqlite-autoconf-3230100.tar.gz" && tar xzvf sqlite-autoconf-3230100.tar.gz \
-    && cd sqlite-autoconf-3230100 && ./configure --disable-static --enable-fts5 --enable-json1 CFLAGS="-g -O2 -DSQLITE_ENABLE_FTS3=1 -DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_RTREE=1" \
+RUN wget "https://www.sqlite.org/2018/sqlite-autoconf-3230100.tar.gz" && tar xzf sqlite-autoconf-3230100.tar.gz \
+    && cd sqlite-autoconf-3230100 && ./configure --disable-static --enable-fts5 --enable-json1 CFLAGS="-g -O2 -DSQLITE_ENABLE_FTS3=1 -DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_RTREE=1 -DSQLITE_ENABLE_JSON1" \
     && make && make install
 
-RUN wget "https://www.gaia-gis.it/gaia-sins/freexl-1.0.5.tar.gz" && tar zxvf freexl-1.0.5.tar.gz && cd freexl-1.0.5 && ./configure && make && make install
+RUN wget "https://www.gaia-gis.it/gaia-sins/freexl-1.0.5.tar.gz" && tar zxf freexl-1.0.5.tar.gz \
+    && cd freexl-1.0.5 && ./configure && make && make install
 
-RUN wget "https://www.gaia-gis.it/gaia-sins/libspatialite-4.4.0-RC0.tar.gz" && tar zxvf libspatialite-4.4.0-RC0.tar.gz
-RUN cd libspatialite-4.4.0-RC0 && ./configure && make && make install
+RUN wget "https://www.gaia-gis.it/gaia-sins/libspatialite-4.4.0-RC0.tar.gz" && tar zxf libspatialite-4.4.0-RC0.tar.gz \
+    && cd libspatialite-4.4.0-RC0 && ./configure && make && make install
 
-RUN wget "https://www.gaia-gis.it/gaia-sins/readosm-1.1.0.tar.gz" && tar zxvf readosm-1.1.0.tar.gz && cd readosm-1.1.0 && ./configure && make && make install
+RUN wget "https://www.gaia-gis.it/gaia-sins/readosm-1.1.0.tar.gz" && tar zxf readosm-1.1.0.tar.gz && cd readosm-1.1.0 && ./configure && make && make install
 
-RUN wget "https://www.gaia-gis.it/gaia-sins/spatialite-tools-4.4.0-RC0.tar.gz" && tar zxvf spatialite-tools-4.4.0-RC0.tar.gz && cd spatialite-tools-4.4.0-RC0 && ./configure && make && make install
+RUN wget "https://www.gaia-gis.it/gaia-sins/spatialite-tools-4.4.0-RC0.tar.gz" && tar zxf spatialite-tools-4.4.0-RC0.tar.gz \
+    && cd spatialite-tools-4.4.0-RC0 && ./configure && make && make install
 
 
 # Add local code to the image instead of fetching from pypi.
-ADD . /datasette
+COPY . /datasette
 
 RUN pip install /datasette
 
-
 FROM python:3.6-slim-stretch
 
-# Copy python dependencies
+# Copy python dependencies and spatialite libraries
 COPY --from=build /usr/local/lib/ /usr/local/lib/
 # Copy executables
 COPY --from=build /usr/local/bin /usr/local/bin

--- a/datasette/app.py
+++ b/datasette/app.py
@@ -377,7 +377,7 @@ class Datasette:
         for fts in ("FTS5", "FTS4", "FTS3"):
             try:
                 conn.execute(
-                    "CREATE VIRTUAL TABLE v{fts} USING {fts} (t TEXT)".format(fts=fts)
+                    "CREATE VIRTUAL TABLE v{fts} USING {fts} (data)".format(fts=fts)
                 )
                 fts_versions.append(fts)
             except sqlite3.OperationalError:

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'hupper==1.0',
         'pint==0.8.1',
         'pluggy>=0.1.0,<1.0',
+        'pysqlite3==0.1.4',
     ],
     entry_points='''
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'hupper==1.0',
         'pint==0.8.1',
         'pluggy>=0.1.0,<1.0',
-        'pysqlite3==0.1.4',
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
This solves #278 without bloating the Dockerfile too much, the image size is now
495MB (original was ~240MB) but it could be reduced significantly if we only
copied the output of the compilation of spatialite and friends to
/usr/local/lib, instead of the entirety of it however that will take more time.

In the python code change references to `import sqlite3` to `import pysqlite3`
and it should use the compiled version of sqlite3.23.1. You don't need to
try/except because pysqlite3 falls back to builtin sqlite3 if there is no
compiled version.

```bash
  $ docker run --rm -it datasette spatialite
  SpatiaLite version ..: 4.4.0-RC0	Supported Extensions:
    - 'VirtualShape'	[direct Shapefile access]
    - 'VirtualDbf'		[direct DBF access]
    - 'VirtualXL'		[direct XLS access]
    - 'VirtualText'		[direct CSV/TXT access]
    - 'VirtualNetwork'	[Dijkstra shortest path]
    - 'RTree'		[Spatial Index - R*Tree]
    - 'MbrCache'		[Spatial Index - MBR cache]
    - 'VirtualSpatialIndex'	[R*Tree metahandler]
    - 'VirtualElementary'	[ElemGeoms metahandler]
    - 'VirtualKNN'	[K-Nearest Neighbors metahandler]
    - 'VirtualXPath'	[XML Path Language - XPath]
    - 'VirtualFDO'		[FDO-OGR interoperability]
    - 'VirtualGPKG'	[OGC GeoPackage interoperability]
    - 'VirtualBBox'		[BoundingBox tables]
    - 'SpatiaLite'		[Spatial SQL - OGC]
  PROJ.4 version ......: Rel. 4.9.3, 15 August 2016
  GEOS version ........: 3.5.1-CAPI-1.9.1 r4246
  TARGET CPU ..........: x86_64-linux-gnu
  the SPATIAL_REF_SYS table already contains some row(s)
  SQLite version ......: 3.23.1
  Enter ".help" for instructions
  SQLite version 3.23.1 2018-04-10 17:39:29
  Enter ".help" for instructions
  Enter SQL statements terminated with a ";"
  spatialite>
```

```bash
$ docker run --rm -it datasette python -c "import pysqlite3; print(pysqlite3.sqlite_version)"
3.23.1
```