### PR TITLE
Use DOMContentLoaded instead of load event for CodeMirror initialization

### DIFF
--- a/datasette/templates/_codemirror_foot.html
+++ b/datasette/templates/_codemirror_foot.html
@@ -80,7 +80,7 @@
     units: ["distance", "frequency", "pk"],
   };
 
-  window.onload = () => {
+  window.addEventListener("DOMContentLoaded", () => {
     const sqlFormat = document.querySelector("button#sql-format");
     const readOnly = document.querySelector("pre#sql-query");
     const sqlInput = document.querySelector("textarea#sql-editor");
@@ -113,5 +113,5 @@
         });
       }
     }
-  };
+  });
 </script>


### PR DESCRIPTION
 Closes #1894

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--1898.org.readthedocs.build/en/1898/

<!-- readthedocs-preview datasette end -->