### PR TITLE
add Python 3.11 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
         "Intended Audience :: End Users/Desktop",
         "Topic :: Database",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Python 3.11 is tested in CI and is used in the docker image, so add the Python 3.11 Trove classifier.

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--2028.org.readthedocs.build/en/2028/

<!-- readthedocs-preview datasette end -->