### PR TITLE
Use $DATASETTE_INTERNAL in absence of --internal

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -310,9 +310,6 @@ class Datasette:
                 Database(self, file, is_mutable=file not in self.immutables)
             )
 
-        if internal is None and "DATASETTE_INTERNAL_DB_PATH" in os.environ:
-            internal = os.environ.get("DATASETTE_INTERNAL_DB_PATH")
-
         self.internal_db_created = False
         if internal is None:
             self._internal_database = Database(self, memory_name=secrets.token_hex())

--- a/datasette/app.py
+++ b/datasette/app.py
@@ -310,6 +310,9 @@ class Datasette:
                 Database(self, file, is_mutable=file not in self.immutables)
             )
 
+        if internal is None and "DATASETTE_INTERNAL_DB_PATH" in os.environ:
+            internal = os.environ.get("DATASETTE_INTERNAL_DB_PATH")
+
         self.internal_db_created = False
         if internal is None:
             self._internal_database = Database(self, memory_name=secrets.token_hex())

--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -477,6 +477,7 @@ def uninstall(packages, yes):
     "--internal",
     type=click.Path(),
     help="Path to a persistent Datasette internal SQLite database",
+    envvar="DATASETTE_INTERNAL"
 )
 def serve(
     files,

--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -477,7 +477,7 @@ def uninstall(packages, yes):
     "--internal",
     type=click.Path(),
     help="Path to a persistent Datasette internal SQLite database",
-    envvar="DATASETTE_INTERNAL"
+    envvar="DATASETTE_INTERNAL",
 )
 def serve(
     files,


### PR DESCRIPTION
#refs 2157, specifically [this comment](https://github.com/simonw/datasette/issues/2157#issuecomment-1700291967)

Passing in `--internal my_internal.db` over and over again can get repetitive. 

This PR adds a new configurable env variable `DATASETTE_INTERNAL_DB_PATH`. If it's defined, then it takes place as the path to the internal database. Users can still overwrite this behavior by passing in their own `--internal internal.db` flag.

In draft mode for now, needs tests and documentation. 

Side note: Maybe we can have a sections in the docs that lists all the "configuration environment variables" that Datasette respects? I did a quick grep and found:

- `DATASETTE_LOAD_PLUGINS`
- `DATASETTE_SECRETS`


<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--2174.org.readthedocs.build/en/2174/

<!-- readthedocs-preview datasette end -->