### PR TITLE
Suppress rendering of binary data

### DIFF
--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -118,6 +118,8 @@ class RowTableShared(BaseView):
                 )
                 if plugin_display_value is not None:
                     display_value = plugin_display_value
+                elif isinstance(value, bytes):
+                    display_value = jinja2.Markup("<{}&nbsp;bytes>".format(len(value)))
                 elif isinstance(value, dict):
                     # It's an expanded foreign key - display link to other row
                     label = value["label"]


### PR DESCRIPTION
Binary columns (including spatialite geographies) get shown as ugly
binary strings in the HTML by default. Nobody wants to see that mess.

Show the size of the column in bytes instead. If you want to decode
the binary data, you can use a plugin to do it.