### PR TITLE
Expand foreign key references in row view as well

### DIFF
--- a/datasette/views/row.py
+++ b/datasette/views/row.py
@@ -12,7 +12,7 @@ from datasette.utils import (
 from datasette.plugins import pm
 import json
 import sqlite_utils
-from .table import display_columns_and_rows, _get_extras
+from .table import display_columns_and_rows, expand_labels, _get_extras
 
 
 class RowView(DataView):
@@ -41,6 +41,11 @@ class RowView(DataView):
         rows = list(results.rows)
         if not rows:
             raise NotFound(f"Record not found: {pk_values}")
+
+        # Expand labeled columns if requested
+        rows, _ = await expand_labels(
+            self.ds, db, request, table, columns, rows, default_labels
+        )
 
         async def template_data():
             display_columns, display_rows = await display_columns_and_rows(

--- a/tests/test_table_html.py
+++ b/tests/test_table_html.py
@@ -630,6 +630,38 @@ async def test_table_html_foreign_key_links(ds_client):
 
 
 @pytest.mark.asyncio
+async def test_row_html_foreign_key_links(ds_client):
+    response = await ds_client.get("/fixtures/foreign_key_references/1")
+    assert response.status_code == 200
+    table = Soup(response.text, "html.parser").find("table")
+    actual = [[str(td) for td in tr.select("td")] for tr in table.select("tbody tr")]
+    assert actual == [
+        [
+            '<td class="col-pk type-str">1</td>',
+            '<td class="col-foreign_key_with_label type-int"><a href="/fixtures/simple_primary_key/1">hello</a>\xa0<em>1</em></td>',
+            '<td class="col-foreign_key_with_blank_label type-int"><a href="/fixtures/simple_primary_key/3">-</a>\xa0<em>3</em></td>',
+            '<td class="col-foreign_key_with_no_label type-str"><a href="/fixtures/primary_key_multiple_columns/1">1</a></td>',
+            '<td class="col-foreign_key_compound_pk1 type-str">a</td>',
+            '<td class="col-foreign_key_compound_pk2 type-str">b</td>',
+        ],
+    ]
+    response = await ds_client.get("/fixtures/foreign_key_references/2")
+    assert response.status_code == 200
+    table = Soup(response.text, "html.parser").find("table")
+    actual = [[str(td) for td in tr.select("td")] for tr in table.select("tbody tr")]
+    assert actual == [
+        [
+            '<td class="col-pk type-str">2</td>',
+            '<td class="col-foreign_key_with_label type-none">\xa0</td>',
+            '<td class="col-foreign_key_with_blank_label type-none">\xa0</td>',
+            '<td class="col-foreign_key_with_no_label type-none">\xa0</td>',
+            '<td class="col-foreign_key_compound_pk1 type-none">\xa0</td>',
+            '<td class="col-foreign_key_compound_pk2 type-none">\xa0</td>',
+        ],
+    ]
+
+
+@pytest.mark.asyncio
 async def test_table_html_foreign_key_facets(ds_client):
     response = await ds_client.get(
         "/fixtures/foreign_key_references?_facet=foreign_key_with_blank_label"


### PR DESCRIPTION
Unlike the table view, the single row view does not resolve foreign key references into labels. This patch extracts the foreign key reference expansion code from TableView.data() into a standalone function that is then called by both TableView.data() and RowView.data().

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--2031.org.readthedocs.build/en/2031/

<!-- readthedocs-preview datasette end -->