### PR TITLE
Fallback to databases in inspect-data.json when no -i options are passed

### DIFF
--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -412,7 +412,7 @@ def serve(
         metadata_data = parse_metadata(metadata.read())
 
     kwargs = dict(
-        immutables=immutable,
+        immutables=immutable or None,
         cache_headers=not reload,
         cors=cors,
         inspect_data=inspect_data,


### PR DESCRIPTION
Currenlty `Datasette.__init__` checks immutables against None to decide whether to fallback to inspect-data.json. This patch modifies the serve command to pass None when no -i options are passed so this fallback works correctly.