### PR TITLE
Fix table name in spatialite example command

### DIFF
--- a/docs/spatialite.rst
+++ b/docs/spatialite.rst
@@ -65,7 +65,7 @@ Here's a recipe for taking a table with existing latitude and longitude columns,
     conn.execute("SELECT AddGeometryColumn('museums', 'point_geom', 4326, 'POINT', 2);")
     # Now update that geometry column with the lat/lon points
     conn.execute('''
-        UPDATE events SET
+        UPDATE museums SET
         point_geom = GeomFromText('POINT('||"longitude"||' '||"latitude"||')',4326);
     ''')
     # Now add a spatial index to that column


### PR DESCRIPTION
The example query for creating a new point geometry seems to be using a table called 'museums' but at one point it instead uses 'events'. I *believe* it is intended to be museums (the example makes more sense if so). 