### PR TITLE
Add a max-line-length setting for flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,5 @@ versionfile_build = datasette/_version.py
 tag_prefix =
 parentdir_prefix = datasette-
 
+[flake8]
+max-line-length = 160


### PR DESCRIPTION
This stops my automatic editor linting from flagging lines which are too
long. It's been lingering in my checkout for ages.

160 is an arbitrary large number - we could alter it if we have any
opinions (but I find the line length limit to be my least favourite part
of PEP8).