### PR TITLE
fix word break in facets by adding ul.tight-bullets li word-break: break-all

### DIFF
--- a/datasette/static/app.css
+++ b/datasette/static/app.css
@@ -260,6 +260,7 @@ ul.bullets li {
 ul.tight-bullets li {
     list-style-type: disc;
     margin-bottom: 0;
+    word-break: break-all;
 }
 a.not-underlined {
     text-decoration: none;


### PR DESCRIPTION
I noticed that long words break the layout of facets:

![image](https://user-images.githubusercontent.com/128286/187013146-fb2bbb60-a225-441b-ba8e-b9e74fb04f93.png)

So I added CSS to add a line break. This is how the result looks now:

![image](https://user-images.githubusercontent.com/128286/187013175-a706fc72-9e69-4a75-9bdf-bdaa34a0cf51.png)

I don't know enough about facet edge cases to decide if this change might break other things but it looks better for me so maybe this is helpful.

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--1794.org.readthedocs.build/en/1794/

<!-- readthedocs-preview datasette end -->