### PR TITLE
Remove deprecated/unused args from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
         [console_scripts]
         datasette=datasette.cli:cli
     """,
-    setup_requires=["pytest-runner"],
     extras_require={
         "docs": [
             "Sphinx==7.2.6",
@@ -93,7 +92,6 @@ setup(
         ],
         "rich": ["rich"],
     },
-    tests_require=["datasette[test]"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Datasette",


### PR DESCRIPTION
These were added in https://github.com/simonw/datasette/commit/be768f26d09fa060b1ca71785ff546dd572f3fbc and https://github.com/simonw/datasette/commit/47e689a89b3f5f0969595b17d2ec59ea3caffb3b and as best as I can tell no longer used. 

[Pypa](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#build-system-requirement) states that these are deprecated and [pytest-runner](https://pypi.org/project/pytest-runner/) itself recommends removing them. 

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2222.org.readthedocs.build/en/2222/

<!-- readthedocs-preview datasette end -->