### PR TITLE
[WIP] Add primary key to the extra_body_script hook arguments

### DIFF
--- a/datasette/hookspecs.py
+++ b/datasette/hookspecs.py
@@ -26,7 +26,7 @@ def extra_js_urls(template, database, table, datasette):
 
 
 @hookspec
-def extra_body_script(template, database, table, datasette):
+def extra_body_script(template, database, table, primary_key, datasette):
     "Extra JavaScript code to be included in <script> at bottom of body"
 
 

--- a/datasette/views/base.py
+++ b/datasette/views/base.py
@@ -97,7 +97,8 @@ class RenderMixin(HTTPMethodView):
             template=template.name,
             database=context.get("database"),
             table=context.get("table"),
-            datasette=self.ds
+            primary_key=context.get("primary_key_values"),
+            datasette=self.ds,
         ):
             body_scripts.append(jinja2.Markup(script))
         return response.html(

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -529,8 +529,8 @@ If the value matches that pattern, the plugin returns an HTML link element:
 
 .. _plugin_hook_extra_body_script:
 
-extra_body_script(template, database, table, datasette)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+extra_body_script(template, database, table, primary_key, datasette)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``template`` - string
     The template that is being rendered, e.g. ``database.html``
@@ -539,7 +539,10 @@ extra_body_script(template, database, table, datasette)
     The name of the database, or ``None`` if the page does not correspond to a database (e.g. the root page)
 
 ``table`` - string or None
-    The name of the table, or ``None`` if the page does not correct to a table
+    The name of the table, or ``None`` if the page does not correspond to a table
+
+``primary_key`` - list or None
+    A list of primary key(s) for the row, or ``None`` if the page does not correspond to a row
 
 ``datasette`` - Datasette instance
     You can use this to access plugin configuration options via ``datasette.plugin_config(your_plugin_name)``


### PR DESCRIPTION
This allows the row to be identified on row pages. The context here is that I want to access the row's data to plot it on a map.

I considered passing the entire template context through to the hook function. This would expose the actual row data and potentially avoid a further fetch request in JS, but it does make the plugin API a lot more leaky. 

(At any rate, using the selected row data is tricky in my case because of Spatialite's infuriating custom binary representation...)