### PR TITLE
Rework the `--static` documentation a bit

### DIFF
--- a/docs/custom_templates.rst
+++ b/docs/custom_templates.rst
@@ -173,18 +173,18 @@ Datasette can serve static files for you, using the ``--static`` option.
 Consider the following directory structure::
 
     metadata.json
-    static/styles.css
-    static/app.js
+    static-files/styles.css
+    static-files/app.js
 
-You can start Datasette using ``--static static:static/`` to serve those
-files from the ``/static/`` mount point::
+You can start Datasette using ``--static loc:static-files/`` to serve those
+files from the ``/loc/`` mount point::
 
-    $ datasette -m metadata.json --static static:static/ --memory
+    $ datasette -m metadata.json --static loc:static-files/ --memory
 
 The following URLs will now serve the content from those CSS and JS files::
 
-    http://localhost:8001/static/styles.css
-    http://localhost:8001/static/app.js
+    http://localhost:8001/loc/styles.css
+    http://localhost:8001/loc/app.js
 
 You can reference those files from ``metadata.json`` like so:
 
@@ -192,10 +192,10 @@ You can reference those files from ``metadata.json`` like so:
 
     {
         "extra_css_urls": [
-            "/static/styles.css"
+            "/loc/styles.css"
         ],
         "extra_js_urls": [
-            "/static/app.js"
+            "/loc/app.js"
         ]
     }
 
@@ -205,7 +205,7 @@ Publishing static assets
 The :ref:`cli_publish` command can be used to publish your static assets,
 using the same syntax as above::
 
-    $ datasette publish cloudrun mydb.db --static static:static/
+    $ datasette publish cloudrun mydb.db --static loc:static-files/
 
 This will upload the contents of the ``static/`` directory as part of the
 deployment, and configure Datasette to correctly serve the assets.


### PR DESCRIPTION
Per https://github.com/simonw/datasette/issues/1457, I was confused by the current docs and took a few minutes to sort out what the right combination of locations was.

This is a PR that differentiates the docs to split out  `/static/` in URL from `--static` option and `./static/` path.

Not wedded to the details in any way, happy to change to suit.