### PR TITLE
DRAFT: A new plugin hook for dynamic metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ ENV/
 # macOS files
 .DS_Store
 node_modules
+.*.swp

--- a/datasette/app.py
+++ b/datasette/app.py
@@ -380,6 +380,7 @@ class Datasette:
         return self.databases[name]
 
     def add_database(self, db, name=None):
+        new_databases = self.databases.copy()
         if name is None:
             # Pick a unique name for this database
             suggestion = db.suggest_name()
@@ -391,14 +392,18 @@ class Datasette:
             name = "{}_{}".format(suggestion, i)
             i += 1
         db.name = name
-        self.databases[name] = db
+        new_databases[name] = db
+        # don't mutate! that causes race conditions with live import
+        self.databases = new_databases
         return db
 
     def add_memory_database(self, memory_name):
         return self.add_database(Database(self, memory_name=memory_name))
 
     def remove_database(self, name):
-        self.databases.pop(name)
+        new_databases = self.databases.copy()
+        new_databases.pop(name)
+        self.databases = new_databases
 
     def setting(self, key):
         return self._settings.get(key, None)

--- a/datasette/app.py
+++ b/datasette/app.py
@@ -418,9 +418,7 @@ class Datasette:
 
         for key, upd_value in updated.items():
             if isinstance(upd_value, dict) and isinstance(orig.get(key), dict):
-                orig[key] = self._metadata_recursive_update(
-                    orig[key], upd_value
-                )
+                orig[key] = self._metadata_recursive_update(orig[key], upd_value)
             else:
                 orig[key] = upd_value
         return orig
@@ -435,11 +433,8 @@ class Datasette:
         ), "Cannot call metadata() with table= specified but not database="
         metadata = {}
 
-        # TODO: change this to update_metadata, pass meta back allow the
-        # plugins to mutate it?
         for hook_dbs in pm.hook.get_metadata(
-            datasette=self, key=key, database=database, table=table,
-            fallback=fallback
+            datasette=self, key=key, database=database, table=table, fallback=fallback
         ):
             metadata = self._metadata_recursive_update(metadata, hook_dbs)
 
@@ -460,8 +455,6 @@ class Datasette:
             ) or {}
             search_list.insert(0, table_metadata)
 
-        # TODO: get full data for here, we need to work down to tables from that
-        # as opposed to simply returning table data above?
         search_list.append(metadata)
         if not fallback:
             # No fallback allowed, so just use the first one in the list
@@ -1002,7 +995,7 @@ class Datasette:
             r"/:memory:(?P<rest>.*)$",
         )
         add_route(
-            JsonDataView.as_view(self, "metadata.json", lambda: self._metadata),
+            JsonDataView.as_view(self, "metadata.json", lambda: self.metadata()),
             r"/-/metadata(?P<as_format>(\.json)?)$",
         )
         add_route(

--- a/datasette/hookspecs.py
+++ b/datasette/hookspecs.py
@@ -11,6 +11,11 @@ def startup(datasette):
 
 
 @hookspec
+def get_metadata(datasette, key, database, table, fallback):
+    """Get configuration"""
+
+
+@hookspec
 def asgi_wrapper(datasette):
     """Returns an ASGI middleware callable to wrap our ASGI application with"""
 

--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -21,7 +21,6 @@ import numbers
 import yaml
 from .shutil_backport import copytree
 from .sqlite import sqlite3, sqlite_version, supports_table_xinfo
-from ..plugins import pm
 
 
 # From https://www.sqlite.org/lang_keywords.html

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -440,7 +440,7 @@ def test_permissions_cascade(cascade_app_client, path, permissions, expected_sta
     """Test that e.g. having view-table but NOT view-database lets you view table page, etc"""
     allow = {"id": "*"}
     deny = {}
-    previous_metadata = cascade_app_client.ds._metadata
+    previous_metadata = cascade_app_client.ds.metadata()
     updated_metadata = copy.deepcopy(previous_metadata)
     actor = {"id": "test"}
     if "download" in permissions:
@@ -457,11 +457,11 @@ def test_permissions_cascade(cascade_app_client, path, permissions, expected_sta
         updated_metadata["databases"]["fixtures"]["queries"]["magic_parameters"][
             "allow"
         ] = (allow if "query" in permissions else deny)
-        cascade_app_client.ds._metadata = updated_metadata
+        cascade_app_client.ds._metadata_local = updated_metadata
         response = cascade_app_client.get(
             path,
             cookies={"ds_actor": cascade_app_client.actor_cookie(actor)},
         )
         assert expected_status == response.status
     finally:
-        cascade_app_client.ds._metadata = previous_metadata
+        cascade_app_client.ds._metadata_local = previous_metadata


### PR DESCRIPTION
Note that this is a WORK IN PROGRESS!

This PR adds the following plugin hook:

    get_metadata(
      datasette=self, key=key, database=database, table=table,
      fallback=fallback
    )

This gets called when we're building our metdata for the rest of the system to use. Datasette merges whatever the plugins return with any local metadata (from metadata.yml/yaml/json) allowing for a live-editable dynamic Datasette. __A major design consideration is this: should Datasette perform the metadata merge? Or should Datasette allow plugins to perform any modifications themselves?__

As a security precation, local meta is *not* overwritable by plugin hooks. The workflow for transitioning to live-meta would be to load the plugin with the full metadata.yaml and save. Then remove the parts of the metadata that you want to be able to change from the file.

I have a WIP dynamic configuration plugin here, for reference: https://github.com/next-LI/datasette-live-config/