### PR TITLE
Open Datasette link in new tab

### DIFF
--- a/datasette/templates/_footer.html
+++ b/datasette/templates/_footer.html
@@ -1,4 +1,4 @@
-Powered by <a href="https://datasette.io/" title="Datasette v{{ datasette_version }}">Datasette</a>
+Powered by <a href="https://datasette.io/" target="_blank" title="Datasette v{{ datasette_version }}">Datasette</a>
 {% if query_ms %}&middot; Queries took {{ query_ms|round(3) }}ms{% endif %}
 {% if metadata %}
     {% if metadata.license or metadata.license_url %}&middot; Data license:


### PR DESCRIPTION
This is technically a Sandstorm-specific fix (as external links do not work inside the grain frame), however, I think it is an improvement to the upstream project, so I wanted to propose it here rather than patching it in our package.

There's much opinions on the Internet about whether external links should open in a new tab by default or not, but I'd argue very few people who might click a "powered by" link intend to complete their interaction with the source page (a Datasette). And furthermore, users may be working within various queries or loading visualizations (navigating away when trying to plot a million GPS coordinates pretty much just resets your progress!), so linking away within the tab might be a frustrating or destructive act to one's work, even inadvertently.

original report: https://github.com/ocdtrekkie/datasette-sandstorm/issues/1

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--1838.org.readthedocs.build/en/1838/

<!-- readthedocs-preview datasette end -->