### PR TITLE
Add Authorization header when CORS flag is set

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -1319,6 +1319,7 @@ class DatasetteRouter:
         headers = {}
         if self.ds.cors:
             headers["Access-Control-Allow-Origin"] = "*"
+            headers["Access-Control-Allow-Headers"] = "Authorization"
         if request.path.split("?")[0].endswith(".json"):
             await asgi_send_json(send, info, status=status, headers=headers)
         else:


### PR DESCRIPTION
This PR adds the [`Access-Control-Allow-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) flag when CORS mode is enabled.

This would fix https://github.com/simonw/datasette-auth-tokens/issues/4. When making cross-origin requests, the server must respond with all allowable HTTP headers. A Datasette instance using auth tokens must accept the `Authorization` HTTP header in order for cross-origin authenticated requests to take place.

Please let me know if there's a better way of doing this! I couldn't figure out a way to change the app's response from the plugin itself, so I'm starting here. If you'd rather this logic live in the plugin, I'd love any guidance you're able to give.