### PR TITLE
[WIP] publish on google cloud run

### DIFF
--- a/datasette/plugins.py
+++ b/datasette/plugins.py
@@ -5,6 +5,7 @@ from . import hookspecs
 DEFAULT_PLUGINS = (
     "datasette.publish.heroku",
     "datasette.publish.now",
+    "datasette.publish.cloudrun",
 )
 
 pm = pluggy.PluginManager("datasette")

--- a/datasette/publish/cloudrun.py
+++ b/datasette/publish/cloudrun.py
@@ -1,0 +1,71 @@
+from datasette import hookimpl
+import click
+import json
+from subprocess import check_call, check_output
+
+from .common import (
+    add_common_publish_arguments_and_options,
+    fail_if_publish_binary_not_installed,
+)
+from ..utils import temporary_docker_directory
+
+
+@hookimpl
+def publish_subcommand(publish):
+    @publish.command()
+    @add_common_publish_arguments_and_options
+    @click.option(
+        "-n",
+        "--name",
+        default="datasette",
+        help="Application name to use when deploying",
+    )
+    @click.option("--spatialite", is_flag=True, help="Enable SpatialLite extension")
+    def cloudrun(
+        files,
+        metadata,
+        extra_options,
+        branch,
+        template_dir,
+        plugins_dir,
+        static,
+        install,
+        version_note,
+        title,
+        license,
+        license_url,
+        source,
+        source_url,
+        about,
+        about_url,
+        name,
+        spatialite,
+    ):
+        fail_if_publish_binary_not_installed("gcloud", "Google Cloud", "https://cloud.google.com/sdk/")
+        project = check_output("gcloud config get-value project", shell=True).decode("utf-8").strip()
+
+        with temporary_docker_directory(
+            files,
+            name,
+            metadata,
+            extra_options,
+            branch,
+            template_dir,
+            plugins_dir,
+            static,
+            install,
+            spatialite,
+            version_note,
+            {
+                "title": title,
+                "license": license,
+                "license_url": license_url,
+                "source": source,
+                "source_url": source_url,
+                "about": about,
+                "about_url": about_url,
+            },
+        ):
+            image_id = f"gcr.io/{project}/{name}"
+            check_call(f"gcloud builds submit --tag {image_id}", shell=True)
+        check_call(f"gcloud beta run deploy --allow-unauthenticated --image {image_id}", shell=True)

--- a/datasette/publish/cloudrun.py
+++ b/datasette/publish/cloudrun.py
@@ -42,7 +42,7 @@ def publish_subcommand(publish):
         spatialite,
     ):
         fail_if_publish_binary_not_installed("gcloud", "Google Cloud", "https://cloud.google.com/sdk/")
-        project = check_output("gcloud config get-value project", shell=True).decode("utf-8").strip()
+        project = check_output("gcloud config get-value project", shell=True, universal_newlines=True).strip()
 
         with temporary_docker_directory(
             files,

--- a/datasette/publish/cloudrun.py
+++ b/datasette/publish/cloudrun.py
@@ -66,6 +66,6 @@ def publish_subcommand(publish):
                 "about_url": about_url,
             },
         ):
-            image_id = f"gcr.io/{project}/{name}"
-            check_call(f"gcloud builds submit --tag {image_id}", shell=True)
-        check_call(f"gcloud beta run deploy --allow-unauthenticated --image {image_id}", shell=True)
+            image_id = "gcr.io/{project}/{name}".format(project=project, name=name)
+            check_call("gcloud builds submit --tag {}".format(image_id), shell=True)
+        check_call("gcloud beta run deploy --allow-unauthenticated --image {}".format(image_id), shell=True)

--- a/datasette/utils.py
+++ b/datasette/utils.py
@@ -283,7 +283,7 @@ def make_dockerfile(files, metadata_file, extra_options, branch, template_dir, p
         for opt in extra_options.split():
             cmd.append('{}'.format(opt))
     cmd = ' '.join(cmd)
-    shell_command = f'"sh", "-c", "{cmd}"'
+    shell_command = '"sh", "-c", "{}"'.format(cmd)
     if branch:
         install = ['https://github.com/simonw/datasette/archive/{}.zip'.format(
             branch

--- a/datasette/utils.py
+++ b/datasette/utils.py
@@ -267,7 +267,7 @@ def escape_sqlite(s):
 def make_dockerfile(files, metadata_file, extra_options, branch, template_dir, plugins_dir, static, install, spatialite, version_note):
     cmd = ['"datasette"', '"serve"', '"--host"', '"0.0.0.0"']
     cmd.append('"' + '", "'.join(files) + '"')
-    cmd.extend(['"--cors"', '"--port"', '"8001"', '"--inspect-file"', '"inspect-data.json"'])
+    cmd.extend(['"--cors"', '"--port"', '"8080"', '"--inspect-file"', '"inspect-data.json"'])
     if metadata_file:
         cmd.extend(['"--metadata"', '"{}"'.format(metadata_file)])
     if template_dir:

--- a/tests/test_publish_cloudrun.py
+++ b/tests/test_publish_cloudrun.py
@@ -1,0 +1,41 @@
+from click.testing import CliRunner
+from datasette import cli
+from unittest import mock
+
+
+@mock.patch("shutil.which")
+def test_publish_cloudrun_requires_gcloud(mock_which):
+    mock_which.return_value = False
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("test.db", "w").write("data")
+        result = runner.invoke(cli.cli, ["publish", "cloudrun", "test.db"])
+        assert result.exit_code == 1
+        assert "Publishing to Google Cloud requires gcloud" in result.output
+
+
+@mock.patch("shutil.which")
+def test_publish_cloudrun_invalid_database(mock_which):
+    mock_which.return_value = True
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ["publish", "cloudrun", "woop.db"])
+    assert result.exit_code == 2
+    assert 'Path "woop.db" does not exist' in result.output
+
+
+@mock.patch("shutil.which")
+@mock.patch("datasette.publish.cloudrun.check_output")
+@mock.patch("datasette.publish.cloudrun.check_call")
+def test_publish_cloudrun(mock_call, mock_output, mock_which):
+    mock_output.return_value = "myproject"
+    mock_which.return_value = True
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        open("test.db", "w").write("data")
+        result = runner.invoke(cli.cli, ["publish", "cloudrun", "test.db"])
+        assert 0 == result.exit_code
+        tag = "gcr.io/{}/datasette".format(mock_output.return_value)
+        mock_call.assert_has_calls([
+            mock.call("gcloud builds submit --tag {}".format(tag), shell=True),
+            mock.call("gcloud beta run deploy --allow-unauthenticated --image {}".format(tag), shell=True)])
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -317,6 +317,29 @@ def test_temporary_docker_directory_uses_copy_if_hard_link_fails(mock_link):
             assert 1 == os.stat(hello).st_nlink
 
 
+def test_temporary_docker_directory_quotes_args():
+     with tempfile.TemporaryDirectory() as td:
+        os.chdir(td)
+        open('hello', 'w').write('world')
+        with utils.temporary_docker_directory(
+            files=['hello'],
+            name='t',
+            metadata=None,
+            extra_options='--$HOME',
+            branch=None,
+            template_dir=None,
+            plugins_dir=None,
+            static=[],
+            install=[],
+            spatialite=False,
+            version_note='$PWD',
+        ) as temp_docker:
+            df = os.path.join(temp_docker, 'Dockerfile')
+            df_contents = open(df).read()
+            assert "'$PWD'" in df_contents
+            assert "'--$HOME'" in df_contents
+
+
 def test_compound_keys_after_sql():
     assert '((a > :p0))' == utils.compound_keys_after_sql(['a'])
     assert '''


### PR DESCRIPTION
This is a very rough draft to start a discussion on a possible datasette cloud run publish plugin (see issue #400).

The main change was to dynamically set the listening port in `make_dockerfile` to satisfy cloud run's [requirements](https://cloud.google.com/run/docs/reference/container-contract).

This was done by running `datasette` through `sh` to get environment variable substitution. Not sure if that's the right approach?
