### PR TITLE
Reload support for config_dir mode.

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -2,6 +2,7 @@ import asyncio
 import asgi_csrf
 import collections
 import datetime
+import glob
 import hashlib
 import inspect
 import itertools
@@ -263,9 +264,10 @@ class Datasette:
         # Execute plugins in constructor, to ensure they are available
         # when the rest of `datasette inspect` executes
         if self.plugins_dir:
-            for filename in os.listdir(self.plugins_dir):
-                filepath = os.path.join(self.plugins_dir, filename)
-                mod = module_from_path(filepath, name=filename)
+            for filepath in glob.glob(os.path.join(self.plugins_dir, "*.py")):
+                if not os.path.isfile(filepath):
+                    continue
+                mod = module_from_path(filepath, name=os.path.basename(filepath))
                 try:
                     pm.register(mod)
                 except ValueError:


### PR DESCRIPTION
A reference implementation for adding support to reload when datasette is in the config_dir mode. 

This implementation is flawed since it is watching the entire directory and any changes to the database will reload the server and adding unrelated files to the directory will also reload the server. 