### PR TITLE
array facet: don't materialize unnecessary columns

### DIFF
--- a/datasette/facets.py
+++ b/datasette/facets.py
@@ -380,23 +380,17 @@ class ArrayFacet(Facet):
             # https://github.com/simonw/datasette/issues/448
             facet_sql = """
                 with inner as ({sql}),
-                deduped_array_items as (
-                    select
-                        distinct j.value,
-                        inner.{col}
-                    from
-                        json_each([inner].{col}) j
-                        join inner
-                )
+                with_ids as (select row_number() over () as row_number, {col} as array from inner),
+                array_items as (select row_number, each.value from json_each(with_ids.array) each, with_ids)
                 select
                     value as value,
-                    count(*) as count
+                    count(distinct row_number) as count
                 from
-                    deduped_array_items
+                    array_items
                 group by
                     value
                 order by
-                    count(*) desc, value limit {limit}
+                    count(distinct row_number) desc, value limit {limit}
             """.format(
                 col=escape_sqlite(column), sql=self.sql, limit=facet_size + 1
             )

--- a/datasette/facets.py
+++ b/datasette/facets.py
@@ -383,7 +383,7 @@ class ArrayFacet(Facet):
                 deduped_array_items as (
                     select
                         distinct j.value,
-                        inner.*
+                        inner.{col}
                     from
                         json_each([inner].{col}) j
                         join inner

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -408,21 +408,33 @@ async def test_array_facet_results(ds_client):
 async def test_array_facet_handle_duplicate_tags():
     ds = Datasette([], memory=True)
     db = ds.add_database(Database(ds, memory_name="test_array_facet"))
-    await db.execute_write("create table otters(name text, tags text)")
-    for name, tags in (
-        ("Charles", ["friendly", "cunning", "friendly"]),
-        ("Shaun", ["cunning", "empathetic", "friendly"]),
-        ("Tracy", ["empathetic", "eager"]),
+    await db.execute_write("create table otters(tags text)")
+    for tags in (
+        ["friendly", "cunning", "friendly"],
+        ["cunning", "empathetic", "friendly"],
+        ["empathetic", "eager"],
+        ["placid"],
+        ["placid"],
+        ["placid"],
     ):
         await db.execute_write(
-            "insert into otters (name, tags) values (?, ?)", [name, json.dumps(tags)]
+            "insert into otters (tags) values (?)", [json.dumps(tags)]
         )
 
     response = await ds.client.get("/test_array_facet/otters.json?_facet_array=tags")
+
+    print(response.json()["facet_results"]["tags"])
     assert response.json()["facet_results"]["tags"] == {
         "name": "tags",
         "type": "array",
         "results": [
+            {
+                "value": "placid",
+                "label": "placid",
+                "count": 3,
+                "toggle_url": "http://localhost/test_array_facet/otters.json?_facet_array=tags&tags__arraycontains=placid",
+                "selected": False,
+            },
             {
                 "value": "cunning",
                 "label": "cunning",


### PR DESCRIPTION
The presence of `inner.*` causes SQLite to materialize a row with all the columns. Those columns will be discarded later.

Instead, we can select only the column we'll use. This lets SQLite's optimizer realize that the other columns in the CTE definition aren't needed.

On a test table with 278K rows, 98K of which had an array, this speeds up the facet calculation from 4 sec to 1 sec.

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--2008.org.readthedocs.build/en/2008/

<!-- readthedocs-preview datasette end -->