### PR TITLE
don't use immutable=1, only mode=ro

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -603,7 +603,7 @@ class Datasette:
                     continue
                 sql = 'ATTACH DATABASE "file:{path}?{qs}" AS [{name}];'.format(
                     path=db.path,
-                    qs="mode=ro" if db.is_mutable else "immutable=1",
+                    qs="mode=ro",
                     name=db_name,
                 )
                 conn.execute(sql)

--- a/datasette/database.py
+++ b/datasette/database.py
@@ -81,13 +81,9 @@ class Database:
             return conn
         if self.is_memory:
             return sqlite3.connect(":memory:", uri=True)
-        # mode=ro or immutable=1?
-        if self.is_mutable:
-            qs = "?mode=ro"
-            if self.ds.nolock:
-                qs += "&nolock=1"
-        else:
-            qs = "?immutable=1"
+        qs = "?mode=ro"
+        if self.ds.nolock:
+            qs += "&nolock=1"
         assert not (write and not self.is_mutable)
         if write:
             qs = ""


### PR DESCRIPTION
Opening db files in immutable mode sometimes leads to the file being mutated, which causes duplication in the docker image layers: see #1836, #1480

That this happens in "immutable" mode is surprising, because the sqlite docs say that setting this should open the database as read only. 

https://www.sqlite.org/c3ref/open.html

> immutable: The immutable parameter is a boolean query parameter that indicates that the database file is stored on read-only media. When immutable is set, SQLite assumes that the database file cannot be changed, even by a process with higher privilege, and so the database is opened read-only and all locking and change detection is disabled. Caution: Setting the immutable property on a database file that does in fact change can result in incorrect query results and/or [SQLITE_CORRUPT](https://www.sqlite.org/rescode.html#corrupt) errors. See also: [SQLITE_IOCAP_IMMUTABLE](https://www.sqlite.org/c3ref/c_iocap_atomic.html).

Perhaps this is a bug in sqlite?



<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--1870.org.readthedocs.build/en/1870/

<!-- readthedocs-preview datasette end -->