### PR TITLE
Added support for multi arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=build /usr/local/lib/ /usr/local/lib/
 # Copy executables
 COPY --from=build /usr/local/bin /usr/local/bin
 # Copy spatial extensions
-COPY --from=build /usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu
+COPY --from=build /usr/lib/*-linux-gnu /usr/lib/
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+DOCKER_BUILDKIT=1
+IMAGE_NAME="heussd/rpi-datasette:latest"
+
+all: setup build clean
+.PHONY: all
+
+setup:
+	docker buildx create --name "nubuilder" --use
+build:
+	docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm/v6 -t $(IMAGE_NAME) --push .
+clean:
+	docker buildx rm nubuilder


### PR DESCRIPTION
Minor changes in Dockerfile and new Makefile to support Docker multi architecture builds. `make`will build one image per architecture and push them as one Docker manifest to Docker Hub. Feel free to change `IMAGE_NAME ` to `datasetteproject/datasette` to update your official Docker Hub image(s).