### PR TITLE
Load only python files from plugins-dir.

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -2,6 +2,7 @@ import asyncio
 import asgi_csrf
 import collections
 import datetime
+import glob
 import hashlib
 import inspect
 import itertools
@@ -263,9 +264,10 @@ class Datasette:
         # Execute plugins in constructor, to ensure they are available
         # when the rest of `datasette inspect` executes
         if self.plugins_dir:
-            for filename in os.listdir(self.plugins_dir):
-                filepath = os.path.join(self.plugins_dir, filename)
-                mod = module_from_path(filepath, name=filename)
+            for filepath in glob.glob(os.path.join(self.plugins_dir, "*.py")):
+                if not os.path.isfile(filepath):
+                    continue
+                mod = module_from_path(filepath, name=os.path.basename(filepath))
                 try:
                     pm.register(mod)
                 except ValueError:

--- a/tests/test_config_dir.py
+++ b/tests/test_config_dir.py
@@ -30,6 +30,8 @@ def config_dir_client(tmp_path_factory):
     plugins_dir = config_dir / "plugins"
     plugins_dir.mkdir()
     (plugins_dir / "hooray.py").write_text(PLUGIN, "utf-8")
+    (plugins_dir / "non_py_file.txt").write_text(PLUGIN, "utf-8")
+    (plugins_dir / ".mypy_cache").mkdir()
 
     templates_dir = config_dir / "templates"
     templates_dir.mkdir()
@@ -95,6 +97,8 @@ def test_plugins(config_dir_client):
     response = config_dir_client.get("/-/plugins.json")
     assert 200 == response.status
     assert "hooray.py" in {p["name"] for p in response.json}
+    assert "non_py_file.txt" not in {p["name"] for p in response.json}
+    assert "mypy_cache" not in {p["name"] for p in response.json}
 
 
 def test_templates_and_plugin(config_dir_client):


### PR DESCRIPTION
The current behavior for `--plugins-dir` is to load every file in that folder as a python module. This can result in errors if there are non-python files in the plugins dir (such as .mypy_cache). 

This PR restricts the module loading to only python files. 