### PR TITLE
Start a new `datasette.yaml` configuration file, with settings support

### DIFF
--- a/docs/cli-reference.rst
+++ b/docs/cli-reference.rst
@@ -112,8 +112,7 @@ Once started you can access it at ``http://localhost:8001``
       --static MOUNT:DIRECTORY        Serve static files from this directory at
                                       /MOUNT/...
       --memory                        Make /_memory database available
-      --config CONFIG                 Deprecated: set config option using
-                                      configname:value. Use --setting instead.
+      --config FILENAME               Path to JSON/YAML Datasette configuration file
       --setting SETTING...            Setting, see
                                       docs.datasette.io/en/stable/settings.html
       --secret TEXT                   Secret used for signing secure values, such as

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,10 @@
+.. _configuration:
+
+Configuration
+========
+
+Datasette offers many way to configure your Datasette instances: server settings, plugin configuration, authentication, and more.
+
+To facilitate this, You can provide a `datasette.yaml` configuration file to datasette with the ``--config``/ ``-c`` flag:
+
+    datasette mydatabase.db --config datasette.yaml

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -47,9 +47,9 @@ Datasette will detect the files in that directory and automatically configure it
 The files that can be included in this directory are as follows. All are optional.
 
 * ``*.db`` (or ``*.sqlite3`` or ``*.sqlite``) - SQLite database files that will be served by Datasette
+* ``datasette.json`` - :ref:`configuration` for the Datasette instance
 * ``metadata.json`` - :ref:`metadata` for those databases - ``metadata.yaml`` or ``metadata.yml`` can be used as well
 * ``inspect-data.json`` - the result of running ``datasette inspect *.db --inspect-file=inspect-data.json`` from the configuration directory - any database files listed here will be treated as immutable, so they should not be changed while Datasette is running
-* ``settings.json`` - settings that would normally be passed using ``--setting`` - here they should be stored as a JSON object of key/value pairs
 * ``templates/`` - a directory containing :ref:`customization_custom_templates`
 * ``plugins/`` - a directory containing plugins, see :ref:`writing_plugins_one_off`
 * ``static/`` - a directory containing static files - these will be served from ``/static/filename.txt``, see :ref:`customization_static_files`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -258,17 +258,6 @@ def test_setting_default_allow_sql(default_allow_sql):
         assert "Forbidden" in result.output
 
 
-def test_config_deprecated():
-    # The --config option should show a deprecation message
-    runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(
-        cli, ["--config", "allow_download:off", "--get", "/-/settings.json"]
-    )
-    assert result.exit_code == 0
-    assert not json.loads(result.output)["allow_download"]
-    assert "will be deprecated in" in result.stderr
-
-
 def test_sql_errors_logged_to_stderr():
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(cli, ["--get", "/_memory.json?sql=select+blah"])


### PR DESCRIPTION
refs #2093 #2143 

This is the first step to implementing the new `datasette.yaml`/`datasette.json` configuration file. 

- The old `--config` argument is now back, and is the path to a `datasette.yaml` file. Acts like the `--metadata` flag.
- The old `settings.json` behavior has been removed.
- The `"settings"` key inside `datasette.yaml` defines the same `--settings` flags
- Values passed in `--settings` will over-write values in `datasette.yaml`

Docs for the Config file is pretty light, not much to add until we add more config to the file.

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--2149.org.readthedocs.build/en/2149/

<!-- readthedocs-preview datasette end -->