### PR TITLE
Make hash and size a lazy property

### DIFF
--- a/datasette/database.py
+++ b/datasette/database.py
@@ -39,7 +39,7 @@ class Database:
         self.memory_name = memory_name
         if memory_name is not None:
             self.is_memory = True
-        self.hash = None
+        self.cached_hash = None
         self.cached_size = None
         self._cached_table_counts = None
         self._write_thread = None
@@ -47,14 +47,20 @@ class Database:
         # These are used when in non-threaded mode:
         self._read_connection = None
         self._write_connection = None
-        if not self.is_mutable and not self.is_memory:
-            if self.ds.inspect_data and self.ds.inspect_data.get(self.name):
-                self.hash = self.ds.inspect_data[self.name]["hash"]
-                self.cached_size = self.ds.inspect_data[self.name]["size"]
-            else:
-                p = Path(path)
-                self.hash = inspect_hash(p)
-                self.cached_size = p.stat().st_size
+
+    @property
+    def hash(self):
+        if self.cached_hash is not None:
+            return self.cached_hash
+        elif self.is_mutable or self.is_memory:
+            return None
+        elif self.ds.inspect_data and self.ds.inspect_data.get(self.name):
+            self.cached_hash = self.ds.inspect_data[self.name]["hash"]
+            return self.cached_hash
+        else:
+            p = Path(path)
+            self.cached_hash = inspect_hash(p)
+            return self.cached_hash
 
     @property
     def cached_table_counts(self):
@@ -268,12 +274,18 @@ class Database:
 
     @property
     def size(self):
-        if self.is_memory:
-            return 0
         if self.cached_size is not None:
             return self.cached_size
-        else:
+        elif self.is_memory:
+            return 0
+        elif self.is_mutable:
             return Path(self.path).stat().st_size
+        elif self.ds.inspect_data and self.ds.inspect_data.get(self.name):
+            self.cached_size = self.ds.inspect_data[self.name]["size"]
+            return self.cached_size
+        else:
+            self.cached_size = Path(self.path).stat().st_size
+            return self.cached_size
 
     async def table_counts(self, limit=10):
         if not self.is_mutable and self.cached_table_counts is not None:

--- a/datasette/database.py
+++ b/datasette/database.py
@@ -49,20 +49,6 @@ class Database:
         self._write_connection = None
 
     @property
-    def hash(self):
-        if self.cached_hash is not None:
-            return self.cached_hash
-        elif self.is_mutable or self.is_memory:
-            return None
-        elif self.ds.inspect_data and self.ds.inspect_data.get(self.name):
-            self.cached_hash = self.ds.inspect_data[self.name]["hash"]
-            return self.cached_hash
-        else:
-            p = Path(path)
-            self.cached_hash = inspect_hash(p)
-            return self.cached_hash
-
-    @property
     def cached_table_counts(self):
         if self._cached_table_counts is not None:
             return self._cached_table_counts
@@ -271,6 +257,20 @@ class Database:
         with trace("sql", database=self.name, sql=sql.strip(), params=params):
             results = await self.execute_fn(sql_operation_in_thread)
         return results
+
+    @property
+    def hash(self):
+        if self.cached_hash is not None:
+            return self.cached_hash
+        elif self.is_mutable or self.is_memory:
+            return None
+        elif self.ds.inspect_data and self.ds.inspect_data.get(self.name):
+            self.cached_hash = self.ds.inspect_data[self.name]["hash"]
+            return self.cached_hash
+        else:
+            p = Path(self.path)
+            self.cached_hash = inspect_hash(p)
+            return self.cached_hash
 
     @property
     def size(self):

--- a/datasette/database.py
+++ b/datasette/database.py
@@ -48,9 +48,13 @@ class Database:
         self._read_connection = None
         self._write_connection = None
         if not self.is_mutable and not self.is_memory:
-            p = Path(path)
-            self.hash = inspect_hash(p)
-            self.cached_size = p.stat().st_size
+            if self.ds.inspect_data and self.ds.inspect_data.get(self.name):
+                self.hash = self.ds.inspect_data[self.name]["hash"]
+                self.cached_size = self.ds.inspect_data[self.name]["size"]
+            else:
+                p = Path(path)
+                self.hash = inspect_hash(p)
+                self.cached_size = p.stat().st_size
 
     @property
     def cached_table_counts(self):


### PR DESCRIPTION
Many apologies, @simonw. My previous PR #1835 did not really solve the problem because the name of the database is often not known to database object in the init method.

I took a cue from how you dealt with this issue and made hash a lazy property and did something similar with size.

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--1837.org.readthedocs.build/en/1837/

<!-- readthedocs-preview datasette end -->