### PR TITLE
Add minimum supported python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     packages=find_packages(exclude=("tests",)),
     package_data={"datasette": ["templates/*.html"]},
     include_package_data=True,
+    python_requires=">=3.6",
     install_requires=[
         "asgiref>=3.2.10,<3.4.0",
         "click~=7.1.1",


### PR DESCRIPTION
Thanks for `datasette`!

This PR adds `python_requires` to formally signal the [minimum supported python version](https://packaging.python.org/guides/dropping-older-python-versions/#specify-the-version-ranges-for-supported-python-distributions) (which is pointed out with classifiers, so seems pretty straightforward).