### PR TITLE
Heroku --include-vcs-ignore

### DIFF
--- a/datasette/publish/heroku.py
+++ b/datasette/publish/heroku.py
@@ -96,4 +96,4 @@ def publish_subcommand(publish):
                 create_output = check_output(cmd).decode("utf8")
                 app_name = json.loads(create_output)["name"]
 
-            call(["heroku", "builds:create", "-a", app_name])
+            call(["heroku", "builds:create", "-a", app_name, "--include-vcs-ignore"])

--- a/tests/test_publish_heroku.py
+++ b/tests/test_publish_heroku.py
@@ -57,7 +57,7 @@ def test_publish_heroku(mock_call, mock_check_output, mock_which):
         open("test.db", "w").write("data")
         result = runner.invoke(cli.cli, ["publish", "heroku", "test.db"])
         assert 0 == result.exit_code, result.output
-        mock_call.assert_called_once_with(["heroku", "builds:create", "-a", "f"])
+        mock_call.assert_called_once_with(["heroku", "builds:create", "-a", "f", "--include-vcs-ignore"])
 
 
 @mock.patch("shutil.which")


### PR DESCRIPTION
Should mean `datasette publish heroku` can work under Travis, unlike this failure:

https://travis-ci.org/simonw/fivethirtyeight-datasette/builds/488047550

```
2.25s$ datasette publish heroku fivethirtyeight.db -m metadata.json -n fivethirtyeight-datasette
tar: unrecognized option '--exclude-vcs-ignores'
Try 'tar --help' or 'tar --usage' for more information.
 ▸    Command failed: tar cz -C /tmp/tmpuaxm7i8f --exclude-vcs-ignores --exclude
 ▸    .git --exclude .gitmodules . >
 ▸    /tmp/f49440e0-1bf3-4d3f-9eb0-fbc2967d1fd4.tar.gz
 ▸    tar: unrecognized option '--exclude-vcs-ignores'
 ▸    Try 'tar --help' or 'tar --usage' for more information.
 ▸    
The command "datasette publish heroku fivethirtyeight.db -m metadata.json -n fivethirtyeight-datasette" exited with 0.
```

The fix for that issue is to call the heroku command like this:

    heroku builds:create -a app_name --include-vcs-ignore

