### PR TITLE
Update deploying.rst

### DIFF
--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -188,4 +188,8 @@ Then add these directives to proxy traffic::
     ProxyPass /datasette-prefix/ http://127.0.0.1:8009/datasette-prefix/
     ProxyPreserveHost On
 
+Using ``--uds`` you can use Unix domain sockets similiar to the Nginx example:
+
+    ProxyPass /my-datasette/ unix:/tmp/datasette.sock|http://localhost/my-datasette/
+
 The `ProxyPreserveHost On <https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxypreservehost>`__ directive ensures that the original ``Host:`` header from the incoming request is passed through to Datasette. Datasette needs this to correctly assemble links to other pages using the :ref:`datasette_absolute_url` method.


### PR DESCRIPTION
Example on how to use Unix domain socket option on Apache. Not testet.

(Usually I would have used [`ProxyPassReverse`](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassreverse) in combination with `ProxyPass` , i.e.

```apache
ProxyPass /my-datasette/ http://127.0.0.1:8009/my-datasette/
ProxyPassReverse /my-datasette/ http://127.0.0.1:8009/my-datasette/
```

and

```apache
ProxyPass /my-datasette/ unix:/tmp/datasette.sock|http://localhost/my-datasette/
ProxyPassReverse /my-datasette/ unix:/tmp/datasette.sock|http://localhost/my-datasette/
```
)