### PR TITLE
/db/table/-/upsert

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -40,7 +40,7 @@ from .views.special import (
     PermissionsDebugView,
     MessagesDebugView,
 )
-from .views.table import TableView, TableInsertView, TableDropView
+from .views.table import TableView, TableInsertView, TableUpsertView, TableDropView
 from .views.row import RowView, RowDeleteView, RowUpdateView
 from .renderer import json_renderer
 from .url_builder import Urls
@@ -1291,6 +1291,10 @@ class Datasette:
         add_route(
             TableInsertView.as_view(self),
             r"/(?P<database>[^\/\.]+)/(?P<table>[^\/\.]+)/-/insert$",
+        )
+        add_route(
+            TableUpsertView.as_view(self),
+            r"/(?P<database>[^\/\.]+)/(?P<table>[^\/\.]+)/-/upsert$",
         )
         add_route(
             TableDropView.as_view(self),

--- a/datasette/default_permissions.py
+++ b/datasette/default_permissions.py
@@ -85,7 +85,7 @@ def permission_allowed_actor_restrictions(actor, action, resource):
             if action_initials in database_allowed:
                 return None
     # Or the current table? That's any time the resource is (database, table)
-    if not isinstance(resource, str) and len(resource) == 2:
+    if resource is not None and not isinstance(resource, str) and len(resource) == 2:
         database, table = resource
         table_allowed = _r.get("t", {}).get(database, {}).get(table)
         # TODO: What should this do for canned queries?
@@ -138,6 +138,8 @@ def actor_from_request(datasette, request):
             # Expired
             return None
     actor = {"id": decoded["a"], "token": "dstok"}
+    if "_r" in decoded:
+        actor["_r"] = decoded["_r"]
     if duration:
         actor["token_expires"] = created + duration
     return actor

--- a/datasette/views/special.py
+++ b/datasette/views/special.py
@@ -316,21 +316,37 @@ class ApiExplorerView(BaseView):
                     request.actor, "insert-row", (name, table)
                 ):
                     pks = await db.primary_keys(table)
-                    table_links.append(
-                        {
-                            "path": self.ds.urls.table(name, table) + "/-/insert",
-                            "method": "POST",
-                            "label": "Insert rows into {}".format(table),
-                            "json": {
-                                "rows": [
-                                    {
-                                        column: None
-                                        for column in await db.table_columns(table)
-                                        if column not in pks
-                                    }
-                                ]
+                    table_links.extend(
+                        [
+                            {
+                                "path": self.ds.urls.table(name, table) + "/-/insert",
+                                "method": "POST",
+                                "label": "Insert rows into {}".format(table),
+                                "json": {
+                                    "rows": [
+                                        {
+                                            column: None
+                                            for column in await db.table_columns(table)
+                                            if column not in pks
+                                        }
+                                    ]
+                                },
                             },
-                        }
+                            {
+                                "path": self.ds.urls.table(name, table) + "/-/upsert",
+                                "method": "POST",
+                                "label": "Upsert rows into {}".format(table),
+                                "json": {
+                                    "rows": [
+                                        {
+                                            column: None
+                                            for column in await db.table_columns(table)
+                                            if column not in pks
+                                        }
+                                    ]
+                                },
+                            },
+                        ]
                     )
                 if await self.ds.permission_allowed(
                     request.actor, "drop-table", (name, table)

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -1083,6 +1083,9 @@ class TableInsertView(BaseView):
         else:
             pks_list = list(pks)
 
+        if not pks_list:
+            pks_list = ["rowid"]
+
         def _errors(errors):
             return None, errors, {}
 
@@ -1140,6 +1143,8 @@ class TableInsertView(BaseView):
 
         # Validate columns of each row
         columns = set(await db.table_columns(table_name))
+        columns.update(pks_list)
+
         for i, row in enumerate(rows):
             if upsert:
                 # It MUST have the primary key
@@ -1218,7 +1223,7 @@ class TableInsertView(BaseView):
             table = sqlite_utils.Database(conn)[table_name]
             kwargs = {}
             if upsert:
-                kwargs["pk"] = pks[0] if len(pks) == 1 else pks
+                kwargs["pk"] = (pks[0] if len(pks) == 1 else pks) or "rowid"
             else:
                 kwargs = {"ignore": ignore, "replace": replace}
             if should_return:

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -1224,7 +1224,7 @@ class TableInsertView(BaseView):
 
         should_return = bool(extras.get("return", False))
         row_pk_values_for_later = []
-        if should_return:
+        if should_return and upsert:
             row_pk_values_for_later = [tuple(row[pk] for pk in pks) for row in rows]
 
         def insert_or_upsert_rows(conn):

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -1193,6 +1193,9 @@ class TableInsertView(BaseView):
         ignore = extras.get("ignore")
         replace = extras.get("replace")
 
+        if upsert and (ignore or replace):
+            return _error(["Upsert does not support ignore or replace"], 400)
+
         should_return = bool(extras.get("return", False))
 
         def insert_or_upsert_rows(conn):

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -1179,6 +1179,8 @@ class TableInsertView(BaseView):
             request.actor, "insert-row", resource=(database_name, table_name)
         ):
             return _error(["Permission denied"], 403)
+        if not db.is_mutable:
+            return _error(["Database is immutable"], 403)
 
         pks = await db.primary_keys(table_name)
 

--- a/docs/json_api.rst
+++ b/docs/json_api.rst
@@ -527,7 +527,7 @@ To insert multiple rows at a time, use the same API method but send a list of di
         ]
     }
 
-If successful, this will return a ``201`` status code and an empty ``{}`` response body.
+If successful, this will return a ``201`` status code and a ``{"ok": true}`` response body.
 
 To return the newly inserted rows, add the ``"return": true`` key to the request body:
 

--- a/docs/json_api.rst
+++ b/docs/json_api.rst
@@ -615,7 +615,7 @@ The upsert API is mostly the same shape as the :ref:`insert API <TableInsertView
                 "title": "Item 3",
                 "description": "Description for 3"
             }
-        }
+        ]
     }
 
 Imagine a table with a primary key of ``id`` and which already has rows with ``id`` values of ``1`` and ``2``.

--- a/docs/json_api.rst
+++ b/docs/json_api.rst
@@ -582,6 +582,116 @@ Pass ``"ignore": true`` to ignore these errors and insert the other rows:
 
 Or you can pass ``"replace": true`` to replace any rows with conflicting primary keys with the new values.
 
+.. _TableUpsertView:
+
+Upserting rows
+~~~~~~~~~~~~~~
+
+An upsert is an insert or update operation. If a row with a matching primary key already exists it will be updated - otherwise a new row will be inserted.
+
+The upsert API is mostly the same shape as the :ref:`insert API <TableInsertView>`. It requires both the :ref:`permissions_insert_row` and :ref:`permissions_update_row` permissions.
+
+::
+
+    POST /<database>/<table>/-/upsert
+    Content-Type: application/json
+    Authorization: Bearer dstok_<rest-of-token>
+
+.. code-block:: json
+
+    {
+        "rows": [
+            {
+                "id": 1,
+                "title": "Updated title for 1",
+                "description": "Updated description for 1"
+            },
+            {
+                "id": 2,
+                "description": "Updated description for 2",
+            },
+            {
+                "id": 3,
+                "title": "Item 3",
+                "description": "Description for 3"
+            }
+        }
+    }
+
+Imagine a table with a primary key of ``id`` and which already has rows with ``id`` values of ``1`` and ``2``.
+
+The above example will:
+
+- Update the row with ``id`` of ``1`` to set both ``title`` and ``description`` to the new values
+- Update the row with ``id`` of ``2`` to set ``title`` to the new value - ``description`` will be left unchanged
+- Insert a new row with ``id`` of ``3`` and both ``title`` and ``description`` set to the new values
+
+Similar to ``/-/insert``, a ``row`` key with an object can be used instead of a ``rows`` array to upsert a single row.
+
+If successful, this will return a ``200`` status code and a ``{"ok": true}`` response body.
+
+Add ``"return": true`` to the request body to return full copies of the affected rows after they have been inserted or updated:
+
+.. code-block:: json
+
+    {
+        "rows": [
+            {
+                "id": 1,
+                "title": "Updated title for 1",
+                "description": "Updated description for 1"
+            },
+            {
+                "id": 2,
+                "description": "Updated description for 2",
+            },
+            {
+                "id": 3,
+                "title": "Item 3",
+                "description": "Description for 3"
+            }
+        ],
+        "return": true
+    }
+
+This will return the following:
+
+.. code-block:: json
+
+    {
+        "ok": true,
+        "rows": [
+            {
+                "id": 1,
+                "title": "Updated title for 1",
+                "description": "Updated description for 1"
+            },
+            {
+                "id": 2,
+                "title": "Item 2",
+                "description": "Updated description for 2"
+            },
+            {
+                "id": 3,
+                "title": "Item 3",
+                "description": "Description for 3"
+            }
+        ]
+    }
+
+When using upsert you must provide the primary key column (or columns if the table has a compound primary key) for every row, or you will get a ``400`` error:
+
+.. code-block:: json
+
+    {
+        "ok": false,
+        "errors": [
+            "Row 0 is missing primary key column(s): \"id\""
+        ]
+    }
+
+If your table does not have an explicit primary key you should pass the SQLite ``rowid`` key instead.
+
 .. _RowUpdateView:
 
 Updating a row

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -30,7 +30,7 @@ def write_token(ds, actor_id="root"):
 
 
 @pytest.mark.asyncio
-async def test_write_row(ds_write):
+async def test_insert_row(ds_write):
     token = write_token(ds_write)
     response = await ds_write.client.post(
         "/data/docs/-/insert",
@@ -50,7 +50,7 @@ async def test_write_row(ds_write):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("return_rows", (True, False))
-async def test_write_rows(ds_write, return_rows):
+async def test_insert_rows(ds_write, return_rows):
     token = write_token(ds_write)
     data = {
         "rows": [
@@ -208,7 +208,7 @@ async def test_write_rows(ds_write, return_rows):
         ),
     ),
 )
-async def test_write_row_errors(
+async def test_insert_row_errors(
     ds_write, path, input, special_case, expected_status, expected_errors
 ):
     token = write_token(ds_write)

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -407,7 +407,7 @@ async def test_insert_ignore_replace(
         ),
     ),
 )
-@pytest.mark.parametrize("should_return", (False,))
+@pytest.mark.parametrize("should_return", (False, True))
 async def test_upsert(ds_write, initial, input, expected_rows, should_return):
     token = write_token(ds_write)
     # Insert initial data
@@ -434,7 +434,9 @@ async def test_upsert(ds_write, initial, input, expected_rows, should_return):
     assert response.status_code == 200
     assert response.json()["ok"] is True
     if should_return:
-        assert response.json()["rows"] == expected_rows
+        # We only expect it to return rows corresponding to those we sent
+        expected_returned_rows = expected_rows[: len(input["rows"])]
+        assert response.json()["rows"] == expected_returned_rows
     # Check the database too
     actual_rows = (
         await ds_write.client.get("/data/upsert_test.json?_shape=array")

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -42,6 +42,7 @@ async def test_write_row(ds_write):
     )
     expected_row = {"id": 1, "title": "Test", "score": 1.2, "age": 5}
     assert response.status_code == 201
+    assert response.json()["ok"] is True
     assert response.json()["rows"] == [expected_row]
     rows = (await ds_write.get_database("data").execute("select * from docs")).rows
     assert dict(rows[0]) == expected_row

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -195,6 +195,13 @@ async def test_insert_rows(ds_write, return_rows):
             400,
             ['Invalid parameter: "one", "two"'],
         ),
+        (
+            "/immutable/docs/-/insert",
+            {"rows": [{"title": "Test"}]},
+            None,
+            403,
+            ['Database is immutable'],
+        ),
         # Validate columns of each row
         (
             "/data/docs/-/insert",

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -200,7 +200,7 @@ async def test_insert_rows(ds_write, return_rows):
             {"rows": [{"title": "Test"}]},
             None,
             403,
-            ['Database is immutable'],
+            ["Database is immutable"],
         ),
         # Validate columns of each row
         (
@@ -213,9 +213,40 @@ async def test_insert_rows(ds_write, return_rows):
                 "Row 1 has invalid columns: bad, worse",
             ],
         ),
+        ## UPSERT ERRORS:
+        (
+            "/immutable/docs/-/upsert",
+            {"rows": [{"title": "Test"}]},
+            None,
+            403,
+            ["Database is immutable"],
+        ),
+        (
+            "/data/badtable/-/upsert",
+            {"rows": [{"title": "Test"}]},
+            None,
+            404,
+            ["Table not found: badtable"],
+        ),
+        # missing primary key
+        (
+            "/data/docs/-/upsert",
+            {"rows": [{"title": "Missing PK"}]},
+            None,
+            400,
+            ['Row 0 is missing primary key column(s): "id"'],
+        ),
+        # Upsert does not support ignore or replace
+        (
+            "/data/docs/-/upsert",
+            {"rows": [{"id": 1, "title": "Bad"}], "ignore": True},
+            None,
+            400,
+            ["Upsert does not support ignore or replace"],
+        ),
     ),
 )
-async def test_insert_row_errors(
+async def test_insert_or_upsert_row_errors(
     ds_write, path, input, special_case, expected_status, expected_errors
 ):
     token = write_token(ds_write)


### PR DESCRIPTION
Refs #1878

Still todo:
- [x] Support `"return": true` properly for upserts (with tests)
- [x] Require both `insert-row` and `update-row` permissions
- [x] Tests are going to need to cover both rowid-only and compound primary key tables, including all of the error states
- [x] Documentation

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--1931.org.readthedocs.build/en/1931/

<!-- readthedocs-preview datasette end -->