### PR TITLE
Ensure db.path is a string before trying to insert into internal database

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -354,7 +354,7 @@ class Datasette:
                 INSERT OR REPLACE INTO databases (database_name, path, is_memory, schema_version)
                 VALUES (?, ?, ?, ?)
             """,
-                [database_name, db.path, db.is_memory, schema_version],
+                [database_name, str(db.path), db.is_memory, schema_version],
                 block=True,
             )
             await populate_schema_tables(internal_db, db)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,6 +25,7 @@ from .fixtures import (  # noqa
     METADATA,
 )
 import json
+import pathlib
 import pytest
 import sys
 import urllib
@@ -2123,3 +2124,16 @@ def test_col_nocol_errors(app_client, path, expected_error):
     response = app_client.get(path)
     assert response.status == 400
     assert response.json["error"] == expected_error
+
+
+@pytest.mark.asyncio
+async def test_db_path(app_client):
+    db = app_client.ds.get_database()
+    path = pathlib.Path(db.path)
+
+    assert path.exists()
+
+    datasette = Datasette([path])
+
+    # this will break with a path
+    await datasette.refresh_schemas()


### PR DESCRIPTION
Fixes #1365 

This is the simplest possible fix, with a test that will fail without it. There are a bunch of places where `db.path` is getting converted to and from a `Path` type, so this fix errs on the side of calling `str(db.path)` right before it's inserted.