### PR TITLE
Add support for running datasette as a module

### DIFF
--- a/datasette/__main__.py
+++ b/datasette/__main__.py
@@ -1,0 +1,4 @@
+from datasette.cli import cli
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
This PR allows running datasette using `python -m datasette` command in addition to just running the executable.

This function is quite useful when debugging a plugin in a project because IDEs like PyCharm can easily start a debug session when datasette is run as a module in contrast to trying to attach a debugger to a running process.

![image](https://user-images.githubusercontent.com/3243482/60890448-fc4ede80-a263-11e9-8b42-d2a3db8d1a59.png)
