### PR TITLE
Use keyed rows - fixes #521

### DIFF
--- a/datasette/templates/_rows_and_columns.html
+++ b/datasette/templates/_rows_and_columns.html
@@ -17,10 +17,10 @@
         </tr>
     </thead>
     <tbody>
-    {% for row in display_rows %}
+    {% for row in display_rows_keyed %}
         <tr>
-            {% for cell in row %}
-                <td class="col-{{ cell.column|to_css_class }}">{{ cell.value }}</td>
+            {% for column in display_columns %}
+                <td class="col-{{ column.name|to_css_class }}">{{ row[column.name] }}</td>
             {% endfor %}
         </tr>
     {% endfor %}

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -699,6 +699,10 @@ class TableView(RowTableShared):
                 "display_columns": display_columns,
                 "filter_columns": filter_columns,
                 "display_rows": display_rows,
+                "display_rows_keyed": [
+                    {cell["column"]: cell["value"] for cell in row}
+                    for row in display_rows
+                ],
                 "facets_timed_out": facets_timed_out,
                 "sorted_facet_results": sorted(
                     facet_results.values(),
@@ -799,6 +803,10 @@ class RowView(RowTableShared):
                 ),
                 "display_columns": display_columns,
                 "display_rows": display_rows,
+                "display_rows_keyed": [
+                    {cell["column"]: cell["value"] for cell in row}
+                    for row in display_rows
+                ],
                 "custom_rows_and_columns_templates": [
                     "_rows_and_columns-{}-{}.html".format(
                         to_css_class(database), to_css_class(table)


### PR DESCRIPTION
Supports template syntax like this:

```
{% for row in display_rows %}
  <h2 class="scientist">{{ row["First_Name"] }} {{ row["Last_Name"] }}</h2>
  ...
```