### PR TITLE
Update docs: explain allow_download setting

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -163,7 +163,7 @@ Should Datasette calculate suggested facets? On by default, turn this off like s
 allow_download
 ~~~~~~~~~~~~~~
 
-Should users be able to download the original SQLite database using a link on the database index page? This is turned on by default - to disable database downloads, use the following::
+Should users be able to download the original SQLite database using a link on the database index page? This is turned on by default. However, databases can only be downloaded if they are served in immutable mode and not in-memory. If downloading is forbidden for either of these reasons, the download link is hidden even if `allow_download` is on. To disable database downloads, use the following::
 
     datasette mydatabase.db --setting allow_download off
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -163,7 +163,7 @@ Should Datasette calculate suggested facets? On by default, turn this off like s
 allow_download
 ~~~~~~~~~~~~~~
 
-Should users be able to download the original SQLite database using a link on the database index page? This is turned on by default. However, databases can only be downloaded if they are served in immutable mode and not in-memory. If downloading is forbidden for either of these reasons, the download link is hidden even if `allow_download` is on. To disable database downloads, use the following::
+Should users be able to download the original SQLite database using a link on the database index page? This is turned on by default. However, databases can only be downloaded if they are served in immutable mode and not in-memory. If downloading is unavailable for either of these reasons, the download link is hidden even if ``allow_download`` is on. To disable database downloads, use the following::
 
     datasette mydatabase.db --setting allow_download off
 


### PR DESCRIPTION
This fixes one possible source of confusion seen in #502 and clarifies
when database downloads will be shown and allowed.