### PR TITLE
Split pypi and docker travis tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,17 @@ jobs:
     - stage: release tagged version
       if: tag IS present
       python: 3.6
+      deploy:
+        - provider: pypi
+          user: simonw
+          distributions: bdist_wheel
+          password: ${PYPI_PASSWORD}
+          on:
+            branch: master
+            tags: true
+    - stage: publish docker image
+      if: tag IS present
+      python: 3.6
       script:
         - npm install -g now
         - export ALIAS=`echo $TRAVIS_COMMIT | cut -c 1-7`
@@ -42,11 +53,3 @@ jobs:
         - docker build -f Dockerfile -t $REPO:$TRAVIS_TAG .
         - docker tag $REPO:$TRAVIS_TAG $REPO:latest
         - docker push $REPO
-      deploy:
-        - provider: pypi
-          user: simonw
-          distributions: bdist_wheel
-          password: ${PYPI_PASSWORD}
-          on:
-            branch: master
-            tags: true


### PR DESCRIPTION
Resolves #478 

This *should* work, but because this is a change that'll only really be testable on a) this repo, b) master branch, this might fail fast if I didn't get the configurations right. 


Looking at #478 it should just be as simple as splitting out the docker and pypi processes into separate jobs, but it might end up being more complicated than that, depending on what pre-processes the pypi deployment needs, and how travisci treats deployment steps without scripts in general. 