### PR TITLE
DOC: Fix syntax error

### DIFF
--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -530,7 +530,7 @@ Return a list of ``(regex, view_function)`` pairs, something like this:
     @hookimpl
     def register_routes():
         return [
-            (r"^/hello-from/(?P<name>.*)$"), hello_from)
+            (r"^/hello-from/(?P<name>.*)$", hello_from)
         ]
 
 The view functions can take a number of different optional arguments. The corresponding argument will be passed to your function depending on its named parameters - a form of dependency injection.


### PR DESCRIPTION
If I understand https://docs.datasette.io/en/stable/plugin_hooks.html#register-routes correctly, `register_routes` should return a `List[Tuple[str, Callable]]`. I believe the current code in documentation has a syntax error (extra `)`). 