### PR TITLE
allow leading comments in SQL input field

### DIFF
--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -174,6 +174,7 @@ disallawed_sql_res = [(re.compile("pragma"), "Statement may not contain PRAGMA")
 
 
 def validate_sql_select(sql):
+    sql = "\n".join(line for line in sql.split('\n') if not line.strip().startswith('--'))
     sql = sql.strip().lower()
     if not any(r.match(sql) for r in allowed_sql_res):
         raise InvalidSql("Statement must be a SELECT")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,6 +137,7 @@ def test_custom_json_encoder(obj, expected):
     "bad_sql",
     [
         "update blah;",
+        "-- sql comment to skip\nupdate blah;",
         "PRAGMA case_sensitive_like = true" "SELECT * FROM pragma_index_info('idx52')",
     ],
 )
@@ -150,6 +151,7 @@ def test_validate_sql_select_bad(bad_sql):
     [
         "select count(*) from airports",
         "select foo from bar",
+        "--sql comment to skip\nselect foo from bar",
         "select 1 + 1",
         "explain select 1 + 1",
         "explain query plan select 1 + 1",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -138,6 +138,7 @@ def test_custom_json_encoder(obj, expected):
     [
         "update blah;",
         "-- sql comment to skip\nupdate blah;",
+        "update blah set some_column='# Hello there\n\n* This is a list\n* of items\n--\n[And a link](https://github.com/simonw/datasette-render-markdown).'\nas demo_markdown",
         "PRAGMA case_sensitive_like = true" "SELECT * FROM pragma_index_info('idx52')",
     ],
 )
@@ -152,6 +153,7 @@ def test_validate_sql_select_bad(bad_sql):
         "select count(*) from airports",
         "select foo from bar",
         "--sql comment to skip\nselect foo from bar",
+        "select '# Hello there\n\n* This is a list\n* of items\n--\n[And a link](https://github.com/simonw/datasette-render-markdown).'\nas demo_markdown",
         "select 1 + 1",
         "explain select 1 + 1",
         "explain query plan select 1 + 1",


### PR DESCRIPTION
this changes the SQL validation to allow for lines that are commented out

my main use case for this is that I like to write a succession of queries when trying to solve a problem.
In most native SQL clients there is a key binding that will run just the current highlighted query or the program is smart enough to run just the query that the cursor is in if it's properly delimited with a ';'.
Typically my workflow will start with a single simple query and I'll copy/paste it to a new query below when I want to make big changes while debugging.  This makes it easy to go back to a working version above when the query doesn't work.
Since datasette sends the whole query to the DB I have to comment out the older queries by prefixing each line with `--`.  This gets caught by the validators when I use my typical strategy of copy/pasting each successive query below the last one.   
so this is just a simple fix to allow for a query to be sent to the DB with leading comments.
