### PR TITLE
Minor Docs Update. Added `--app` to fly install command.

### DIFF
--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -90,7 +90,7 @@ Publishing to Fly
 ::
 
     pip install datasette-publish-fly
-    datasette publish fly mydatabase.db
+    datasette publish fly mydatabase.db --app="my-app"
 
 Consult the `datasette-publish-fly README <https://github.com/simonw/datasette-publish-fly/blob/main/README.md>`__ for more details.
 


### PR DESCRIPTION
Without this flag, there's an error locally. 

```
> datasette publish fly bigmac.db

Usage: datasette publish fly [OPTIONS] [FILES]...
Try 'datasette publish fly --help' for help.

Error: Missing option '-a' / '--app'.
```

I also got an error message which later turned out to be because I hadn't added my credit card information yet to `fly`. I wasn't sure if I should add that mention to the docs here, or to submit a bug-report over at https://github.com/simonw/datasette-publish-fly. 