### PR TITLE
Keep track of config_dir

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -218,6 +218,7 @@ class Datasette:
         assert config_dir is None or isinstance(
             config_dir, Path
         ), "config_dir= should be a pathlib.Path"
+        self.config_dir = config_dir
         self.pdb = pdb
         self._secret = secret or secrets.token_hex(32)
         self.files = tuple(files or []) + tuple(immutables or [])

--- a/tests/test_config_dir.py
+++ b/tests/test_config_dir.py
@@ -1,4 +1,5 @@
 import json
+import pathlib
 import pytest
 
 from datasette.app import Datasette
@@ -150,3 +151,11 @@ def test_metadata_yaml(tmp_path_factory, filename):
     response = client.get("/-/metadata.json")
     assert 200 == response.status
     assert {"title": "Title from metadata"} == response.json
+
+
+def test_store_config_dir(config_dir_client):
+    ds = config_dir_client.ds
+
+    assert hasattr(ds, "config_dir")
+    assert ds.config_dir is not None
+    assert isinstance(ds.config_dir, pathlib.Path)


### PR DESCRIPTION
Closes #1764 

Small change that adds `self.config_dir = config_dir` to `Datasette.__init__`. This will let plugins also use `config_dir`, if available.