### PR TITLE
Remove underscore from search mode parameter name

### DIFF
--- a/docs/full_text_search.rst
+++ b/docs/full_text_search.rst
@@ -70,7 +70,7 @@ Here is an example which enables full-text search (with SQLite advanced search o
                     "display_ads": {
                         "fts_table": "ads_fts",
                         "fts_pk": "id",
-                        "search_mode": "raw"
+                        "searchmode": "raw"
                     }
                 }
             }


### PR DESCRIPTION
The fulltext search documentation refers to the parameter as `searchmode` but the `metadata.json` example uses `search_mode`. The latter doesn't actually seem to work.