### PR TITLE
actors_from_ids plugin hook and datasette.actors_from_ids() method

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -819,6 +819,16 @@ class Datasette:
                 )
         return crumbs
 
+    async def actors_from_ids(
+        self, actor_ids: Iterable[Union[str, int]]
+    ) -> Dict[Union[id, str], Dict]:
+        result = pm.hook.actors_from_ids(datasette=self, actor_ids=actor_ids)
+        if result is None:
+            # Do the default thing
+            return {actor_id: {"id": actor_id} for actor_id in actor_ids}
+        result = await await_me_maybe(result)
+        return result
+
     async def permission_allowed(
         self, actor, action, resource=None, default=DEFAULT_NOT_SET
     ):

--- a/datasette/hookspecs.py
+++ b/datasette/hookspecs.py
@@ -94,6 +94,11 @@ def actor_from_request(datasette, request):
     """Return an actor dictionary based on the incoming request"""
 
 
+@hookspec(firstresult=True)
+def actors_from_ids(datasette, actor_ids):
+    """Returns a dictionary mapping those IDs to actor dictionaries"""
+
+
 @hookspec
 def filters_from_request(request, database, table, datasette):
     """

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -322,6 +322,27 @@ await .render_template(template, context=None, request=None)
 
 Renders a `Jinja template <https://jinja.palletsprojects.com/en/2.11.x/>`__ using Datasette's preconfigured instance of Jinja and returns the resulting string. The template will have access to Datasette's default template functions and any functions that have been made available by other plugins.
 
+.. _datasette_actors_from_ids:
+
+await .actors_from_ids(actor_ids)
+---------------------------------
+
+``actor_ids`` - list of strings or integers
+    A list of actor IDs to look up.
+
+Returns a dictionary, where the keys are the IDs passed to it and the values are the corresponding actor dictionaries.
+
+This method is mainly designed to be used with plugins. See the :ref:`plugin_hook_actors_from_ids` documentation for details.
+
+If no plugins that implement that hook are installed, the default return value looks like this:
+
+.. code-block:: json
+
+    {
+        "1": {"id": "1"},
+        "2": {"id": "2"}
+    }
+
 .. _datasette_permission_allowed:
 
 await .permission_allowed(actor, action, resource=None, default=...)

--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -1126,6 +1126,8 @@ The returned dictionary from this example looks like this:
 
 These IDs could be integers or strings, depending on how the actors used by the Datasette instance are configured.
 
+Example: `datasette-remote-actors <https://github.com/datasette/datasette-remote-actors>`_
+
 .. _plugin_hook_filters_from_request:
 
 filters_from_request(request, database, table, datasette)


### PR DESCRIPTION
Refs:
- #2180

This plugin hook is feature complete - including documentation and tests.

I'm not going to land it in Datasette `main` until we've used it at least once though, which should happen promptly in development for [Datasette Cloud](https://www.datasette.cloud/).

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--2181.org.readthedocs.build/en/2181/

<!-- readthedocs-preview datasette end -->