### PR TITLE
bump uvicorn to 0.9.0 to be Python-3.8 friendly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "hupper~=1.0",
         "pint~=0.8.1",
         "pluggy~=0.12.0",
-        "uvicorn~=0.8.4",
+        "uvicorn~=0.9.0",
         "aiofiles~=0.4.0",
     ],
     entry_points="""


### PR DESCRIPTION
as uvicorn-0.9 is needed to get websockets-8.0.2, which is needed to have Python-3.8 compatibility