### PR TITLE
DRAFT: add test and scan for docker images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ jobs:
       run: |
         docker run -v `pwd`:/mnt --platform ${{ matrix.platform }} \
             ${{ steps.build-image.outputs.image_name }} bash -c '
+              apt-get update --yes && apt-get install --yes gcc && \
               pip install "pytest>=5.2.2,<6.3.0" \
               "pytest-xdist>=2.2.1,<2.3" \
               "pytest-asyncio>=0.10,<0.16" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,64 @@ jobs:
       run: |
         pytest -n auto -m "not serial"
         pytest -m "serial"
+
+  test-docker:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/386
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
+          - linux/ppc64le
+          - linux/s390x
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+
+    - name: Build and push to Local registry
+      id: build-image
+      run: |
+        docker buildx build \
+          --file Dockerfile . \
+          --tag $REPO:${COMMIT_SHA} \
+          --build-arg VERSION=${COMMIT_SHA} \
+          --platform ${{ matrix.platform }} \
+          --load
+        echo "::set-output name=image_name::$REPO:${COMMIT_SHA}"
+      env:
+        COMMIT_SHA: ${{ github.sha }}
+        REPO: datasetteproject/datasette
+
+    - name: Test Docker image
+      run: |
+        docker run -v `pwd`:/mnt --platform ${{ matrix.platform }} \
+            ${{ steps.build-image.outputs.image_name }} bash -c '
+              pip install "pytest>=5.2.2,<6.3.0" \
+              "pytest-xdist>=2.2.1,<2.3" \
+              "pytest-asyncio>=0.10,<0.16" \
+              "beautifulsoup4>=4.8.1,<4.10.0" \
+              "black==21.5b1" \
+              "pytest-timeout>=1.4.2,<1.5" \
+              "trustme>=0.7,<0.8" \
+              && cd /mnt && pytest'
+
+    # Scan image for vulnerabilities
+    - uses: Azure/container-scan@v0
+      with:
+        image-name: ${{ steps.build-image.outputs.image_name }}
+        severity-threshold: CRITICAL
+        run-quality-checks: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG VERSION
 # which we need in order to install a more recent release
 # of libsqlite3-mod-spatialite from the sid distribution
 RUN apt-get update && \
-    apt-get -y --no-install-recommends install software-properties-common && \
+    apt-get -y --no-install-recommends install git software-properties-common && \
     add-apt-repository "deb http://httpredir.debian.org/debian sid main" && \
     apt-get update && \
     apt-get -t sid install -y --no-install-recommends libsqlite3-mod-spatialite && \
@@ -17,7 +17,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt && \
     rm -rf /var/lib/dpkg/info/*
 
-RUN pip install https://github.com/simonw/datasette/archive/refs/tags/${VERSION}.zip && \
+RUN pip install git+git://github.com/simonw/datasette.git@${VERSION} && \
     find /usr/local/lib -name '__pycache__' | xargs rm -r && \
     rm -rf /root/.cache/pip
 


### PR DESCRIPTION
**NOTE: I don't think this PR is ready, since the arm/v6 and arm/v7 images are failing pytest due to missing dependencies (gcc and friends). But it's pretty close.**

Closes https://github.com/simonw/datasette/issues/1344 . Using a build-matrix for the platforms and [this test](https://github.com/simonw/datasette/issues/1344#issuecomment-849820019), we test all the platforms in parallel. I also threw in container scanning.

### Switch `pip install` to use either tags or commit shas

Notably! This also [changes the Dockerfile](https://github.com/blairdrummond/datasette/blob/7fe5315d68e04fce64b5bebf4e2d7feec44f8546/Dockerfile#L20) so that it accepts tags or commit-shas.

```
# It's backwards compatible with tags, but also lets you use shas
root@712071df17af:/# pip install git+git://github.com/simonw/datasette.git@0.56                                                                                                                                            
Collecting git+git://github.com/simonw/datasette.git@0.56                                                                                                                                                                  
  Cloning git://github.com/simonw/datasette.git (to revision 0.56) to /tmp/pip-req-build-u6dhm945                                                                                                                          
  Running command git clone -q git://github.com/simonw/datasette.git /tmp/pip-req-build-u6dhm945                                                                                                                           
  Running command git checkout -q af5a7f1c09f6a902bb2a25e8edf39c7034d2e5de                                                                                                                                                 
Collecting Jinja2<2.12.0,>=2.10.3                                                                            
  Downloading Jinja2-2.11.3-py2.py3-none-any.whl (125 kB) 
```

This lets you build the containers in CI every push for testing, which maybe resolves [this problem](https://github.com/simonw/datasette/issues/1272#issuecomment-808648974)?

# Workflow run example

You can see the results in my workflow [here](https://github.com/blairdrummond/datasette/pull/2/checks?check_run_id=2690570717). The commit history is different because I squashed this branch, also in the testing branch I had to change `github.com/simonw` to `github.com/blairdrummond` for the CI to pick up my git_sha.

## Why did the builds fail?

**NOTE:** The results of all the tests fail, but for different reasons! A few fail to install Rust, the amd64 passes the tests (phew!) but has critical CVEs which fail the container scan, the Arm/v6 and Arm/v7 seem to fail to install the test dependencies due to missing programs like `gcc`. (`gcc` is not sufficient though, as [this run](https://github.com/blairdrummond/datasette/pull/3/checks?check_run_id=2690672982) indicates) 