### PR TITLE
Install Prettier via package.json

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,9 +12,11 @@ jobs:
       name: Configure npm caching
       with:
         path: ~/.npm
-        key: ${{ runner.os }}-npm-${{ hashFiles('**/workflows/prettier.yml') }}
+        key: ${{ runner.OS }}-npm-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-npm-
+          ${{ runner.OS }}-npm-
+    - name: Install dependencies
+      run: npm ci
     - name: Run prettier
       run: |-
         npx --no-install prettier --check 'datasette/static/*[!.min].js'

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -20,4 +20,4 @@ jobs:
           ${{ runner.os }}-npm-
     - name: Run prettier
       run: |-
-        npx prettier --check 'datasette/static/*[!.min].js'
+        npx --no-install prettier --check 'datasette/static/*[!.min].js'

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,6 +1,6 @@
 name: Check JavaScript for conformance with Prettier
 
-on: push
+on: [push]
 
 jobs:
   prettier:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,9 +1,6 @@
 name: Check JavaScript for conformance with Prettier
 
-on:
-  push:
-    paths:
-    - 'datasette/static/*'
+on: push
 
 jobs:
   prettier:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "datasette",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "prettier": "^2.2.1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    }
+  },
+  "dependencies": {
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "datasette",
+  "private": true,
+  "devDependencies": {
+    "prettier": "^2.2.1"
+  }
+}


### PR DESCRIPTION
This adds a package.json with Prettier and means that developers/CI will use the same version. It also ensures that NPM packages are cached on GitHub Actions which fixes #1169.