### PR TITLE
Add Docker multi-arch support with Buildx

### DIFF
--- a/.github/workflows/push_docker_tag.yml
+++ b/.github/workflows/push_docker_tag.yml
@@ -11,15 +11,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASS }}
+
     - name: Build and push to Docker Hub
+      run: |
+        docker buildx build \
+          --file Dockerfile . \
+          --tag $REPO:${VERSION_TAG} \
+          --build-arg VERSION=${VERSION_TAG} \
+          --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x \
+          --push
       env:
-        DOCKER_USER: ${{ secrets.DOCKER_USER }}
-        DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+        REPO: datasetteproject/datasette
         VERSION_TAG: ${{ github.event.inputs.version_tag }}
-      run: |-
-        docker login -u $DOCKER_USER -p $DOCKER_PASS
-        export REPO=datasetteproject/datasette
-        docker build -f Dockerfile \
-          -t $REPO:${VERSION_TAG} \
-          --build-arg VERSION=${VERSION_TAG} .
-        docker push $REPO:${VERSION_TAG}


### PR DESCRIPTION
This adds Docker support to extra CPU architectures (like arm) using [Docker's Buildx action](https://github.com/marketplace/actions/docker-setup-buildx)

You can see [what that looks like on Dockerhub](https://hub.docker.com/r/blairdrummond/datasette/tags?page=1&ordering=last_updated)

And how it lets Datasette run on a Raspberry Pi (top is my dockerhub, bottom is upstream)

![Screenshot from 2021-05-08 15-32-25](https://user-images.githubusercontent.com/10801138/117551210-a17a9f80-b012-11eb-966b-10e1590dd4a9.png)

The workflow log [here](https://github.com/blairdrummond/datasette/runs/2535743398?check_suite_focus=true) (I subbed `blairdrummond` for datasetteproject in my branch) 