### PR TITLE
set link to download db to nofollow

### DIFF
--- a/datasette/templates/database.html
+++ b/datasette/templates/database.html
@@ -95,7 +95,7 @@
 {% endif %}
 
 {% if allow_download %}
-    <p class="download-sqlite">Download SQLite DB: <a href="{{ urls.database(database) }}.db">{{ database }}.db</a> <em>{{ format_bytes(size) }}</em></p>
+    <p class="download-sqlite">Download SQLite DB: <a href="{{ urls.database(database) }}.db" rel="nofollow">{{ database }}.db</a> <em>{{ format_bytes(size) }}</em></p>
 {% endif %}
 
 {% include "_codemirror_foot.html" %}


### PR DESCRIPTION
This directs well-behaved web crawlers to not attempt to download the whole sqlite db, which is something you probably don't want a web crawler to do. 

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2236.org.readthedocs.build/en/2236/

<!-- readthedocs-preview datasette end -->