### PR TITLE
Upgrade to Jinja2==2.10.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'click>=6.7',
         'click-default-group==1.2',
         'Sanic==0.7.0',
-        'Jinja2==2.10',
+        'Jinja2==2.10.1',
         'hupper==1.0',
         'pint==0.8.1',
         'pluggy>=0.7.1',


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-10906

This is only a security issue of concern if evaluating templates from untrusted sources, which isn't something I would ever expect a Datasette user to do.