### PR TITLE
Validate metadata json on startup

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -6,6 +6,7 @@ import sys
 import threading
 import traceback
 import urllib.parse
+from copy import deepcopy
 from concurrent import futures
 from pathlib import Path
 
@@ -173,7 +174,7 @@ class Datasette:
             self.databases[db.name] = db
         self.cache_headers = cache_headers
         self.cors = cors
-        self._metadata = metadata or {}
+        self._metadata = deepcopy(metadata) or {}
         self.sqlite_functions = []
         self.sqlite_extensions = sqlite_extensions or []
         self.template_dir = template_dir

--- a/datasette/app.py
+++ b/datasette/app.py
@@ -21,6 +21,7 @@ from .views.special import JsonDataView
 from .views.table import RowView, TableView
 from .renderer import json_renderer
 from .database import Database
+from .metadata import get_metadata_schema
 
 from .utils import (
     QueryInterrupted,
@@ -200,7 +201,6 @@ class Datasette:
                     pass
 
     async def run_sanity_checks(self):
-        # Only one check right now, for Spatialite
         for database_name, database in self.databases.items():
             # Run pragma_info on every table
             for table in await database.table_names():
@@ -218,6 +218,13 @@ class Datasette:
                         )
                     else:
                         raise
+
+        # validate metadata
+        Schema = await get_metadata_schema(self)
+        schema = Schema()
+        # this will raise a marshmallow.ValidationError
+        # if self._metadata is invalid
+        schema.load(self._metadata)
 
     def config(self, key):
         return self._config.get(key, None)

--- a/datasette/metadata.py
+++ b/datasette/metadata.py
@@ -1,0 +1,140 @@
+import re
+from marshmallow import Schema, fields, validate
+from marshmallow_union import Union
+
+
+# these fields can be used at instance, database or table-level
+STANDARD_FIELDS = {
+    "title": fields.String(),
+    "description": fields.String(),
+    "description_html": fields.String(),
+    "license": fields.String(),
+    "license_url": fields.String(),
+    "source": fields.String(),
+    "source_url": fields.String(),
+    "about": fields.String(),
+    "about_url": fields.String(),
+}
+
+
+def _get_units_schema(columns):
+    return Schema.from_dict({col: fields.String() for col in columns})
+
+
+def _get_table_schema(columns, tables):
+    UnitsSchema = _get_units_schema(columns)
+    columns_regex = f"^({'|'.join([re.escape(c) for c in columns])})$"
+    tables_regex = f"^({'|'.join([re.escape(t) for t in tables])})$"
+    TableSchema = Schema.from_dict(
+        {
+            **STANDARD_FIELDS,
+            **{
+                "units": fields.Nested(UnitsSchema()),
+                "sortable_columns": fields.List(
+                    fields.String(
+                        required=True,
+                        validate=validate.Regexp(columns_regex, error="Invalid column"),
+                    )
+                ),
+                "label_column": fields.String(
+                    validate=validate.Regexp(columns_regex, error="Invalid column")
+                ),
+                "hidden": fields.Boolean(),
+                "plugins": fields.Dict(),
+                "fts_table": fields.String(
+                    validate=validate.Regexp(tables_regex, error="Invalid table")
+                ),
+                "fts_pk": fields.String(
+                    validate=validate.Regexp(columns_regex, error="Invalid column")
+                ),
+            },
+        }
+    )
+
+    return TableSchema
+
+
+def _get_tables_schema(tables):
+    tables_dict = {}
+    for table, columns in tables.items():
+        TableSchema = _get_table_schema(columns, tables.keys())
+        tables_dict[table] = fields.Nested(TableSchema())
+
+    return Schema.from_dict(tables_dict)
+
+
+def _get_queries_schema(queries):
+    QuerySchema = Schema.from_dict(
+        {
+            "sql": fields.String(required=True),
+            "title": fields.String(),
+            "description": fields.String(),
+            "description_html": fields.String(),
+        }
+    )
+
+    return Schema.from_dict(
+        {
+            q: Union([fields.Nested(QuerySchema()), fields.String(required=True)])
+            for q in queries
+        }
+    )
+
+
+def _get_database_schema(database):
+    TablesSchema = _get_tables_schema({**database["tables"], **database["views"]})
+    QueriesSchema = _get_queries_schema(database["queries"])
+    DatabaseSchema = Schema.from_dict(
+        {
+            **STANDARD_FIELDS,
+            **{
+                "plugins": fields.Dict(),
+                "tables": fields.Nested(TablesSchema()),
+                "queries": fields.Nested(QueriesSchema()),
+            },
+        }
+    )
+
+    return DatabaseSchema
+
+
+def _get_databases_schema(databases):
+    schema_dict = {}
+    for database in databases:
+        DatabaseSchema = _get_database_schema(databases[database])
+        schema_dict[database] = fields.Nested(DatabaseSchema())
+
+    return Schema.from_dict(schema_dict)
+
+
+async def get_metadata_schema(app):
+    db_structure = {}
+
+    for name, db in app.databases.items():
+        table_names = await db.table_names()
+        view_names = await db.view_names()
+        tables_structure = {t: await db.table_columns(t) for t in table_names}
+        views_structure = {v: await db.table_columns(v) for v in view_names}
+
+        db_structure[name] = {"tables": tables_structure, "views": views_structure}
+
+        try:
+            db_structure[name]["queries"] = app._metadata["databases"]["fixtures"][
+                "queries"
+            ].keys()
+        except KeyError:
+            db_structure[name]["queries"] = []
+
+    DatabasesSchema = _get_databases_schema(db_structure)
+    MetadataSchema = Schema.from_dict(
+        {
+            **STANDARD_FIELDS,
+            **{
+                "plugins": fields.Dict(),
+                "custom_units": fields.List(fields.String()),
+                "databases": fields.Nested(DatabasesSchema()),
+            },
+        }
+    )
+
+    return MetadataSchema

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setup(
         "pluggy~=0.13.0",
         "uvicorn~=0.10.4",
         "aiofiles~=0.4.0",
+        "marshmallow~=3.2.0",
+        "marshmallow-union~=0.1.12",
     ],
     entry_points="""
         [console_scripts]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -163,6 +163,11 @@ def app_client():
     yield from make_app_client()
 
 
+@pytest.fixture(scope="function")
+def app_client_function_scope():
+    yield from make_app_client()
+
+
 @pytest.fixture(scope="session")
 def app_client_no_files():
     ds = Datasette([])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 from datasette.utils import detect_json1
 from .fixtures import (  # noqa
     app_client,
+    app_client_function_scope,
     app_client_no_files,
     app_client_with_hash,
     app_client_shorter_time_limit,
@@ -1200,8 +1201,8 @@ def test_databases_json(app_client_two_attached_databases_one_immutable):
     assert False == fixtures_database["is_memory"]
 
 
-def test_metadata_json(app_client):
-    response = app_client.get("/-/metadata.json")
+def test_metadata_json(app_client_function_scope):
+    response = app_client_function_scope.get("/-/metadata.json")
     assert METADATA == response.json
 
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,6 +1,7 @@
 from bs4 import BeautifulSoup as Soup
 from .fixtures import (  # noqa
     app_client,
+    app_client_function_scope,
     app_client_shorter_time_limit,
     app_client_two_attached_databases,
     app_client_with_hash,
@@ -1041,8 +1042,8 @@ def test_binary_data_display(app_client):
     ]
 
 
-def test_metadata_json_html(app_client):
-    response = app_client.get("/-/metadata")
+def test_metadata_json_html(app_client_function_scope):
+    response = app_client_function_scope.get("/-/metadata")
     assert response.status == 200
     pre = Soup(response.body, "html.parser").find("pre")
     assert METADATA == json.loads(pre.text)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,101 @@
+from copy import deepcopy
+from marshmallow import ValidationError
+import pytest
+from datasette.metadata import get_metadata_schema
+from .fixtures import METADATA, app_client
+
+
+@pytest.mark.asyncio
+async def test_valid(app_client):
+    Schema = await get_metadata_schema(app_client.ds)
+    schema = Schema()
+    assert isinstance(schema.load(METADATA), dict)
+
+
+@pytest.mark.asyncio
+async def test_empty(app_client):
+    Schema = await get_metadata_schema(app_client.ds)
+    schema = Schema()
+    assert isinstance(schema.load({}), dict)
+
+
+@pytest.mark.asyncio
+async def test_unexpected_key(app_client):
+    Schema = await get_metadata_schema(app_client.ds)
+    schema = Schema()
+    with pytest.raises(ValidationError):
+        schema.load({**METADATA, **{"foo": "bar"}})
+
+
+@pytest.mark.asyncio
+async def test_unexpected_database(app_client):
+    Schema = await get_metadata_schema(app_client.ds)
+    schema = Schema()
+    with pytest.raises(ValidationError):
+        md = deepcopy(METADATA)
+        md["databases"]["not_a_db"] = {}
+        schema.load(md)
+
+
+@pytest.mark.asyncio
+async def test_unexpected_table(app_client):
+    Schema = await get_metadata_schema(app_client.ds)
+    schema = Schema()
+    with pytest.raises(ValidationError):
+        md = deepcopy(METADATA)
+        md["databases"]["fixtures"]["tables"]["not_a_table"] = {}
+        schema.load(md)
+
+
+@pytest.mark.asyncio
+async def test_unexpected_table_fts_table(app_client):
+    Schema = await get_metadata_schema(app_client.ds)
+    schema = Schema()
+    with pytest.raises(ValidationError):
+        md = deepcopy(METADATA)
+        md["databases"]["fixtures"]["tables"]["sortable"]["fts_table"] = "not_a_table"
+        schema.load(md)
+
+
+@pytest.mark.asyncio
+async def test_unexpected_column_units(app_client):
+    Schema = await get_metadata_schema(app_client.ds)
+    schema = Schema()
+    with pytest.raises(ValidationError):
+        md = deepcopy(METADATA)
+        md["databases"]["fixtures"]["tables"]["units"]["units"]["not_a_column"] = "Hz"
+        schema.load(md)
+
+
+@pytest.mark.asyncio
+async def test_unexpected_column_sortable_columns(app_client):
+    Schema = await get_metadata_schema(app_client.ds)
+    schema = Schema()
+    with pytest.raises(ValidationError):
+        md = deepcopy(METADATA)
+        md["databases"]["fixtures"]["tables"]["sortable"]["sortable_columns"].append(
+            "not_a_column"
+        )
+        schema.load(md)
+
+
+@pytest.mark.asyncio
+async def test_unexpected_column_label_column(app_client):
+    Schema = await get_metadata_schema(app_client.ds)
+    schema = Schema()
+    with pytest.raises(ValidationError):
+        md = deepcopy(METADATA)
+        md["databases"]["fixtures"]["tables"]["sortable"][
+            "label_column"
+        ] = "not_a_column"
+        schema.load(md)
+
+
+@pytest.mark.asyncio
+async def test_unexpected_column_fts_pk(app_client):
+    Schema = await get_metadata_schema(app_client.ds)
+    schema = Schema()
+    with pytest.raises(ValidationError):
+        md = deepcopy(METADATA)
+        md["databases"]["fixtures"]["tables"]["sortable"]["fts_pk"] = "not_a_column"
+        schema.load(md)


### PR DESCRIPTION
This PR adds a sanity check which builds up a marshmallow schema on-the-fly based on the structure of the database(s) on startup and then validates the metadata json against it.

In case of invalid data, this will raise with a descriptive error e.g:

```
marshmallow.exceptions.ValidationError: {'databases': {'fixtures': {'tables': {'not_a_table': ['Unknown field.']}}}}
```

Closes #260

---

This was intended to be fairly self-contained, but then while I was working on it, I hit some problems getting the tests to pass in the context of the test suite as a whole. My tests passed in isolation, but then failed while doing a full test suite run. That's when the worms started coming out of the can :bug: After some sleuthing, it turned out this was essentially the result of several issues intersecting:

* There are certain events in the application lifecycle where the metadata schema can be modified after it is loaded e.g: https://github.com/simonw/datasette/blob/a562f2965552fb2dbbbd74df245c9965ee23d886/datasette/app.py#L299-L320 This means that sometimes what goes in isn't always exactly what comes out when you call `/-/metadata`.
* Because the test fixtures use session scope for performance reasons if one unit test performs an action which mutates the metadata, that can impact on other unit tests which run after it using the same fixture.
* Because the `self._metadata` property was being set with a simple assignment `self._metadata = metadata`, that created an object reference to the test fixture data, so operating on `self._metadata` was actually modifying the test fixture `METADATA` meaning that depending on when it was loaded in the test suite lifecycle, `METADATA` had different content, which was somewhat unexpected.

As such, I've added some band-aids in 3552024 and 6859fd8:
* Switching the metadata object to a `deepcopy` of the input prevents us directly mutating the input fixture.
* I've switched some of the tests to use a fixture with function scope instead of session scope so we're working on a clean copy that hasn't been mutated by other tests where necessary but keeping session scope in most cases for performance.
* I haven't really addressed the fact that sometimes the metadata object gets mutated in place, so the object that is served from `/-/metadata` isn't necessarily always exactly the same as the file you fed into it on init. I'm not sure how much of a problem that is. The way the tests were written makes me think it was unexpected, but getting into it feels like too much scope creep for this PR so its probably best addressed as another issue.