### PR TITLE
GitHub Action to lint Python code with ruff

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repo
-      uses: actions/checkout@v2
-    - uses: actions/cache@v2
+      uses: actions/checkout@v3
+    - uses: actions/cache@v3
       name: Configure npm caching
       with:
         path: ~/.npm

--- a/.github/workflows/push_docker_tag.yml
+++ b/.github/workflows/push_docker_tag.yml
@@ -13,7 +13,7 @@ jobs:
   deploy_docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build and push to Docker Hub
       env:
         DOCKER_USER: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,15 @@
+# https://beta.ruff.rs
+name: ruff
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user ruff
+    - run: ruff --exclude=tests/ --ignore=E713,F401,F522,F811,F841 --format=github --line-length=145 --target-version=py37 .
+    - run: ruff --ignore=E711,E712,E713,E741,F401,F522,F811,F841 --format=github --line-length=252 --target-version=py37 .

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -13,3 +13,19 @@ jobs:
     - run: pip install --user ruff
     - run: ruff --exclude=tests/ --ignore=E713,F401,F522,F811,F841 --format=github --line-length=145 --target-version=py37 .
     - run: ruff --ignore=E711,E712,E713,E741,F401,F522,F811,F841 --format=github --line-length=252 --target-version=py37 .
+  ruff_with_cache:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    # Read self to find an exactly pinned dependency (ruff==x.y.z) and then echo if we got a cache hit
+    # https://github.com/actions/setup-python#caching-packages-dependencies
+    - uses: actions/setup-python@v4
+      id: python_with_cache
+      with:
+        python-version: 3.x
+        cache: pip
+        cache-dependency-path: .github/workflows/ruff.yml
+    - run: echo 'cache-hit = ${{ steps.python_with_cache.outputs.cache-hit }}' # true if cache-hit occured on pip
+    - run: pip install --user ruff==0.0.261
+    - run: ruff --exclude=tests/ --ignore=E713,F401,F522,F811,F841 --format=github --line-length=145 --target-version=py37 .
+    - run: ruff --ignore=E711,E712,E713,E741,F401,F522,F811,F841 --format=github --line-length=252 --target-version=py37 .

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -9,12 +9,12 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       name: Configure pip caching
       with:
         path: ~/.cache/pip

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out datasette
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - uses: actions/cache@v2

--- a/.github/workflows/test-pyodide.yml
+++ b/.github/workflows/test-pyodide.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
         cache: 'pip'
         cache-dependency-path: '**/setup.py'
     - name: Cache Playwright browsers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/ms-playwright/
         key: ${{ runner.os }}-browsers

--- a/.github/workflows/tmate-mac.yml
+++ b/.github/workflows/tmate-mac.yml
@@ -10,6 +10,6 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/tmate.yml
+++ b/.github/workflows/tmate.yml
@@ -10,6 +10,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

The ruff Action uses minimal steps to run in ~5 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--2056.org.readthedocs.build/en/2056/

<!-- readthedocs-preview datasette end -->