### PR TITLE
sort files by mtime

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -267,6 +267,7 @@ class Datasette:
             db_files = []
             for ext in ("db", "sqlite", "sqlite3"):
                 db_files.extend(config_dir.glob("*.{}".format(ext)))
+            db_files.sort(key=os.path.getmtime, reverse=True)
             self.files += tuple(str(f) for f in db_files)
         if (
             config_dir


### PR DESCRIPTION
serving multiple database files and getting tired by the default sort, changes so the sort order puts the latest changed databases to be on top of the list so don't have to scroll down, lazy as i am ;)

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--2074.org.readthedocs.build/en/2074/

<!-- readthedocs-preview datasette end -->