### PR TITLE
Catch query interrupted on facet suggest row count

### DIFF
--- a/datasette/facets.py
+++ b/datasette/facets.py
@@ -157,10 +157,13 @@ class ColumnFacet(Facet):
     type = "column"
 
     async def suggest(self):
-        row_count = await self.get_row_count()
-        columns = await self.get_columns(self.sql, self.params)
-        facet_size = self.get_facet_size()
         suggested_facets = []
+        try:
+            row_count = await self.get_row_count()
+            columns = await self.get_columns(self.sql, self.params)
+        except QueryInterrupted:
+            return suggested_facets
+        facet_size = self.get_facet_size()
         already_enabled = [c["config"]["simple"] for c in self.get_configs()]
         for column in columns:
             if column in already_enabled:


### PR DESCRIPTION
Just like facet's `suggest()` is trapping `QueryInterrupted` for facet columns, we also need to trap `get_row_count()`, which can reach timeout if database tables are big enough. 

I've included `get_columns()` inside the block as that's just another query, despite it's a really cheap one and might never raise the exception.

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--2082.org.readthedocs.build/en/2082/

<!-- readthedocs-preview datasette end -->