### PR TITLE
Add /opt/homebrew to where spatialite extension can be found

### DIFF
--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -51,6 +51,7 @@ SPATIALITE_PATHS = (
     "/usr/lib/x86_64-linux-gnu/mod_spatialite.so",
     "/usr/local/lib/mod_spatialite.dylib",
     "/usr/local/lib/mod_spatialite.so",
+    "/opt/homebrew/lib/mod_spatialite.dylib",
 )
 # Used to display /-/versions.json SpatiaLite information
 SPATIALITE_FUNCTIONS = (


### PR DESCRIPTION
Helps homebrew on Apple Silicon setups find spatialite without needing
a full path.

Similar to #1114