### PR TITLE
Pass view_name to extra_body_script hook

### DIFF
--- a/datasette/hookspecs.py
+++ b/datasette/hookspecs.py
@@ -26,7 +26,7 @@ def extra_js_urls(template, database, table, datasette):
 
 
 @hookspec
-def extra_body_script(template, database, table, datasette):
+def extra_body_script(template, database, table, view_name, datasette):
     "Extra JavaScript code to be included in <script> at bottom of body"
 
 

--- a/datasette/views/base.py
+++ b/datasette/views/base.py
@@ -94,6 +94,7 @@ class RenderMixin(HTTPMethodView):
             template=template.name,
             database=context.get("database"),
             table=context.get("table"),
+            view_name=self.name,
             datasette=self.ds
         ):
             body_scripts.append(jinja2.Markup(script))

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -529,8 +529,8 @@ If the value matches that pattern, the plugin returns an HTML link element:
 
 .. _plugin_hook_extra_body_script:
 
-extra_body_script(template, database, table, datasette)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+extra_body_script(template, database, table, view_name, datasette)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``template`` - string
     The template that is being rendered, e.g. ``database.html``
@@ -540,6 +540,9 @@ extra_body_script(template, database, table, datasette)
 
 ``table`` - string or None
     The name of the table, or ``None`` if the page does not correct to a table
+
+``view_name`` - string
+    The name of the view being displayed. (`database`, `table`, and `row` are the most important ones.)
 
 ``datasette`` - Datasette instance
     You can use this to access plugin configuration options via ``datasette.plugin_config(your_plugin_name)``


### PR DESCRIPTION
At the moment it's not easy to tell whether the hook is being called
in (for example) the row or table view, as in both cases the
`database` and `table` parameters are provided.

This passes the `view_name` added in #441 to the `extra_body_script`
hook.