### PR TITLE
Add documentation for serving via OpenRC

### DIFF
--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -74,6 +74,8 @@ Once the service has started you can confirm that Datasette is running on port 8
     curl 127.0.0.1:8000/-/versions.json
     # Should output JSON showing the installed version
 
+Datasette will not be accessible from outside the server because it is listening on ``127.0.0.1``. You can expose it by instead listening on ``0.0.0.0``, but a better way is to set up a proxy such as ``nginx`` - see :ref:`deploying_proxy`.
+
 .. _deploying_openrc:
 
 Running Datasette using OpenRC

--- a/docs/deploying.rst
+++ b/docs/deploying.rst
@@ -74,18 +74,28 @@ Once the service has started you can confirm that Datasette is running on port 8
     curl 127.0.0.1:8000/-/versions.json
     # Should output JSON showing the installed version
 
-Datasette will not be accessible from outside the server because it is listening on ``127.0.0.1``. You can expose it by instead listening on ``0.0.0.0``, but a better way is to set up a proxy such as ``nginx``.
+.. _deploying_openrc:
 
-Ubuntu offer `a tutorial on installing nginx <https://ubuntu.com/tutorials/install-and-configure-nginx#1-overview>`__. Once it is installed you can add configuration to proxy traffic through to Datasette that looks like this::
+Running Datasette using OpenRC
+===============================
+OpenRC is the service manager on non-systemd Linux distributions like `Alpine Linux <https://www.alpinelinux.org/>`__ and `Gentoo <https://www.gentoo.org/>`__.
 
-    server {
-        server_name mysubdomain.myhost.net;
+Create an init script at ``/etc/init.d/datasette`` with the following contents:
 
-        location / {
-            proxy_pass http://127.0.0.1:8000/;
-            proxy_set_header Host $host;
-        }
-    }
+.. code-block:: sh
+
+    #!/sbin/openrc-run
+
+    name="datasette"
+    command="datasette"
+    command_args="serve -h 0.0.0.0 /path/to/db.db"
+    command_background=true
+    pidfile="/run/${RC_SVCNAME}.pid"
+
+You then need to configure the service to run at boot and start it::
+
+    rc-update add datasette
+    rc-service datasette start
 
 .. _deploying_buildpacks:
 


### PR DESCRIPTION
I also removed a few lines which felt redundant given the following section dedicated to running behind a nginx proxy.

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--1825.org.readthedocs.build/en/1825/

<!-- readthedocs-preview datasette end -->