### PR TITLE
check_visibility can now take multiple permissions into account

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -736,7 +736,7 @@ class Datasette:
         self,
         actor: dict,
         action: Optional[str] = None,
-        resource: Optional[str] = None,
+        resource: Optional[Union[str, Tuple[str, str]]] = None,
         permissions: Optional[
             Sequence[Union[Tuple[str, Union[str, Tuple[str, str]]], str]]
         ] = None,

--- a/datasette/app.py
+++ b/datasette/app.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Sequence, Union, Tuple
+from typing import Sequence, Union, Tuple, Optional
 import asgi_csrf
 import collections
 import datetime
@@ -707,7 +707,7 @@ class Datasette:
 
         Raises datasette.Forbidden() if any of the checks fail
         """
-        assert actor is None or isinstance(actor, dict)
+        assert actor is None or isinstance(actor, dict), "actor must be None or a dict"
         for permission in permissions:
             if isinstance(permission, str):
                 action = permission
@@ -732,23 +732,34 @@ class Datasette:
                 else:
                     raise Forbidden(action)
 
-    async def check_visibility(self, actor, action, resource):
+    async def check_visibility(
+        self,
+        actor: dict,
+        action: Optional[str] = None,
+        resource: Optional[str] = None,
+        permissions: Optional[
+            Sequence[Union[Tuple[str, Union[str, Tuple[str, str]]], str]]
+        ] = None,
+    ):
         """Returns (visible, private) - visible = can you see it, private = can others see it too"""
-        visible = await self.permission_allowed(
-            actor,
-            action,
-            resource=resource,
-            default=True,
-        )
-        if not visible:
+        if permissions:
+            assert (
+                not action and not resource
+            ), "Can't use action= or resource= with permissions="
+        else:
+            permissions = [(action, resource)]
+        try:
+            await self.ensure_permissions(actor, permissions)
+        except Forbidden:
             return False, False
-        private = not await self.permission_allowed(
-            None,
-            action,
-            resource=resource,
-            default=True,
-        )
-        return visible, private
+        # User can see it, but can the anonymous user see it?
+        try:
+            await self.ensure_permissions(None, permissions)
+        except Forbidden:
+            # It's visible but private
+            return True, True
+        # It's visible to everyone
+        return True, False
 
     async def execute(
         self,

--- a/datasette/templates/row.html
+++ b/datasette/templates/row.html
@@ -20,7 +20,7 @@
 {% endblock %}
 
 {% block content %}
-<h1 style="padding-left: 10px; border-left: 10px solid #{{ database_color(database) }}">{{ table }}: {{ ', '.join(primary_key_values) }}</h1>
+<h1 style="padding-left: 10px; border-left: 10px solid #{{ database_color(database) }}">{{ table }}: {{ ', '.join(primary_key_values) }}{% if private %} 🔒{% endif %}</h1>
 
 {% block description_source_license %}{% include "_description_source_license.html" %}{% endblock %}
 

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -50,13 +50,6 @@ class DatabaseView(DataView):
         if not visible:
             raise Forbidden("You do not have permission to view this database")
 
-        await self.ds.ensure_permissions(
-            request.actor,
-            [
-                ("view-database", database),
-                "view-instance",
-            ],
-        )
         metadata = (self.ds.metadata("databases") or {}).get(database, {})
         self.ds.update_with_inherited_metadata(metadata)
 

--- a/datasette/views/index.py
+++ b/datasette/views/index.py
@@ -23,25 +23,25 @@ class IndexView(BaseView):
         await self.ds.ensure_permissions(request.actor, ["view-instance"])
         databases = []
         for name, db in self.ds.databases.items():
-            visible, database_private = await self.ds.check_visibility(
+            database_visible, database_private = await self.ds.check_visibility(
                 request.actor,
                 "view-database",
                 name,
             )
-            if not visible:
+            if not database_visible:
                 continue
             table_names = await db.table_names()
             hidden_table_names = set(await db.hidden_table_names())
 
             views = []
             for view_name in await db.view_names():
-                visible, private = await self.ds.check_visibility(
+                view_visible, view_private = await self.ds.check_visibility(
                     request.actor,
                     "view-table",
                     (name, view_name),
                 )
-                if visible:
-                    views.append({"name": view_name, "private": private})
+                if view_visible:
+                    views.append({"name": view_name, "private": view_private})
 
             # Perform counts only for immutable or DBS with <= COUNT_TABLE_LIMIT tables
             table_counts = {}

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -390,7 +390,9 @@ This example checks if the user can access a specific table, and sets ``private`
 .. code-block:: python
 
     visible, private = await self.ds.check_visibility(
-        request.actor, action="view-table", resource=(database, table)
+        request.actor,
+        action="view-table",
+        resource=(database, table),
     )
 
 The following example runs three checks in a row, similar to :ref:`datasette_ensure_permissions`. If any of the checks are denied before one of them is explicitly granted then ``visible`` will be ``False``. ``private`` will be ``True`` if an anonymous user would not be able to view the resource.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -163,6 +163,9 @@ def make_app_client(
             crossdb=crossdb,
         )
         yield TestClient(ds)
+        # Close the connection to avoid "too many open files" errors
+        conn.close()
+        os.remove(filepath)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -21,19 +21,20 @@ def test_view_instance(allow, expected_anon, expected_auth):
             "/fixtures/compound_three_primary_keys",
             "/fixtures/compound_three_primary_keys/a,a,a",
         ):
+            fragment = "🔒</h1>"
             anon_response = client.get(path)
             assert expected_anon == anon_response.status
-            if allow and path == "/" and anon_response.status == 200:
+            if allow and anon_response.status == 200:
                 # Should be no padlock
-                assert "<h1>Datasette 🔒</h1>" not in anon_response.text
+                assert fragment not in anon_response.text
             auth_response = client.get(
                 path,
                 cookies={"ds_actor": client.actor_cookie({"id": "root"})},
             )
             assert expected_auth == auth_response.status
             # Check for the padlock
-            if allow and path == "/" and expected_anon == 403 and expected_auth == 200:
-                assert "<h1>Datasette 🔒</h1>" in auth_response.text
+            if allow and expected_anon == 403 and expected_auth == 200:
+                assert fragment in auth_response.text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -482,11 +482,15 @@ def test_permissions_cascade(cascade_app_client, path, permissions, expected_sta
         updated_metadata["databases"]["fixtures"]["queries"]["magic_parameters"][
             "allow"
         ] = (allow if "query" in permissions else deny)
-        cascade_app_client.ds._local_metadata = updated_metadata
+        cascade_app_client.ds._metadata_local = updated_metadata
         response = cascade_app_client.get(
             path,
             cookies={"ds_actor": cascade_app_client.actor_cookie(actor)},
         )
-        assert expected_status == response.status
+        assert (
+            response.status == expected_status
+        ), "path: {}, permissions: {}, expected_status: {}, status: {}".format(
+            path, permissions, expected_status, response.status
+        )
     finally:
         cascade_app_client.ds._local_metadata = previous_metadata

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -823,8 +823,14 @@ def test_hook_forbidden(restore_working_directory):
         assert 403 == response.status
         response2 = client.get("/data2")
         assert 302 == response2.status
-        assert "/login?message=view-database" == response2.headers["Location"]
-        assert "view-database" == client.ds._last_forbidden_message
+        assert (
+            response2.headers["Location"]
+            == "/login?message=You do not have permission to view this database"
+        )
+        assert (
+            client.ds._last_forbidden_message
+            == "You do not have permission to view this database"
+        )
 
 
 def test_hook_handle_exception(app_client):


### PR DESCRIPTION
Refs #1829

- [x] Fix table page
- [x] Fix database page
- [x] Fix query page
- [x] Fix row page
- [x] Tests
- [x] Updated documentation for `check_visibility` method, to cover the new `permissions=` keyword argument

Also this fix is currently only applied on the table page - needs to be applied on database, row and query pages too.

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--1842.org.readthedocs.build/en/1842/

<!-- readthedocs-preview datasette end -->