### PR TITLE
Mark codemirror files as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 datasette/_version.py export-subst
+datasette/static/codemirror-* linguist-vendored


### PR DESCRIPTION
GitHub lists datasette as a Javascript project, primarily because of the vendored codemirror files. This is somewhat confusing when you're looking for datasette, knowing it's written in Python.

Luckily it's possible exclude certain files from GitHub's code statistics: https://github.com/github/linguist#using-gitattributes