### PR TITLE
Coalesce hidden table count to 0

### DIFF
--- a/datasette/views/index.py
+++ b/datasette/views/index.py
@@ -57,7 +57,9 @@ class IndexView(RenderMixin):
                     "tables_count": len(tables),
                     "tables_more": len(tables) > 5,
                     "table_rows_sum": sum((t["count"] or 0) for t in tables.values()),
-                    "hidden_table_rows_sum": sum(t["count"] for t in hidden_tables),
+                    "hidden_table_rows_sum": sum(
+                        (t["count"] or 0) for t in hidden_tables
+                    ),
                     "hidden_tables_count": len(hidden_tables),
                     "views_count": len(views),
                 }


### PR DESCRIPTION
For some reason I'm hitting a `None` here with a FTS table. I'm not
entirely sure why but this makes the logic work the same as with
non-hidden tables.