### PR TITLE
Add timeout option to Cloudrun build

### DIFF
--- a/datasette/publish/cloudrun.py
+++ b/datasette/publish/cloudrun.py
@@ -42,6 +42,11 @@ def publish_subcommand(publish):
         help="Number of vCPUs to allocate in Cloud Run",
     )
     @click.option(
+        "--timeout",
+        default="1800",
+        help="Build timeout in seconds",
+    )
+    @click.option(
         "--apt-get-install",
         "apt_get_extras",
         multiple=True,
@@ -72,6 +77,7 @@ def publish_subcommand(publish):
         show_files,
         memory,
         cpu,
+        timeout,
         apt_get_extras,
     ):
         "Publish databases to Datasette running on Cloud Run"
@@ -156,7 +162,7 @@ def publish_subcommand(publish):
                 print("\n====================\n")
 
             image_id = f"gcr.io/{project}/{name}"
-            check_call(f"gcloud builds submit --tag {image_id}", shell=True)
+            check_call(f"gcloud builds submit --tag={image_id} --timeout={timeout}", shell=True)
         check_call(
             "gcloud run deploy --allow-unauthenticated --platform=managed --image {} {}{}{}".format(
                 image_id,

--- a/datasette/publish/cloudrun.py
+++ b/datasette/publish/cloudrun.py
@@ -43,7 +43,6 @@ def publish_subcommand(publish):
     )
     @click.option(
         "--timeout",
-        default="1800",
         help="Build timeout in seconds",
     )
     @click.option(
@@ -162,7 +161,12 @@ def publish_subcommand(publish):
                 print("\n====================\n")
 
             image_id = f"gcr.io/{project}/{name}"
-            check_call(f"gcloud builds submit --tag={image_id} --timeout={timeout}", shell=True)
+            check_call(
+                "gcloud builds submit --tag {}{}".format(
+                    image_id, " --timeout {}".format(timeout) if timeout else ""
+                ),
+                shell=True,
+            )
         check_call(
             "gcloud run deploy --allow-unauthenticated --platform=managed --image {} {}{}{}".format(
                 image_id,

--- a/tests/test_publish_cloudrun.py
+++ b/tests/test_publish_cloudrun.py
@@ -105,18 +105,19 @@ def test_publish_cloudrun(mock_call, mock_output, mock_which, tmp_path_factory):
 @mock.patch("datasette.publish.cloudrun.check_output")
 @mock.patch("datasette.publish.cloudrun.check_call")
 @pytest.mark.parametrize(
-    "memory,cpu,expected_gcloud_args",
+    "memory,cpu,timeout,expected_gcloud_args",
     [
-        ["1Gi", None, "--memory 1Gi"],
-        ["2G", None, "--memory 2G"],
-        ["256Mi", None, "--memory 256Mi"],
-        ["4", None, None],
-        ["GB", None, None],
-        [None, 1, "--cpu 1"],
-        [None, 2, "--cpu 2"],
-        [None, 3, None],
-        [None, 4, "--cpu 4"],
-        ["2G", 4, "--memory 2G --cpu 4"],
+        ["1Gi", None, None, "--memory 1Gi"],
+        ["2G", None, None, "--memory 2G"],
+        ["256Mi", None, None, "--memory 256Mi"],
+        ["4", None, None, None],
+        ["GB", None, None, None],
+        [None, 1, None, "--cpu 1"],
+        [None, 2, None, "--cpu 2"],
+        [None, 3, None, None],
+        [None, 4, None, "--cpu 4"],
+        ["2G", 4, None, "--memory 2G --cpu 4"],
+        [None, None, 1800, "--timeout 1800"],
     ],
 )
 def test_publish_cloudrun_memory_cpu(
@@ -125,6 +126,7 @@ def test_publish_cloudrun_memory_cpu(
     mock_which,
     memory,
     cpu,
+    timeout,
     expected_gcloud_args,
     tmp_path_factory,
 ):
@@ -139,6 +141,8 @@ def test_publish_cloudrun_memory_cpu(
         args.extend(["--memory", memory])
     if cpu:
         args.extend(["--cpu", str(cpu)])
+    if timeout:
+        args.extend(["--timeout", str(timeout)])
     result = runner.invoke(cli.cli, args)
     if expected_gcloud_args is None:
         assert 2 == result.exit_code
@@ -149,13 +153,16 @@ def test_publish_cloudrun_memory_cpu(
         "gcloud run deploy --allow-unauthenticated --platform=managed"
         " --image {} test".format(tag)
     )
+    expected_build_call = f"gcloud builds submit --tag {tag}"
     if memory:
         expected_call += " --memory {}".format(memory)
     if cpu:
         expected_call += " --cpu {}".format(cpu)
+    if timeout:
+        expected_build_call += f" --timeout {timeout}"
     mock_call.assert_has_calls(
         [
-            mock.call(f"gcloud builds submit --tag {tag}", shell=True),
+            mock.call(expected_build_call, shell=True),
             mock.call(
                 expected_call,
                 shell=True,


### PR DESCRIPTION
I've found that the Cloudrun build phase often hits a timeout limit with large databases. I believe the default timeout is 10 minutes. This pull request just adds a `--timeout` option to the cloudrun `publish` command and passes the value on to the build step.