### PR TITLE
Ensure template_path always uses "/" to match jinja

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -1212,7 +1212,8 @@ class DatasetteRouter:
         else:
             # Is there a pages/* template matching this path?
             route_path = request.scope.get("route_path", request.scope["path"])
-            template_path = os.path.join("pages", *route_path.split("/")) + ".html"
+            # Ensure template_path always uses "/" to match jina
+            template_path = "pages" + route_path + ".html"
             try:
                 template = self.ds.jinja_env.select_template([template_path])
             except TemplateNotFound:

--- a/datasette/app.py
+++ b/datasette/app.py
@@ -1212,10 +1212,10 @@ class DatasetteRouter:
         else:
             # Is there a pages/* template matching this path?
             route_path = request.scope.get("route_path", request.scope["path"])
-            # Ensure template_path always uses "/" to match jina
-            template_path = "pages" + route_path + ".html"
+            # Jinja requires template names to use "/" even on Windows
+            template_name = "pages" + route_path + ".html"
             try:
-                template = self.ds.jinja_env.select_template([template_path])
+                template = self.ds.jinja_env.select_template([template_name])
             except TemplateNotFound:
                 template = None
             if template is None:


### PR DESCRIPTION
This PR shoudl fix #1545 

The existing code substituted / for \, assuming this was the right behaviour for windows. But on Windows, Jinja still uses / for the template list - See https://github.com/pallets/jinja/blob/896a62135bcc151f2997e028c5125bec2cb2431f/src/jinja2/loaders.py#L225