### PR TITLE
Fix hupper.start_reloader entry point

### DIFF
--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -557,7 +557,7 @@ def serve(
     if reload:
         import hupper
 
-        reloader = hupper.start_reloader("datasette.cli.serve")
+        reloader = hupper.start_reloader("datasette.cli.cli")
         if immutable:
             reloader.watch_files(immutable)
         if metadata:


### PR DESCRIPTION
Update hupper's entry point so that click commands are processed properly.

Fixes #2123