### PR TITLE
Fix static mounts using relative paths and prevent traversal exploits

### DIFF
--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -735,7 +735,7 @@ class StaticMount(click.ParamType):
                 param,
                 ctx,
             )
-        path, dirpath = value.split(":")
+        path, dirpath = value.split(":", 1)
         dirpath = os.path.abspath(dirpath)
         if not os.path.exists(dirpath) or not os.path.isdir(dirpath):
             self.fail("%s is not a valid directory path" % value, param, ctx)

--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -736,6 +736,7 @@ class StaticMount(click.ParamType):
                 ctx,
             )
         path, dirpath = value.split(":")
+        dirpath = os.path.abspath(dirpath)
         if not os.path.exists(dirpath) or not os.path.isdir(dirpath):
             self.fail("%s is not a valid directory path" % value, param, ctx)
         return path, dirpath

--- a/datasette/utils/asgi.py
+++ b/datasette/utils/asgi.py
@@ -300,7 +300,7 @@ async def asgi_send_file(
 def asgi_static(root_path, chunk_size=4096, headers=None, content_type=None):
     async def inner_static(scope, receive, send):
         path = scope["url_route"]["kwargs"]["path"]
-        full_path = (Path(root_path) / path).absolute()
+        full_path = (Path(root_path) / path).resolve().absolute()
         # Ensure full_path is within root_path to avoid weird "../" tricks
         try:
             full_path.relative_to(root_path)

--- a/datasette/utils/asgi.py
+++ b/datasette/utils/asgi.py
@@ -300,7 +300,7 @@ async def asgi_send_file(
 def asgi_static(root_path, chunk_size=4096, headers=None, content_type=None):
     async def inner_static(scope, receive, send):
         path = scope["url_route"]["kwargs"]["path"]
-        try
+        try:
             full_path = (Path(root_path) / path).resolve().absolute()
         except FileNotFoundError:
             await asgi_send_html(send, "404", 404)

--- a/datasette/utils/asgi.py
+++ b/datasette/utils/asgi.py
@@ -300,7 +300,11 @@ async def asgi_send_file(
 def asgi_static(root_path, chunk_size=4096, headers=None, content_type=None):
     async def inner_static(scope, receive, send):
         path = scope["url_route"]["kwargs"]["path"]
-        full_path = (Path(root_path) / path).resolve().absolute()
+        try
+            full_path = (Path(root_path) / path).resolve().absolute()
+        except FileNotFoundError:
+            await asgi_send_html(send, "404", 404)
+            return
         # Ensure full_path is within root_path to avoid weird "../" tricks
         try:
             full_path.relative_to(root_path)

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -67,6 +67,8 @@ def test_static_mounts():
         assert response.status == 200
         response = client.get("/custom-static/not_exists.py")
         assert response.status == 404
+        response = client.get("/custom-static/../LICENSE")
+        assert response.status == 404
 
 
 def test_memory_database_page():


### PR DESCRIPTION
While debugging why my static mounts using a relative path (`--static mystatic:rel/path/to/dir`) not working, I noticed that the requests fail no matter what, returning 404 errors. 

The reason is that datasette tries to prevent traversal exploits by checking if the path is relative to its registered directory. This check fails when the mount is a relative directory, because `/abs/dir/file` obviously not under `dir/file`. 

https://github.com/simonw/datasette/blob/81fa8b6cdc5457b42a224779e5291952314e8d20/datasette/utils/asgi.py#L303-L306

This also has the consequence of returning any requested file, because when `/abs/dir/../../evil.file` resolves `aiofiles` happily returns it to the client after it resolves the path itself. The solution is to make sure we're checking relativity of paths after they're fully resolved.

I've implemented the mentioned changes and also updated the tests.