### PR TITLE
Use click.echo() instead of print() for --root option

### DIFF
--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -618,7 +618,7 @@ def serve(
         url = "http://{}:{}{}?token={}".format(
             host, port, ds.urls.path("-/auth-token"), ds._root_token
         )
-        print(url)
+        click.echo(url)
     if open_browser:
         if url is None:
             # Figure out most convenient URL - to table, database or homepage


### PR DESCRIPTION
This ensures the URL is output correctly when running under Docker.

Closes #1958

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--1961.org.readthedocs.build/en/1961/

<!-- readthedocs-preview datasette end -->