### PR TITLE
Use dash encoding for table names and row primary keys in URLs

### DIFF
--- a/datasette/templates/_table.html
+++ b/datasette/templates/_table.html
@@ -4,7 +4,7 @@
         <thead>
             <tr>
                 {% for column in display_columns %}
-                    <th {% if column.description %}data-column-description="{{ column.description }}" {% endif %}class="col-{{ column.name|to_css_class }}" scope="col" data-column="{{ column.name }}" data-column-type="{{ column.type }}" data-column-not-null="{{ column.notnull }}" data-is-pk="{% if column.is_pk %}1{% else %}0{% endif %}">
+                    <th {% if column.description %}data-column-description="{{ column.description }}" {% endif %}class="col-{{ column.name|to_css_class }}" scope="col" data-column="{{ column.name }}" data-column-type="{{ column.type.lower() }}" data-column-not-null="{{ column.notnull }}" data-is-pk="{% if column.is_pk %}1{% else %}0{% endif %}">
                         {% if not column.sortable %}
                             {{ column.name }}
                         {% else %}

--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -1139,3 +1139,15 @@ def add_cors_headers(headers):
     headers["Access-Control-Allow-Origin"] = "*"
     headers["Access-Control-Allow-Headers"] = "Authorization"
     headers["Access-Control-Expose-Headers"] = "Link"
+
+
+@documented
+def dash_encode(s: str) -> str:
+    "Returns dash-encoded string - for example ``/foo/bar`` -> ``-/foo-/bar``"
+    return s.replace("-", "--").replace(".", "-.").replace("/", "-/")
+
+
+@documented
+def dash_decode(s: str) -> str:
+    "Decodes a dash-encoded string, so ``-/foo-/bar`` -> ``/foo/bar``"
+    return s.replace("-/", "/").replace("-.", ".").replace("--", "-")

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -876,6 +876,29 @@ Utility function for calling ``await`` on a return value if it is awaitable, oth
 
 .. autofunction:: datasette.utils.await_me_maybe
 
+.. _internals_dash_encoding:
+
+Dash encoding
+-------------
+
+Datasette uses a custom encoding scheme in some places, called **dash encoding**. This is primarily used for table names and row primary keys, to avoid any confusion between ``/`` characters in those values and the Datasette URL that references them.
+
+Dash encoding applies the following rules, in order:
+
+- All single ``-`` characters are replaced by ``--``
+- ``.`` characters are replaced by ``-.``
+- ``/`` characters are replaced by ``./``
+
+These rules are applied in reverse order to decode a dash encoded string.
+
+.. _internals_utils_dash_encode:
+
+.. autofunction:: datasette.utils.dash_encode
+
+.. _internals_utils_dash_decode:
+
+.. autofunction:: datasette.utils.dash_decode
+
 .. _internals_tracer:
 
 datasette.tracer

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -881,7 +881,7 @@ Utility function for calling ``await`` on a return value if it is awaitable, oth
 Dash encoding
 -------------
 
-Datasette uses a custom encoding scheme in some places, called **dash encoding**. This is primarily used for table names and row primary keys, to avoid any confusion between ``/`` characters in those values and the Datasette URL that references them.
+Datasette uses a custom encoding scheme in some places, called **dash encoding**. This is primarily used for table names and row primary keys, to avoid any confusion between ``/`` characters in those values and the Datasette URL that reference them.
 
 Dash encoding applies the following rules, in order:
 

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -881,7 +881,7 @@ Utility function for calling ``await`` on a return value if it is awaitable, oth
 Dash encoding
 -------------
 
-Datasette uses a custom encoding scheme in some places, called **dash encoding**. This is primarily used for table names and row primary keys, to avoid any confusion between ``/`` characters in those values and the Datasette URL that reference them.
+Datasette uses a custom encoding scheme in some places, called **dash encoding**. This is primarily used for table names and row primary keys, to avoid any confusion between ``/`` characters in those values and the Datasette URLs that reference them.
 
 Dash encoding applies the following rules, in order:
 

--- a/tests/test_internals_database.py
+++ b/tests/test_internals_database.py
@@ -279,7 +279,15 @@ async def test_table_columns(db, table, expected):
 @pytest.mark.asyncio
 async def test_table_column_details(db, table, expected):
     columns = await db.table_column_details(table)
-    assert columns == expected
+    # Convert "type" to lowercase before comparison
+    # https://github.com/simonw/datasette/issues/1647
+    compare_columns = [
+        Column(
+            c.cid, c.name, c.type.lower(), c.notnull, c.default_value, c.is_pk, c.hidden
+        )
+        for c in columns
+    ]
+    assert compare_columns == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -646,3 +646,19 @@ async def test_derive_named_parameters(sql, expected):
     db = ds.get_database("_memory")
     params = await utils.derive_named_parameters(db, sql)
     assert params == expected
+
+
+@pytest.mark.parametrize(
+    "original,expected",
+    (
+        ("abc", "abc"),
+        ("/foo/bar", "-/foo-/bar"),
+        ("/-/bar", "-/---/bar"),
+        ("-/db-/table---.csv-.csv", "---/db---/table-------.csv---.csv"),
+    ),
+)
+def test_dash_encoding(original, expected):
+    actual = utils.dash_encode(original)
+    assert actual == expected
+    # And test round-trip
+    assert original == utils.dash_decode(actual)


### PR DESCRIPTION
Refs #1439.