### PR TITLE
Magic parameters for canned queries

### DIFF
--- a/datasette/database.py
+++ b/datasette/database.py
@@ -132,7 +132,7 @@ class Database:
             with sqlite_timelimit(conn, time_limit_ms):
                 try:
                     cursor = conn.cursor()
-                    cursor.execute(sql, params or {})
+                    cursor.execute(sql, params if params is not None else {})
                     max_returned_rows = self.ds.max_returned_rows
                     if max_returned_rows == page_size:
                         max_returned_rows += 1

--- a/datasette/default_magic_parameters.py
+++ b/datasette/default_magic_parameters.py
@@ -5,7 +5,7 @@ import os
 import time
 
 
-def request(key, request):
+def header(key, request):
     key = key.replace("_", "-").encode("utf-8")
     headers_dict = dict(request.scope["headers"])
     return headers_dict[key].decode("utf-8")
@@ -27,7 +27,7 @@ def timestamp(key, request):
     elif key == "date_utc":
         return datetime.datetime.utcnow().date().isoformat()
     elif key == "datetime_utc":
-        return datetime.datetime.utcnow().isoformat()
+        return datetime.datetime.utcnow().strftime(r"%Y-%m-%dT%H:%M:%S") + "Z"
     else:
         raise KeyError
 
@@ -47,7 +47,7 @@ def random(key, request):
 @hookimpl
 def register_magic_parameters():
     return [
-        ("request", request),
+        ("header", header),
         ("actor", actor),
         ("cookie", cookie),
         ("timestamp", timestamp),

--- a/datasette/default_magic_parameters.py
+++ b/datasette/default_magic_parameters.py
@@ -1,0 +1,55 @@
+from datasette import hookimpl
+from datasette.utils import escape_fts
+import datetime
+import os
+import time
+
+
+def request(key, request):
+    key = key.replace("_", "-").encode("utf-8")
+    headers_dict = dict(request.scope["headers"])
+    return headers_dict[key].decode("utf-8")
+
+
+def actor(key, request):
+    if request.actor is None:
+        raise KeyError
+    return request.actor[key]
+
+
+def cookie(key, request):
+    return request.cookies[key]
+
+
+def timestamp(key, request):
+    if key == "epoch":
+        return int(time.time())
+    elif key == "date_utc":
+        return datetime.datetime.utcnow().date().isoformat()
+    elif key == "datetime_utc":
+        return datetime.datetime.utcnow().isoformat()
+    else:
+        raise KeyError
+
+
+def random(key, request):
+    if key.startswith("chars_") and key.split("chars_")[-1].isdigit():
+        num_chars = int(key.split("chars_")[-1])
+        if num_chars % 2 == 1:
+            urandom_len = (num_chars + 1) / 2
+        else:
+            urandom_len = num_chars / 2
+        return os.urandom(int(urandom_len)).hex()[:num_chars]
+    else:
+        raise KeyError
+
+
+@hookimpl
+def register_magic_parameters():
+    return [
+        ("request", request),
+        ("actor", actor),
+        ("cookie", cookie),
+        ("timestamp", timestamp),
+        ("random", random),
+    ]

--- a/datasette/hookspecs.py
+++ b/datasette/hookspecs.py
@@ -83,3 +83,8 @@ def permission_allowed(datasette, actor, action, resource):
 @hookspec
 def canned_queries(datasette, database, actor):
     "Return a dictonary of canned query definitions or an awaitable function that returns them"
+
+
+@hookspec
+def register_magic_parameters(datasette):
+    "Return a list of (name, function) magic parameter functions"

--- a/datasette/plugins.py
+++ b/datasette/plugins.py
@@ -11,6 +11,7 @@ DEFAULT_PLUGINS = (
     "datasette.sql_functions",
     "datasette.actor_auth_cookie",
     "datasette.default_permissions",
+    "datasette.default_magic_parameters",
 )
 
 pm = pluggy.PluginManager("datasette")

--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -4,6 +4,7 @@ import base64
 import click
 import hashlib
 import inspect
+import itertools
 import json
 import mergedeep
 import os
@@ -17,6 +18,7 @@ import urllib
 import numbers
 import yaml
 from .shutil_backport import copytree
+from ..plugins import pm
 
 try:
     import pysqlite3 as sqlite3

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -186,10 +186,13 @@ class QueryView(DataView):
         if write:
             if request.method == "POST":
                 params = await request.post_vars()
-                params2 = MagicParameters(params, request, self.ds)
+                if canned_query:
+                    params_for_query = MagicParameters(params, request, self.ds)
+                else:
+                    params_for_query = params
                 try:
                     cursor = await self.ds.databases[database].execute_write(
-                        sql, params2, block=True
+                        sql, params_for_query, block=True
                     )
                     message = metadata.get(
                         "on_success_message"
@@ -230,10 +233,12 @@ class QueryView(DataView):
                     templates,
                 )
         else:  # Not a write
-            # TODO: REMOVE THIS for security:
-            params2 = MagicParameters(params, request, self.ds)
+            if canned_query:
+                params_for_query = MagicParameters(params, request, self.ds)
+            else:
+                params_for_query = params
             results = await self.ds.execute(
-                database, sql, params2, truncate=True, **extra_args
+                database, sql, params_for_query, truncate=True, **extra_args
             )
             columns = [r[0] for r in results.description]
 

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -314,13 +314,13 @@ class MagicParameters(dict):
             )
         )
 
-    def __missing__(self, key):
+    def __getitem__(self, key):
         if key.startswith("_") and key.count("_") >= 2:
             prefix, suffix = key[1:].split("_", 1)
             if prefix in self._magics:
                 try:
                     return self._magics[prefix](suffix, self._request)
                 except KeyError:
-                    return ""
+                    return super().__getitem__(key)
         else:
-            return ""
+            return super().__getitem__(key)

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -1,4 +1,5 @@
 import os
+import itertools
 import jinja2
 
 from datasette.utils import (
@@ -169,7 +170,7 @@ class QueryView(DataView):
 
         # Set to blank string if missing from params
         for named_parameter in named_parameters:
-            if named_parameter not in params:
+            if named_parameter not in params and not named_parameter.startswith("_"):
                 params[named_parameter] = ""
 
         extra_args = {}
@@ -184,9 +185,10 @@ class QueryView(DataView):
         if write:
             if request.method == "POST":
                 params = await request.post_vars()
+                params2 = MagicParameters(params, request, self.ds)
                 try:
                     cursor = await self.ds.databases[database].execute_write(
-                        sql, params, block=True
+                        sql, params2, block=True
                     )
                     message = metadata.get(
                         "on_success_message"
@@ -227,8 +229,10 @@ class QueryView(DataView):
                     templates,
                 )
         else:  # Not a write
+            # TODO: REMOVE THIS for security:
+            params2 = MagicParameters(params, request, self.ds)
             results = await self.ds.execute(
-                database, sql, params, truncate=True, **extra_args
+                database, sql, params2, truncate=True, **extra_args
             )
             columns = [r[0] for r in results.description]
 
@@ -298,3 +302,25 @@ class QueryView(DataView):
             extra_template,
             templates,
         )
+
+
+class MagicParameters(dict):
+    def __init__(self, data, request, datasette):
+        super().__init__(data)
+        self._request = request
+        self._magics = dict(
+            itertools.chain.from_iterable(
+                pm.hook.register_magic_parameters(datasette=datasette)
+            )
+        )
+
+    def __missing__(self, key):
+        if key.startswith("_") and key.count("_") >= 2:
+            prefix, suffix = key[1:].split("_", 1)
+            if prefix in self._magics:
+                try:
+                    return self._magics[prefix](suffix, self._request)
+                except KeyError:
+                    return ""
+        else:
+            return ""

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -166,6 +166,7 @@ class QueryView(DataView):
         named_parameter_values = {
             named_parameter: params.get(named_parameter) or ""
             for named_parameter in named_parameters
+            if not named_parameter.startswith("_")
         }
 
         # Set to blank string if missing from params

--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -893,3 +893,12 @@ Here's an example that allows users to view the ``admin_log`` table only if thei
 See :ref:`built-in permissions <permissions>` for a full list of permissions that are included in Datasette core.
 
 Example: `datasette-permissions-sql <https://github.com/simonw/datasette-permissions-sql>`_
+
+.. _plugin_hook_register_magic_parameters:
+
+register_magic_parameters(datasette)
+------------------------------------
+
+Register additional magic parameter types.
+
+TODO: More docs.

--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -514,7 +514,7 @@ register_routes()
 
 Register additional view functions to execute for specified URL routes.
 
-Return a list of ``(regex, async_view_function)`` pairs, something like this:
+Return a list of ``(regex, view_function)`` pairs, something like this:
 
 .. code-block:: python
 
@@ -553,6 +553,8 @@ The optional view function arguments are as follows:
 
 ``receive`` - function
     The ASGI receive function.
+
+The view function can be a regular function or an ``async def`` function, depending on if it needs to use any ``await`` APIs.
 
 The function can either return a :ref:`internals_response` or it can return nothing and instead respond directly to the request using the ASGI ``send`` function (for advanced uses only).
 

--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -901,6 +901,36 @@ Example: `datasette-permissions-sql <https://github.com/simonw/datasette-permiss
 register_magic_parameters(datasette)
 ------------------------------------
 
-Register additional magic parameter types.
+``datasette`` - :ref:`internals_datasette`
+    You can use this to access plugin configuration options via ``datasette.plugin_config(your_plugin_name)``.
 
-TODO: More docs.
+:ref:`canned_queries_magic_parameters` can be used to add automatic parameters to :ref:`canned queries <canned_queries>`. This plugin hook allows additional magic parameters to be defined by plugins.
+
+Magic parameters all take this format: ``_prefix_rest_of_parameter``. The prefix indicates which magic parameter function should be called - the rest of the parameter is passed as an argument to that function.
+
+To register a new function, return it as a tuple of ``(string prefix, function)`` from this hook. The function you register should take two arguments: ``key`` and ``request``, where ``key`` is the ``rest_of_parameter`` portion of the parameter and ``request`` is the current :ref:`internals_request`.
+
+This example registers two new magic parameters: ``:_request_http_version`` returning the HTTP version of the current request, and ``:_uuid_new`` which returns a new UUID:
+
+.. code-block:: python
+
+    from uuid import uuid4
+
+    def uuid(key, request):
+        if key == "new":
+            return str(uuid4())
+        else:
+            raise KeyError
+
+    def request(key, request):
+        if key == "http_version":
+            return request.scope["http_version"]
+        else:
+            raise KeyError
+
+    @hookimpl
+    def register_magic_parameters(datasette):
+        return [
+            ("request", request),
+            ("uuid", uuid),
+        ]

--- a/docs/sql_queries.rst
+++ b/docs/sql_queries.rst
@@ -324,6 +324,8 @@ Here's an example configuration (this time using ``metadata.yaml`` since that pr
 
 The form presented at ``/mydatabase/add_message`` will have just a field for ``message`` - the other parameters will be populated by the magic parameter mechanism.
 
+Additional custom magic parameters can be added by plugins using the :ref:`plugin_hook_register_magic_parameters` hook.
+
 .. _pagination:
 
 Pagination

--- a/docs/sql_queries.rst
+++ b/docs/sql_queries.rst
@@ -114,8 +114,8 @@ rendered as HTML (rather than having HTML special characters escaped).
 
 .. _canned_queries_named_parameters:
 
-Named parameters
-~~~~~~~~~~~~~~~~
+Canned query parameters
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Canned queries support named parameters, so if you include those in the SQL you
 will then be able to enter them using the form fields on the canned query page
@@ -273,6 +273,60 @@ For example:
 You can use ``"params"`` to explicitly list the named parameters that should be displayed as form fields - otherwise they will be automatically detected.
 
 You can pre-populate form fields when the page first loads using a querystring, e.g. ``/mydatabase/add_name?name=Prepopulated``. The user will have to submit the form to execute the query.
+
+.. _canned_queries_magic_parameters:
+
+Magic parameters
+~~~~~~~~~~~~~~~~
+
+Named parameters that start with an underscore are special: they can be used to automatically add values created by Datasette that are not contained in the incoming form fields or querystring.
+
+Available magic parameters are:
+
+``_actor_*`` - e.g. ``actor_id``, ``actor_name``
+    Fields from the currently authenticated :ref:`actor`.
+
+``_request_ip``
+    The IP of the incoming request.
+
+``_request_user_agent``
+    The browser user-agent of the incoming request.
+
+``_cookie_*`` - e.g. ``cookie_lang``
+    The value of the incoming cookie of that name.
+
+``_timestamp_epoch``
+    The number of seconds since the Unix epoch.
+
+``_timestamp_date_utc``
+    The date in UTC, e.g. ``2020-06-01``
+
+``_timestamp_datetime_utc``
+    The ISO 8601 datetime in UTC, e.g. ``2020-06-24T18:01:07Z``
+
+``_random_chars_*`` - e.g. ``_random_chars_128``
+    A random string of characters of the specified length.
+
+Here's an example configuration (this time using ``metadata.yaml``) that adds a message from the authenticated user, storing various pieces of additional metadata:
+
+
+.. code-block:: yaml
+
+    databases:
+      mydatabase:
+        queries:
+          add_message:
+            allow:
+              id: "*"
+            sql: |-
+              INSERT INTO messages (
+                user_id, ip, message, datetime
+              ) VALUES (
+                :_actor_id, :_request_ip, :message, :_timestamp_datetime_utc
+              )
+            write: true
+
+The form presented at ``/mydatabase/add_message`` will have just a field for ``message`` - the other parameters will be populated by the magic parameter mechanism.
 
 .. _pagination:
 

--- a/docs/sql_queries.rst
+++ b/docs/sql_queries.rst
@@ -283,16 +283,13 @@ Named parameters that start with an underscore are special: they can be used to 
 
 Available magic parameters are:
 
-``_actor_*`` - e.g. ``actor_id``, ``actor_name``
-    Fields from the currently authenticated :ref:`actor`.
+``_actor_*`` - e.g. ``_actor_id``, ``_actor_name``
+    Fields from the currently authenticated :ref:`authentication_actor`.
 
-``_request_ip``
-    The IP of the incoming request.
+``_header_*`` - e.g. ``_header_user_agent``
+    Header from the incoming HTTP request. The key should be in lower case and with hyphens converted to underscores e.g. ``_header_user_agent`` or ``_header_accept_language``.
 
-``_request_user_agent``
-    The browser user-agent of the incoming request.
-
-``_cookie_*`` - e.g. ``cookie_lang``
+``_cookie_*`` - e.g. ``_cookie_lang``
     The value of the incoming cookie of that name.
 
 ``_timestamp_epoch``

--- a/docs/sql_queries.rst
+++ b/docs/sql_queries.rst
@@ -307,8 +307,7 @@ Available magic parameters are:
 ``_random_chars_*`` - e.g. ``_random_chars_128``
     A random string of characters of the specified length.
 
-Here's an example configuration (this time using ``metadata.yaml``) that adds a message from the authenticated user, storing various pieces of additional metadata:
-
+Here's an example configuration (this time using ``metadata.yaml`` since that provides better support for multi-line SQL queries) that adds a message from the authenticated user, storing various pieces of additional metadata using magic parameters:
 
 .. code-block:: yaml
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -49,6 +49,7 @@ EXPECTED_PLUGINS = [
             "prepare_connection",
             "prepare_jinja2_environment",
             "register_facet_classes",
+            "register_magic_parameters",
             "register_routes",
             "render_cell",
             "startup",

--- a/tests/plugins/my_plugin.py
+++ b/tests/plugins/my_plugin.py
@@ -212,3 +212,14 @@ def canned_queries(datasette, database, actor):
             actor["id"] if actor else "null"
         )
     }
+
+
+@hookimpl
+def register_magic_parameters():
+    def request(key, request):
+        if key == "http_version":
+            return request.scope["http_version"]
+        else:
+            raise KeyError
+
+    return [("request", request)]

--- a/tests/plugins/my_plugin.py
+++ b/tests/plugins/my_plugin.py
@@ -187,12 +187,16 @@ def register_routes():
             await datasette.render_template("csrftoken_form.html", request=request)
         )
 
+    def not_async():
+        return Response.html("This was not async")
+
     return [
         (r"/one/$", one),
         (r"/two/(?P<name>.*)$", two),
         (r"/three/$", three),
         (r"/post/$", post),
         (r"/csrftoken-form/$", csrftoken_form),
+        (r"/not-async/$", not_async),
     ]
 
 

--- a/tests/plugins/my_plugin.py
+++ b/tests/plugins/my_plugin.py
@@ -216,10 +216,21 @@ def canned_queries(datasette, database, actor):
 
 @hookimpl
 def register_magic_parameters():
+    from uuid import uuid4
+
+    def uuid(key, request):
+        if key == "new":
+            return str(uuid4())
+        else:
+            raise KeyError
+
     def request(key, request):
         if key == "http_version":
             return request.scope["http_version"]
         else:
             raise KeyError
 
-    return [("request", request)]
+    return [
+        ("request", request),
+        ("uuid", uuid),
+    ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -601,18 +601,6 @@ def test_custom_sql(app_client):
     assert not data["truncated"]
 
 
-def test_canned_query_with_named_parameter(app_client):
-    response = app_client.get("/fixtures/neighborhood_search.json?text=town")
-    assert [
-        ["Corktown", "Detroit", "MI"],
-        ["Downtown", "Los Angeles", "CA"],
-        ["Downtown", "Detroit", "MI"],
-        ["Greektown", "Detroit", "MI"],
-        ["Koreatown", "Los Angeles", "CA"],
-        ["Mexicantown", "Detroit", "MI"],
-    ] == response.json["rows"]
-
-
 def test_sql_time_limit(app_client_shorter_time_limit):
     response = app_client_shorter_time_limit.get("/fixtures.json?sql=select+sleep(0.5)")
     assert 400 == response.status

--- a/tests/test_canned_queries.py
+++ b/tests/test_canned_queries.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup as Soup
 import pytest
 import re
 from .fixtures import make_app_client, app_client
@@ -194,6 +195,12 @@ def test_magic_parameters(magic_parameters_client, magic_parameter, expected_re)
         "ds_actor": magic_parameters_client.actor_cookie({"id": "root"}),
         "foo": "bar",
     }
+    # Test the form
+    form_response = magic_parameters_client.get("/data/runme")
+    soup = Soup(form_response.body, "html.parser")
+    # The magic parameter should not be represented as a form field
+    assert None is soup.find("input", {"name": magic_parameter})
+    # Submit the form to create a log line
     response = magic_parameters_client.post(
         "/data/runme", {}, csrftoken_from=True, cookies=cookies
     )

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -640,7 +640,7 @@ def test_canned_queries_actor(app_client):
     ).json
 
 
-def test_register_magic_parameters():
+def test_register_magic_parameters(restore_working_directory):
     with make_app_client(
         extra_databases={"data.db": "create table logs (line text)"},
         metadata={

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -565,7 +565,12 @@ def test_actor_json(app_client):
 
 
 @pytest.mark.parametrize(
-    "path,body", [("/one/", "2"), ("/two/Ray?greeting=Hail", "Hail Ray"),]
+    "path,body",
+    [
+        ("/one/", "2"),
+        ("/two/Ray?greeting=Hail", "Hail Ray"),
+        ("/not-async/", "This was not async"),
+    ],
 )
 def test_register_routes(app_client, path, body):
     response = app_client.get(path)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -633,3 +633,8 @@ def test_canned_queries_actor(app_client):
     assert [{"1": 1, "actor_id": "bot"}] == app_client.get(
         "/fixtures/from_hook.json?_bot=1&_shape=array"
     ).json
+
+
+def test_register_magic_parameters(app_client):
+    # TODO: Tests
+    assert True

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -651,6 +651,7 @@ def test_register_magic_parameters(restore_working_directory):
                             "sql": "insert into logs (line) values (:_request_http_version)",
                             "write": True,
                         },
+                        "get_uuid": {"sql": "select :_uuid_new",},
                     }
                 }
             }
@@ -659,4 +660,9 @@ def test_register_magic_parameters(restore_working_directory):
         response = client.post("/data/runme", {}, csrftoken_from=True)
         assert 200 == response.status
         actual = client.get("/data/logs.json?_sort_desc=rowid&_shape=array").json
-    assert [{"rowid": 1, "line": "1.0"}] == actual
+        assert [{"rowid": 1, "line": "1.0"}] == actual
+        # Now try the GET request against get_uuid
+        response_get = client.get("/data/get_uuid.json?_shape=array")
+        assert 200 == response_get.status
+        new_uuid = response_get.json[0][":_uuid_new"]
+        assert 4 == new_uuid.count("-")


### PR DESCRIPTION
Implementation for #842

TODO:

- [x] Add tests for built-in magic parameters
- [x] Magic parameters should not show up as blank form fields on the query page
- [x] Update documentation for new `_request_X` (now called `_header_X`) implementation where X is a key from the ASGI scope
- [x] Make sure these only work for canned queries, not for arbitrary SQL queries (security issue)
- [x] Add test for the `register_magic_parameters` plugin hook
- [x] Add documentation for the `register_magic_parameters` plugin hook
