### PR TITLE
Don't install tests package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Issues": "https://github.com/simonw/datasette/issues",
         "CI": "https://travis-ci.org/simonw/datasette",
     },
-    packages=find_packages(exclude="tests"),
+    packages=find_packages(exclude=("tests",)),
     package_data={"datasette": ["templates/*.html"]},
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
The `exclude` argument to `find_packages` needs an iterable of package
names.

Fixes: #456 