### PR TITLE
feat: add a wildcard for _json columns

### DIFF
--- a/datasette/renderer.py
+++ b/datasette/renderer.py
@@ -10,13 +10,13 @@ from datasette.utils.asgi import Response
 
 def convert_specific_columns_to_json(rows, columns, json_cols):
     json_cols = set(json_cols)
-    if not json_cols.intersection(columns):
+    if not json_cols.intersection(columns) and not json_cols == {"*"}:
         return rows
     new_rows = []
     for row in rows:
         new_row = []
         for value, column in zip(row, columns):
-            if column in json_cols:
+            if column in json_cols or (json_cols == {"*"}):
                 try:
                     value = json.loads(value)
                 except (TypeError, ValueError) as e:

--- a/docs/json_api.rst
+++ b/docs/json_api.rst
@@ -190,6 +190,12 @@ query string arguments:
     JSON. Without this argument those columns will be returned as JSON objects
     that have been double-encoded into a JSON string value.
 
+    If you have many columns containing JSON values, you can pass ``_json=*``
+    to attempt converting loading all columns as JSON. This is a best effort
+    approach. Any columns that fail to render as valid JSON will be passed
+    through unaltered, while any column with valid JSON will be converted.
+    There may be a performance impact on large result sets.
+
     Compare `this query without the argument <https://fivethirtyeight.datasettes.com/fivethirtyeight.json?sql=select+%27{%22this+is%22%3A+%22a+json+object%22}%27+as+d&_shape=array>`_ to `this query using the argument <https://fivethirtyeight.datasettes.com/fivethirtyeight.json?sql=select+%27{%22this+is%22%3A+%22a+json+object%22}%27+as+d&_shape=array&_json=d>`_
 
 ``?_json_infinity=on``


### PR DESCRIPTION
This allows _json to accept a wildcard for when there are many JSON columns that the user wants to convert. I hope this is useful. I've tested it on our datasette and haven't ran into any issues. I imagine on a large set of results, there could be some performance issues, but it will probably be negligible for most use cases.

On a side note, I ran into an issue where I had to upgrade black on my system beyond the pinned version in setup.py. Here is the upstream issue <<https://github.com/psf/black/issues/2964> . I didn't include this in the PR yet since I didn't look into the issue too far, but I can if you would like.