### PR TITLE
remove an unused `app` var in cli.py

### DIFF
--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -180,7 +180,6 @@ def inspect(files, inspect_file, sqlite_extensions):
     This can then be passed to "datasette --inspect-file" to speed up count
     operations against immutable database files.
     """
-    app = Datasette([], immutables=files, sqlite_extensions=sqlite_extensions)
     loop = asyncio.get_event_loop()
     inspect_data = loop.run_until_complete(inspect_(files, sqlite_extensions))
     if inspect_file == "-":


### PR DESCRIPTION
this var `app` isn't actually used? unless init it does some side-effect outside of the event loop, idon't think it's necessary. 

Feel free to ignore this PR if the deleted line actually does something.

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--2034.org.readthedocs.build/en/2034/

<!-- readthedocs-preview datasette end -->