### PR TITLE
Skip counting hidden tables

### DIFF
--- a/datasette/database.py
+++ b/datasette/database.py
@@ -178,7 +178,8 @@ class Database:
             return self.cached_table_counts
         # Try to get counts for each table, $limit timeout for each count
         counts = {}
-        for table in await self.table_names():
+        visible_tables = set(await self.table_names()) - set(await self.hidden_table_names())
+        for table in visible_tables:
             try:
                 table_count = (
                     await self.execute(


### PR DESCRIPTION
Potential fix for https://github.com/simonw/datasette/issues/859.

Disabling table counts for hidden tables speeds up database page quite a bit. In my setup it reduced load time by 2/3 (~300 -> ~90ms)