### PR TITLE
Support for other types of databases using external connectors

### DIFF
--- a/datasette/connectors.py
+++ b/datasette/connectors.py
@@ -1,0 +1,22 @@
+import pkg_resources
+
+db_connectors = {}
+
+def load_connectors():
+    for entry_point in pkg_resources.iter_entry_points('datasette.connectors'):
+        db_connectors[entry_point.name] = entry_point.load()
+
+def inspect(path):
+    for connector in db_connectors.values():
+        try:
+            return connector.inspect(path)
+        except:
+            pass
+    else:
+        raise Exception("No database connector found for %s" % path)
+
+def connect(path, dbtype):
+    try:
+        return db_connectors[dbtype].Connection(path)
+    except:
+        raise Exception("No database connector found for %s" % path)


### PR DESCRIPTION
This PR is related to #293, but now all commits have been merged.

The purpose is to support other file formats that aren't SQLite, like files with PyTables format. I've tried to accomplish that using external connectors published with entry points.

The modifications in the original datasette code are minimal and many are in a separated file.