### PR TITLE
Use inspect-file, if possible, for total row count

### DIFF
--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -539,7 +539,19 @@ class TableView(RowTableShared):
 
         # Number of filtered rows in whole set:
         filtered_table_rows_count = None
-        if count_sql:
+        if (
+            not db.is_mutable
+            and self.ds.inspect_data
+            and count_sql == "select count(*) from {} ".format(table)
+        ):
+            try:
+                filtered_table_rows_count = self.ds.inspect_data[database]["tables"][
+                    table
+                ]["count"]
+            except KeyError:
+                pass
+
+        if count_sql and filtered_table_rows_count is None:
             try:
                 count_rows = list(
                     await self.ds.execute(database, count_sql, from_sql_params)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -227,6 +227,12 @@ def app_client_with_cors():
     yield from make_app_client(cors=True)
 
 
+@pytest.fixture(scope="session")
+def app_client_immutable_and_inspect_file():
+    inspect_data = {'fixtures': {'tables': {'sortable': {'count': 100}}}}
+    yield from make_app_client(is_immutable=True, inspect_data=inspect_data)
+
+
 def generate_compound_rows(num):
     for a, b, c in itertools.islice(
         itertools.product(string.ascii_lowercase, repeat=3), num

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,6 +11,7 @@ from .fixtures import (  # noqa
     app_client_conflicting_database_names,
     app_client_with_cors,
     app_client_with_dot,
+    app_client_immutable_and_inspect_file,
     generate_compound_rows,
     generate_sortable_rows,
     make_app_client,
@@ -1766,3 +1767,8 @@ def test_null_foreign_keys_are_not_expanded(app_client):
         },
         {"pk": "2", "foreign_key_with_label": None, "foreign_key_with_no_label": None,},
     ] == response.json
+
+
+def test_inspect_file_used_for_count(app_client_immutable_and_inspect_file):
+    response = app_client_immutable_and_inspect_file.get("/fixtures/sortable.json")
+    assert response.json["filtered_table_rows_count"] == 100


### PR DESCRIPTION
For large tables, counting the number of rows in the table can take a
signficant amount of time. Instead, where an inspect-file is provided
for an immutable database, look up the row-count for a plain count(*).