### PR TITLE
Raise an exception if a "plugins" block exists in metadata.json

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -335,7 +335,9 @@ class Datasette:
             ]
         if config_dir and metadata_files and not metadata:
             with metadata_files[0].open() as fp:
-                metadata = fail_if_plugins_in_metadata(parse_metadata(fp.read()), metadata_files[0].name)
+                metadata = fail_if_plugins_in_metadata(
+                    parse_metadata(fp.read()), metadata_files[0].name
+                )
 
         if config_dir and config_files and not config:
             with config_files[0].open() as fp:

--- a/datasette/app.py
+++ b/datasette/app.py
@@ -76,6 +76,7 @@ from .utils import (
     parse_metadata,
     resolve_env_secrets,
     resolve_routes,
+    fail_if_plugins_in_metadata,
     tilde_decode,
     to_css_class,
     urlsafe_components,
@@ -334,13 +335,14 @@ class Datasette:
             ]
         if config_dir and metadata_files and not metadata:
             with metadata_files[0].open() as fp:
-                metadata = parse_metadata(fp.read())
+                metadata = fail_if_plugins_in_metadata(parse_metadata(fp.read()), metadata_files[0].name)
 
         if config_dir and config_files and not config:
             with config_files[0].open() as fp:
                 config = parse_metadata(fp.read())
 
-        self._metadata_local = metadata or {}
+        self._metadata_local = fail_if_plugins_in_metadata(metadata or {})
+
         self.sqlite_extensions = []
         for extension in sqlite_extensions or []:
             # Resolve spatialite, if requested

--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -33,6 +33,7 @@ from .utils import (
     initial_path_for_datasette,
     pairs_to_nested_config,
     temporary_docker_directory,
+    fail_if_plugins_in_metadata,
     value_as_boolean,
     SpatialiteNotFound,
     StaticMount,
@@ -542,7 +543,7 @@ def serve(
 
     metadata_data = None
     if metadata:
-        metadata_data = parse_metadata(metadata.read())
+        metadata_data = fail_if_plugins_in_metadata(parse_metadata(metadata.read()), metadata.name)
 
     config_data = None
     if config:

--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -543,7 +543,7 @@ def serve(
 
     metadata_data = None
     if metadata:
-        metadata_data = fail_if_plugins_in_metadata(parse_metadata(metadata.read()), metadata.name)
+        metadata_data = fail_if_plugins_in_metadata(parse_metadata(metadata.read()))
 
     config_data = None
     if config:

--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -1268,3 +1268,10 @@ def pairs_to_nested_config(pairs: typing.List[typing.Tuple[str, typing.Any]]) ->
         parsed_pair = _handle_pair(key, value)
         result = _combine(result, parsed_pair)
     return result
+
+def fail_if_plugins_in_metadata(metadata:dict, filename=None):
+    """ If plugin config is inside metadata, raise an Exception """
+    if metadata is not None and metadata.get("plugins") is not None:
+        suggested_extension = ".yaml"  if filename is not None and (filename.endswith(".yaml") or filename.endswith(".yml")) else ".json"
+        raise Exception(f'Datasette no longer accepts plugin configuration in --metadata. Move your "plugins" configuration blocks to a separate file - we suggest calling that datasette.{suggested_extension} - and start Datasette with datasette -c datasette.{suggested_extension}. See https://docs.datasette.io/en/latest/configuration.html for more details.')
+    return metadata

--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -1269,9 +1269,17 @@ def pairs_to_nested_config(pairs: typing.List[typing.Tuple[str, typing.Any]]) ->
         result = _combine(result, parsed_pair)
     return result
 
-def fail_if_plugins_in_metadata(metadata:dict, filename=None):
-    """ If plugin config is inside metadata, raise an Exception """
+
+def fail_if_plugins_in_metadata(metadata: dict, filename=None):
+    """If plugin config is inside metadata, raise an Exception"""
     if metadata is not None and metadata.get("plugins") is not None:
-        suggested_extension = ".yaml"  if filename is not None and (filename.endswith(".yaml") or filename.endswith(".yml")) else ".json"
-        raise Exception(f'Datasette no longer accepts plugin configuration in --metadata. Move your "plugins" configuration blocks to a separate file - we suggest calling that datasette.{suggested_extension} - and start Datasette with datasette -c datasette.{suggested_extension}. See https://docs.datasette.io/en/latest/configuration.html for more details.')
+        suggested_extension = (
+            ".yaml"
+            if filename is not None
+            and (filename.endswith(".yaml") or filename.endswith(".yml"))
+            else ".json"
+        )
+        raise Exception(
+            f'Datasette no longer accepts plugin configuration in --metadata. Move your "plugins" configuration blocks to a separate file - we suggest calling that datasette.{suggested_extension} - and start Datasette with datasette -c datasette.{suggested_extension}. See https://docs.datasette.io/en/latest/configuration.html for more details.'
+        )
     return metadata

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -879,6 +879,14 @@ def test_hook_forbidden(restore_working_directory):
         )
 
 
+def test_plugin_config_in_metadata():
+    with pytest.raises(
+        Exception,
+        match="Datasette no longer accepts plugin configuration in --metadata",
+    ):
+        Datasette(memory=True, metadata={"plugins": {}})
+
+
 @pytest.mark.asyncio
 async def test_hook_handle_exception(ds_client):
     await ds_client.get("/trigger-error?x=123")


### PR DESCRIPTION
refs #2183 #2093

From [this comment](https://github.com/simonw/datasette/pull/2183#issuecomment-1714699724) in #2183: If a `"plugins"` block appears in `metadata.json`, it means that a user hasn't migrated over their plugin configuration from `metadata.json` to `datasette.yaml`, which is a breaking change in Datasette 1.0. 

This PR will ensure that an error is raised whenever that happens.

<!-- readthedocs-preview datasette start -->
----
:books: Documentation preview :books:: https://datasette--2190.org.readthedocs.build/en/2190/

<!-- readthedocs-preview datasette end -->