### PR TITLE
add brand option to metadata.json.

### DIFF
--- a/datasette/templates/_crumbs.html
+++ b/datasette/templates/_crumbs.html
@@ -3,6 +3,9 @@
   {% set items=crumb_items(request=request, database=database, table=table) %}
   {% if items %}
     <p class="crumbs">
+        {% if metadata and metadata.brand %}
+        <a style="font-size: 18px; font-weight:bold; padding-right: 8px;" href="{{metadata.brand_url or '#'}}">{{metadata.brand}}</a>
+        {% endif %}
       {% for item in items %}
         <a href="{{ item.href }}">{{ item.label }}</a>
         {% if not loop.last %}


### PR DESCRIPTION
This adds a brand link to the top navbar if 'brand' key is populated in metadata.json. The link will be either '#' or use the contents of 'brand_url' in metadata.json for href.

I was able to get this done on my own site by replacing `templates/_crumbs.html` with a custom version, but I thought it would be nice to incorporate this in the tool directly.

![image](https://github.com/simonw/datasette/assets/52261150/fdfe9bb5-fee4-466c-8074-6132071d94e6)


<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--2158.org.readthedocs.build/en/2158/

<!-- readthedocs-preview datasette end -->