### PR TITLE
asgi: check raw_path is not None

### DIFF
--- a/datasette/utils/asgi.py
+++ b/datasette/utils/asgi.py
@@ -46,7 +46,7 @@ class Request:
 
     @property
     def path(self):
-        if "raw_path" in self.scope:
+        if self.scope.get("raw_path") is not None:
             return self.scope["raw_path"].decode("latin-1")
         else:
             path = self.scope["path"]


### PR DESCRIPTION
The ASGI spec
(https://asgi.readthedocs.io/en/latest/specs/www.html#http) seems to imply that `None` is a valid value, so we need to check the value itself, not just whether the key is present.

In particular, the [mangum](https://github.com/erm/mangum) adapter passes `None` for this key's value. This change permits mangum to be used to front datasette in Amazon API Gateway + AWS Lambda deployments.