### PR TITLE
Use None as a default arg

### DIFF
--- a/datasette/filters.py
+++ b/datasette/filters.py
@@ -191,7 +191,9 @@ class Filters:
     )
     _filters_by_key = {f.key: f for f in _filters}
 
-    def __init__(self, pairs, units={}, ureg=None):
+    def __init__(self, pairs, units=None, ureg=None):
+        if units is None:
+            units = {}
         self.pairs = pairs
         self.units = units
         self.ureg = ureg

--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -626,7 +626,9 @@ def module_from_path(path, name):
     return mod
 
 
-async def resolve_table_and_format(table_and_format, table_exists, allowed_formats=[]):
+async def resolve_table_and_format(table_and_format, table_exists, allowed_formats=None):
+    if allowed_formats is None:
+        allowed_formats = []
     if "." in table_and_format:
         # Check if a table exists with this exact name
         it_exists = await table_exists(table_and_format)

--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -626,7 +626,9 @@ def module_from_path(path, name):
     return mod
 
 
-async def resolve_table_and_format(table_and_format, table_exists, allowed_formats=None):
+async def resolve_table_and_format(
+    table_and_format, table_exists, allowed_formats=None
+):
     if allowed_formats is None:
         allowed_formats = []
     if "." in table_and_format:


### PR DESCRIPTION
When passing a mutable value as a default argument in a function, the default argument is mutated anytime that value is mutated. This poses a bug risk. Instead, use None as a default and assign the mutable value inside the function.