### PR TITLE
Add back styling to lists within table cells (fixes #1141)

### DIFF
--- a/datasette/static/app.css
+++ b/datasette/static/app.css
@@ -452,6 +452,10 @@ table a:link {
     margin-left: -10%;
     font-size: 0.8em;
 }
+.rows-and-columns td ol,ul {
+    list-style: initial;
+    list-style-position: inside;
+}
 a.blob-download {
     display: inline-block;
 }


### PR DESCRIPTION
This overrides the Datasette reset - see https://github.com/simonw/datasette/blob/d0fd833b8cdd97e1b91d0f97a69b494895d82bee/datasette/static/app.css#L35-L38 - to add back the default styling of list items displayed within Datasette table cells.

Following this change, the same content as in the original issue looks like this:

![2021-03-09_02:57:32](https://user-images.githubusercontent.com/7476523/110411982-63e5ae80-8083-11eb-9b5c-e5dc825073e2.png)
