### PR TITLE
track_event() mechanism for analytics and plugins

### DIFF
--- a/datasette/__init__.py
+++ b/datasette/__init__.py
@@ -1,5 +1,6 @@
 from datasette.permissions import Permission  # noqa
 from datasette.version import __version_info__, __version__  # noqa
+from datasette.events import Event  # noqa
 from datasette.utils.asgi import Forbidden, NotFound, Request, Response  # noqa
 from datasette.utils import actor_matches_allow  # noqa
 from datasette.views import Context  # noqa

--- a/datasette/app.py
+++ b/datasette/app.py
@@ -885,10 +885,11 @@ class Datasette:
         assert isinstance(event, self.event_classes), "Invalid event type: {}".format(
             type(event)
         )
-        properties = dataclasses.asdict(event)
-        actor = properties.pop("actor")
         for hook in pm.hook.track_event(
-            datasette=self, name=event.name, actor=actor, properties=properties
+            datasette=self,
+            name=event.name,
+            actor=event.actor,
+            properties=event.properties(),
         ):
             await await_me_maybe(hook)
 

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -63,7 +63,6 @@ class CreateTokenEvent(Event):
     """
 
     name = "create-token"
-
     expires_after: Optional[int]
     restrict_all: list
     restrict_database: dict
@@ -157,6 +156,26 @@ class UpsertRowsEvent(Event):
     num_rows: int
 
 
+@dataclass
+class UpdateRowEvent(Event):
+    """
+    Event name: ``update-row``
+
+    A row was updated in a table.
+
+    :ivar database: The name of the database where the row was updated.
+    :type database: str
+    :ivar table: The name of the table where the row was updated.
+    :type table: str
+    :ivar pks: The primary key values of the updated row.
+    """
+
+    name = "update-row"
+    database: str
+    table: str
+    pks: list
+
+
 @hookimpl
 def register_events():
     return [
@@ -167,4 +186,5 @@ def register_events():
         DropTableEvent,
         InsertRowsEvent,
         UpsertRowsEvent,
+        UpdateRowEvent,
     ]

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractproperty
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datasette.hookspecs import hookimpl
 
 
@@ -10,6 +10,11 @@ class Event(ABC):
         pass
 
     actor: dict
+
+    def properties(self):
+        properties = asdict(self)
+        properties.pop("actor", None)
+        return properties
 
 
 @dataclass

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -91,6 +91,24 @@ class CreateTableEvent(Event):
     schema: str
 
 
+@dataclass
+class DropTableEvent(Event):
+    """
+    Event name: ``drop-table``
+
+    A table has been dropped from the database.
+
+    :ivar database: The name of the database where the table was dropped.
+    :type database: str
+    :ivar table: The name of the table that was dropped
+    :type table: str
+    """
+
+    name = "drop-table"
+    database: str
+    table: str
+
+
 @hookimpl
 def register_events():
-    return [LoginEvent, LogoutEvent, CreateTableEvent, CreateTokenEvent]
+    return [LoginEvent, LogoutEvent, CreateTableEvent, CreateTokenEvent, DropTableEvent]

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -136,6 +136,27 @@ class InsertRowsEvent(Event):
     replace: bool
 
 
+@dataclass
+class UpsertRowsEvent(Event):
+    """
+    Event name: ``upsert-rows``
+
+    Rows were upserted into a table.
+
+    :ivar database: The name of the database where the rows were inserted.
+    :type database: str
+    :ivar table: The name of the table where the rows were inserted.
+    :type table: str
+    :ivar num_rows: The number of rows that were requested to be inserted.
+    :type num_rows: int
+    """
+
+    name = "upsert-rows"
+    database: str
+    table: str
+    num_rows: int
+
+
 @hookimpl
 def register_events():
     return [
@@ -145,4 +166,5 @@ def register_events():
         CreateTokenEvent,
         DropTableEvent,
         InsertRowsEvent,
+        UpsertRowsEvent,
     ]

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -18,6 +18,11 @@ class Event(ABC):
 
 
 @dataclass
+class LoginEvent(Event):
+    name = "login"
+
+
+@dataclass
 class LogoutEvent(Event):
     name = "logout"
 
@@ -32,4 +37,4 @@ class CreateTableEvent(Event):
 
 @hookimpl
 def register_events():
-    return [LogoutEvent, CreateTableEvent]
+    return [LoginEvent, LogoutEvent, CreateTableEvent]

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -24,6 +24,7 @@ class LoginEvent(Event):
 
     A user (represented by ``event.actor``) has logged in.
     """
+
     name = "login"
 
 
@@ -34,6 +35,7 @@ class LogoutEvent(Event):
 
     A user (represented by ``event.actor``) has logged out.
     """
+
     name = "logout"
 
 
@@ -51,6 +53,7 @@ class CreateTableEvent(Event):
     :ivar schema: The SQL schema definition for the new table.
     :type schema: str
     """
+
     name = "create-table"
     database: str
     table: str

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractproperty
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datasette.hookspecs import hookimpl
+from datetime import datetime, timezone
 from typing import Optional
 
 
@@ -10,11 +11,15 @@ class Event(ABC):
     def name(self):
         pass
 
-    actor: dict
+    created: datetime = field(
+        init=False, default_factory=lambda: datetime.now(timezone.utc)
+    )
+    actor: Optional[dict]
 
     def properties(self):
         properties = asdict(self)
         properties.pop("actor", None)
+        properties.pop("created", None)
         return properties
 
 

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -19,16 +19,38 @@ class Event(ABC):
 
 @dataclass
 class LoginEvent(Event):
+    """
+    Event name: ``login``
+
+    A user (represented by ``event.actor``) has logged in.
+    """
     name = "login"
 
 
 @dataclass
 class LogoutEvent(Event):
+    """
+    Event name: ``logout``
+
+    A user (represented by ``event.actor``) has logged out.
+    """
     name = "logout"
 
 
 @dataclass
 class CreateTableEvent(Event):
+    """
+    Event name: ``create-table``
+
+    A new table has been created in the database.
+
+    :ivar database: The name of the database where the table was created.
+    :type database: str
+    :ivar table: The name of the table that was created
+    :type table: str
+    :ivar schema: The SQL schema definition for the new table.
+    :type schema: str
+    """
     name = "create-table"
     database: str
     table: str

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractproperty
 from dataclasses import asdict, dataclass
 from datasette.hookspecs import hookimpl
+from typing import Optional
 
 
 @dataclass
@@ -40,6 +41,31 @@ class LogoutEvent(Event):
 
 
 @dataclass
+class CreateTokenEvent(Event):
+    """
+    Event name: ``create-token``
+
+    A user created an API token.
+
+    :ivar expires_after: Number of seconds after which this token will expire.
+    :type expires_after: int or None
+    :ivar restrict_all: Restricted permissions for this token.
+    :type restrict_all: list
+    :ivar restrict_database: Restricted database permissions for this token.
+    :type restrict_database: dict
+    :ivar restrict_resource: Restricted resource permissions for this token.
+    :type restrict_resource: dict
+    """
+
+    name = "create-token"
+
+    expires_after: Optional[int]
+    restrict_all: list
+    restrict_database: dict
+    restrict_resource: dict
+
+
+@dataclass
 class CreateTableEvent(Event):
     """
     Event name: ``create-table``
@@ -62,4 +88,4 @@ class CreateTableEvent(Event):
 
 @hookimpl
 def register_events():
-    return [LoginEvent, LogoutEvent, CreateTableEvent]
+    return [LoginEvent, LogoutEvent, CreateTableEvent, CreateTokenEvent]

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -109,6 +109,40 @@ class DropTableEvent(Event):
     table: str
 
 
+@dataclass
+class InsertRowsEvent(Event):
+    """
+    Event name: ``insert-rows``
+
+    Rows were inserted into a table.
+
+    :ivar database: The name of the database where the rows were inserted.
+    :type database: str
+    :ivar table: The name of the table where the rows were inserted.
+    :type table: str
+    :ivar num_rows: The number of rows that were requested to be inserted.
+    :type num_rows: int
+    :ivar ignore: Was ignore set?
+    :type ignore: bool
+    :ivar replace: Was replace set?
+    :type replace: bool
+    """
+
+    name = "insert-rows"
+    database: str
+    table: str
+    num_rows: int
+    ignore: bool
+    replace: bool
+
+
 @hookimpl
 def register_events():
-    return [LoginEvent, LogoutEvent, CreateTableEvent, CreateTokenEvent, DropTableEvent]
+    return [
+        LoginEvent,
+        LogoutEvent,
+        CreateTableEvent,
+        CreateTokenEvent,
+        DropTableEvent,
+        InsertRowsEvent,
+    ]

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -1,0 +1,30 @@
+from abc import ABC, abstractproperty
+from dataclasses import dataclass
+from datasette.hookspecs import hookimpl
+
+
+@dataclass
+class Event(ABC):
+    @abstractproperty
+    def name(self):
+        pass
+
+    actor: dict
+
+
+@dataclass
+class LogoutEvent(Event):
+    name = "logout"
+
+
+@dataclass
+class CreateTableEvent(Event):
+    name = "create-table"
+    database: str
+    table: str
+    schema: str
+
+
+@hookimpl
+def register_events():
+    return [LogoutEvent, CreateTableEvent]

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -176,6 +176,26 @@ class UpdateRowEvent(Event):
     pks: list
 
 
+@dataclass
+class DeleteRowEvent(Event):
+    """
+    Event name: ``delete-row``
+
+    A row was deleted from a table.
+
+    :ivar database: The name of the database where the row was deleted.
+    :type database: str
+    :ivar table: The name of the table where the row was deleted.
+    :type table: str
+    :ivar pks: The primary key values of the deleted row.
+    """
+
+    name = "delete-row"
+    database: str
+    table: str
+    pks: list
+
+
 @hookimpl
 def register_events():
     return [
@@ -187,4 +207,5 @@ def register_events():
         InsertRowsEvent,
         UpsertRowsEvent,
         UpdateRowEvent,
+        DeleteRowEvent,
     ]

--- a/datasette/hookspecs.py
+++ b/datasette/hookspecs.py
@@ -161,8 +161,8 @@ def handle_exception(datasette, request, exception):
 
 
 @hookspec
-def track_event(datasette, name, actor, properties):
-    """Respond to a named event tracked by Datasette"""
+def track_event(datasette, event):
+    """Respond to an event tracked by Datasette"""
 
 
 @hookspec

--- a/datasette/hookspecs.py
+++ b/datasette/hookspecs.py
@@ -161,6 +161,16 @@ def handle_exception(datasette, request, exception):
 
 
 @hookspec
+def track_event(datasette, name, actor, properties):
+    """Respond to a named event tracked by Datasette"""
+
+
+@hookspec
+def register_events(datasette):
+    """Return a list of Event subclasses to use with track_event()"""
+
+
+@hookspec
 def top_homepage(datasette, request):
     """HTML to include at the top of the homepage"""
 

--- a/datasette/plugins.py
+++ b/datasette/plugins.py
@@ -27,6 +27,7 @@ DEFAULT_PLUGINS = (
     "datasette.default_menu_links",
     "datasette.handle_exception",
     "datasette.forbidden",
+    "datasette.events",
 )
 
 pm = pluggy.PluginManager("datasette")

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -10,6 +10,7 @@ import re
 import sqlite_utils
 import textwrap
 
+from datasette.events import CreateTableEvent
 from datasette.database import QueryInterrupted
 from datasette.utils import (
     add_cors_headers,
@@ -969,6 +970,11 @@ class TableCreateView(BaseView):
         }
         if rows:
             details["row_count"] = len(rows)
+        await self.ds.track_event(
+            CreateTableEvent(
+                request.actor, database=db.name, table=table_name, schema=schema
+            )
+        )
         return Response.json(details, status=201)
 
 

--- a/datasette/views/row.py
+++ b/datasette/views/row.py
@@ -1,5 +1,6 @@
 from datasette.utils.asgi import NotFound, Forbidden, Response
 from datasette.database import QueryInterrupted
+from datasette.events import UpdateRowEvent
 from .base import DataView, BaseView, _error
 from datasette.utils import (
     make_slot_function,
@@ -246,4 +247,14 @@ class RowUpdateView(BaseView):
             )
             rows = list(results.rows)
             result["row"] = dict(rows[0])
+
+        await self.ds.track_event(
+            UpdateRowEvent(
+                actor=request.actor,
+                database=resolved.db.name,
+                table=resolved.table,
+                pks=resolved.pk_values,
+            )
+        )
+
         return Response.json(result, status=200)

--- a/datasette/views/special.py
+++ b/datasette/views/special.py
@@ -1,4 +1,5 @@
 import json
+from datasette.events import LogoutEvent
 from datasette.utils.asgi import Response, Forbidden
 from datasette.utils import (
     actor_matches_allow,
@@ -105,6 +106,7 @@ class LogoutView(BaseView):
         response = Response.redirect(self.ds.urls.instance())
         response.set_cookie("ds_actor", "", expires=0, max_age=0)
         self.ds.add_message(request, "You are now logged out", self.ds.WARNING)
+        await self.ds.track_event(LogoutEvent(request.actor))
         return response
 
 

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -8,6 +8,7 @@ import markupsafe
 
 from datasette.plugins import pm
 from datasette.database import QueryInterrupted
+from datasette.events import DropTableEvent
 from datasette import tracer
 from datasette.utils import (
     add_cors_headers,
@@ -587,6 +588,11 @@ class TableDropView(BaseView):
             sqlite_utils.Database(conn)[table_name].drop()
 
         await db.execute_write_fn(drop_table)
+        await self.ds.track_event(
+            DropTableEvent(
+                actor=request.actor, database=database_name, table=table_name
+            )
+        )
         return Response.json({"ok": True}, status=200)
 
 

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -8,7 +8,7 @@ import markupsafe
 
 from datasette.plugins import pm
 from datasette.database import QueryInterrupted
-from datasette.events import DropTableEvent, InsertRowsEvent
+from datasette.events import DropTableEvent, InsertRowsEvent, UpsertRowsEvent
 from datasette import tracer
 from datasette.utils import (
     add_cors_headers,
@@ -533,7 +533,14 @@ class TableInsertView(BaseView):
         # We track the number of rows requested, but do not attempt to show which were actually
         # inserted or upserted v.s. ignored
         if upsert:
-            pass
+            await self.ds.track_event(
+                UpsertRowsEvent(
+                    actor=request.actor,
+                    database=database_name,
+                    table=table_name,
+                    num_rows=num_rows,
+                )
+            )
         else:
             await self.ds.track_event(
                 InsertRowsEvent(

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -8,7 +8,7 @@ import markupsafe
 
 from datasette.plugins import pm
 from datasette.database import QueryInterrupted
-from datasette.events import DropTableEvent
+from datasette.events import DropTableEvent, InsertRowsEvent
 from datasette import tracer
 from datasette.utils import (
     add_cors_headers,
@@ -468,6 +468,8 @@ class TableInsertView(BaseView):
         if errors:
             return _error(errors, 400)
 
+        num_rows = len(rows)
+
         # No that we've passed pks to _validate_data it's safe to
         # fix the rowids case:
         if not pks:
@@ -528,6 +530,22 @@ class TableInsertView(BaseView):
                 result["rows"] = [dict(r) for r in fetched_rows.rows]
             else:
                 result["rows"] = rows
+        # We track the number of rows requested, but do not attempt to show which were actually
+        # inserted or upserted v.s. ignored
+        if upsert:
+            pass
+        else:
+            await self.ds.track_event(
+                InsertRowsEvent(
+                    actor=request.actor,
+                    database=database_name,
+                    table=table_name,
+                    num_rows=num_rows,
+                    ignore=bool(ignore),
+                    replace=bool(replace),
+                )
+            )
+
         return Response.json(result, status=200 if upsert else 201)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,8 @@ extensions = [
 if not os.environ.get("DISABLE_SPHINX_INLINE_TABS"):
     extensions += ["sphinx_inline_tabs"]
 
+autodoc_member_order = "bysource"
+
 extlinks = {
     "issue": ("https://github.com/simonw/datasette/issues/%s", "#%s"),
 }

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -1,3 +1,5 @@
+.. _events:
+
 Events
 ======
 

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -1,0 +1,12 @@
+Events
+======
+
+Datasette includes a mechanism for tracking events that occur while the software is running. This is primarily intended to be used by plugins, which can both trigger events and listen for events.
+
+The core Datasette application triggers events when certain things happen. This page describes those events.
+
+Plugins can listen for events using the :ref:`plugin_hook_track_event` plugin hook.
+
+.. automodule:: datasette.events
+    :members:
+    :exclude-members: Event

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -7,7 +7,7 @@ Datasette includes a mechanism for tracking events that occur while the software
 
 The core Datasette application triggers events when certain things happen. This page describes those events.
 
-Plugins can listen for events using the :ref:`plugin_hook_track_event` plugin hook.
+Plugins can listen for events using the :ref:`plugin_hook_track_event` plugin hook, which will be called with instances of the following classes (or additional classes registered by other plugins):
 
 .. automodule:: datasette.events
     :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,5 +63,6 @@ Contents
    plugin_hooks
    testing_plugins
    internals
+   events
    contributing
    changelog

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -593,6 +593,26 @@ Using either of these pattern will result in the in-memory database being served
 
 This removes a database that has been previously added. ``name=`` is the unique name of that database.
 
+.. _datasette_track_event:
+
+await .track_event(event)
+-------------------------
+
+``event`` - ``Event``
+    An instance of a subclass of ``datasette.events.Event``.
+
+Plugins can call this to track events, using classes they have previously registered. See :ref:`plugin_event_tracking` for details.
+
+The event will then be passed to all plugins that have registered to receive events using the :ref:`plugin_hook_track_event` hook.
+
+Example usage, assuming the plugin has previously registered the ``BanUserEvent`` class:
+
+.. code-block:: python
+
+    await datasette.track_event(
+        BanUserEvent(user={"id": 1, "username": "cleverbot"})
+    )
+
 .. _datasette_sign:
 
 .sign(value, namespace="default")

--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -1788,6 +1788,7 @@ The ``event`` object will always have the following properties:
 
 - ``name``: a string representing the name of the event, for example ``logout`` or ``create-table``.
 - ``actor``: a dictionary representing the actor that triggered the event, or ``None`` if the event was not triggered by an actor.
+- ``created``: a ``datatime.datetime`` object in the ``timezone.utc`` timezone representing the time the event object was created.
 
 Other properties on the event will be available depending on the type of event. You can also access those as a dictionary using ``event.properties()``.
 

--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -1773,8 +1773,8 @@ They can also define their own events for other plugins to receive using the ``r
 
 .. _plugin_hook_track_event:
 
-track_event(datasette, name, event)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+track_event(datasette, event)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``datasette`` - :ref:`internals_datasette`
     You can use this to access plugin configuration options via ``datasette.plugin_config(your_plugin_name)``.

--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -1782,7 +1782,7 @@ track_event(datasette, event)
 ``event`` - ``Event``
     Information about the event, represented as an instance of a subclass of the ``Event`` base class.
 
-This hook will be called any time an event is tracked through code calling the ``datasette.track_event(...)`` internal method.
+This hook will be called any time an event is tracked by code that calls the :ref:`datasette.track_event(...) <datasette_track_event>` internal method.
 
 The ``event`` object will always have the following properties:
 

--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -1789,7 +1789,33 @@ The ``event`` object will always have the following properties:
 - ``name``: a string representing the name of the event, for example ``logout`` or ``create-table``.
 - ``actor``: a dictionary representing the actor that triggered the event, or ``None`` if the event was not triggered by an actor.
 
-Other properties on the event will be available depending on the type of event. TODO: Link to documentation of these.
+Other properties on the event will be available depending on the type of event. You can also access those as a dictionary using ``event.properties()``.
+
+**TODO: Link to documentation of default core events**
+
+This example plugin logs details of all events to standard error:
+
+.. code-block:: python
+
+    from datasette import hookimpl
+    import json
+    import sys
+
+
+    @hookimpl
+    def track_event(event):
+        name = event.name
+        actor = event.actor
+        properties = event.properties()
+        msg = json.dumps(
+            {
+                "name": name,
+                "actor": actor,
+                "properties": properties,
+            }
+        )
+        print(msg, file=sys.stderr, flush=True)
+
 
 .. _plugin_hook_register_events:
 
@@ -1829,4 +1855,6 @@ The plugin can then call ``datasette.track_event(...)`` to send a ``ban-user`` e
 
 .. code-block:: python
 
-    await datasette.track_event(BanUserEvent(user={"id": 1, "username": "cleverbot"}))
+    await datasette.track_event(
+        BanUserEvent(user={"id": 1, "username": "cleverbot"})
+    )

--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -1791,7 +1791,7 @@ The ``event`` object will always have the following properties:
 
 Other properties on the event will be available depending on the type of event. You can also access those as a dictionary using ``event.properties()``.
 
-**TODO: Link to documentation of default core events**
+The events fired by Datasette core are :ref:`documented here <events>`.
 
 This example plugin logs details of all events to standard error:
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -229,6 +229,15 @@ If you run ``datasette plugins --all`` it will include default plugins that ship
             ]
         },
         {
+            "name": "datasette.events",
+            "static": false,
+            "templates": false,
+            "version": null,
+            "hooks": [
+                "register_events"
+            ]
+        },
+        {
             "name": "datasette.facets",
             "static": false,
             "templates": false,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import re
 import subprocess
 import tempfile
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datasette import Event, hookimpl
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -786,7 +786,12 @@ async def test_threads_json(ds_client):
 @pytest.mark.asyncio
 async def test_plugins_json(ds_client):
     response = await ds_client.get("/-/plugins.json")
-    assert EXPECTED_PLUGINS == sorted(response.json(), key=lambda p: p["name"])
+    # Filter out TrackEventPlugin
+    actual_plugins = sorted(
+        [p for p in response.json() if p["name"] != "TrackEventPlugin"],
+        key=lambda p: p["name"],
+    )
+    assert EXPECTED_PLUGINS == actual_plugins
     # Try with ?all=1
     response = await ds_client.get("/-/plugins.json?all=1")
     names = {p["name"] for p in response.json()}

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -456,6 +456,14 @@ async def test_upsert(ds_write, initial, input, expected_rows, should_return):
     )
     assert response.status_code == 200
     assert response.json()["ok"] is True
+
+    # Analytics event
+    event = last_event(ds_write)
+    assert event.name == "upsert-rows"
+    assert event.num_rows == 1
+    assert event.database == "data"
+    assert event.table == "upsert_test"
+
     if should_return:
         # We only expect it to return rows corresponding to those we sent
         expected_returned_rows = expected_rows[: len(input["rows"])]

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -647,6 +647,13 @@ async def test_update_row(ds_write, input, expected_errors, use_return):
         for k, v in input.items():
             assert returned_row[k] == v
 
+    # Analytics event
+    event = last_event(ds_write)
+    assert event.actor == {"id": "root", "token": "dstok"}
+    assert event.database == "data"
+    assert event.table == "docs"
+    assert event.pks == [str(pk)]
+
     # And fetch the row to check it's updated
     response = await ds_write.client.get(
         "/data/docs/{}.json?_shape=array".format(pk),

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -1,5 +1,6 @@
 from datasette.app import Datasette
 from datasette.utils import sqlite3
+from .utils import last_event
 import pytest
 import time
 
@@ -1096,6 +1097,12 @@ async def test_create_table(ds_write, input, expected_status, expected_response)
     assert response.status_code == expected_status
     data = response.json()
     assert data == expected_response
+    # create-table event
+    if expected_status == 201:
+        event = last_event(ds_write)
+        assert event.name == "create-table"
+        assert event.actor == {"id": "root", "token": "dstok"}
+        assert event.schema.startswith("CREATE TABLE ")
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -567,6 +567,13 @@ async def test_delete_row(ds_write, table, row_for_create, pks, delete_path):
         headers=_headers(write_token(ds_write)),
     )
     assert delete_response.status_code == 200
+
+    # Analytics event
+    event = last_event(ds_write)
+    assert event.name == "delete-row"
+    assert event.database == "data"
+    assert event.table == table
+    assert event.pks == str(delete_path).split(",")
     assert (
         await ds_write.client.get(
             "/data.json?_shape=arrayfirst&sql=select+count(*)+from+{}".format(table)

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -677,6 +677,13 @@ async def test_drop_table(ds_write, scenario):
             headers=_headers(token),
         )
         assert response2.json() == {"ok": True}
+        # Check event
+        event = last_event(ds_write)
+        assert event.name == "drop-table"
+        assert event.actor == {"id": "root", "token": "dstok"}
+        assert event.table == "docs"
+        assert event.database == "data"
+        # Table should 404
         assert (await ds_write.client.get("/data/docs")).status_code == 404
 
 

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -50,6 +50,14 @@ async def test_insert_row(ds_write):
     assert response.json()["rows"] == [expected_row]
     rows = (await ds_write.get_database("data").execute("select * from docs")).rows
     assert dict(rows[0]) == expected_row
+    # Analytics event
+    event = last_event(ds_write)
+    assert event.name == "insert-rows"
+    assert event.num_rows == 1
+    assert event.database == "data"
+    assert event.table == "docs"
+    assert not event.ignore
+    assert not event.replace
 
 
 @pytest.mark.asyncio
@@ -69,6 +77,16 @@ async def test_insert_rows(ds_write, return_rows):
         headers=_headers(token),
     )
     assert response.status_code == 201
+
+    # Analytics event
+    event = last_event(ds_write)
+    assert event.name == "insert-rows"
+    assert event.num_rows == 20
+    assert event.database == "data"
+    assert event.table == "docs"
+    assert not event.ignore
+    assert not event.replace
+
     actual_rows = [
         dict(r)
         for r in (
@@ -354,6 +372,16 @@ async def test_insert_ignore_replace(
         headers=_headers(token),
     )
     assert response.status_code == 201
+
+    # Analytics event
+    event = last_event(ds_write)
+    assert event.name == "insert-rows"
+    assert event.num_rows == 1
+    assert event.database == "data"
+    assert event.table == "docs"
+    assert event.ignore == ignore
+    assert event.replace == replace
+
     actual_rows = [
         dict(r)
         for r in (

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -193,6 +193,13 @@ def test_auth_create_token(
         for error in errors:
             assert '<p class="message-error">{}</p>'.format(error) in response2.text
     else:
+        # Check create-token event
+        event = last_event(app_client.ds)
+        assert event.name == "create-token"
+        assert event.expires_after == expected_duration
+        assert isinstance(event.restrict_all, list)
+        assert isinstance(event.restrict_database, dict)
+        assert isinstance(event.restrict_resource, dict)
         # Extract token from page
         token = response2.text.split('value="dstok_')[1].split('"')[0]
         details = app_client.ds.unsign(token, "token")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,7 +100,11 @@ def test_spatialite_error_if_cannot_find_load_extension_spatialite():
 def test_plugins_cli(app_client):
     runner = CliRunner()
     result1 = runner.invoke(cli, ["plugins"])
-    assert json.loads(result1.output) == EXPECTED_PLUGINS
+    actual_plugins = sorted(
+        [p for p in json.loads(result1.output) if p["name"] != "TrackEventPlugin"],
+        key=lambda p: p["name"],
+    )
+    assert actual_plugins == EXPECTED_PLUGINS
     # Try with --all
     result2 = runner.invoke(cli, ["plugins", "--all"])
     names = [p["name"] for p in json.loads(result2.output)]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -19,6 +19,7 @@ from datasette.utils import CustomRow, StartupError
 from jinja2.environment import Template
 from jinja2 import ChoiceLoader, FileSystemLoader
 import base64
+import datetime
 import importlib
 import json
 import os
@@ -1446,12 +1447,18 @@ async def test_hook_track_event():
     from .conftest import TrackEventPlugin
 
     await datasette.invoke_startup()
-    await datasette.track_event(TrackEventPlugin.OneEvent(None, extra="extra extra"))
+    await datasette.track_event(
+        TrackEventPlugin.OneEvent(actor=None, extra="extra extra")
+    )
     assert len(datasette._tracked_events) == 1
     assert isinstance(datasette._tracked_events[0], TrackEventPlugin.OneEvent)
     event = datasette._tracked_events[0]
     assert event.name == "one"
     assert event.properties() == {"extra": "extra extra"}
+    # Should have a recent created as well
+    created = event.created
+    assert isinstance(created, datetime.datetime)
+    assert created.tzinfo == datetime.timezone.utc
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1459,7 +1459,7 @@ class TrackEventPlugin:
 
 
 @pytest.mark.asyncio
-async def test_track_event():
+async def test_hook_track_event():
     try:
         pm.register(TrackEventPlugin(), name="TrackEventPlugin")
         datasette = Datasette(memory=True)
@@ -1472,7 +1472,7 @@ async def test_track_event():
 
 
 @pytest.mark.asyncio
-async def test_register_events():
+async def test_hook_register_events():
     try:
         pm.register(TrackEventPlugin(), name="TrackEventPlugin")
         datasette = Datasette(memory=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,11 @@
 from datasette.utils.sqlite import sqlite3
 
 
+def last_event(datasette):
+    events = getattr(datasette, "_tracked_events", [])
+    return events[-1] if events else None
+
+
 def assert_footer_links(soup):
     footer_links = soup.find("footer").findAll("a")
     assert 4 == len(footer_links)


### PR DESCRIPTION
- #2240

TODO: Add instrumentation to the following:

- [x] Login (using the `/-/auth-token` mechanism, I think that's the only way to login in default Datasette)
- [x] Logout
- [x] Create an API token
- [x] API stuff
  - [x] Create a table
  - [x] Insert rows (tricky due to not necessarily knowing how many rows were inserted)
  - [x] Upsert rows
  - [x] Drop a table
  - [x] Update a row
  - [x] Delete a row
- [x] Tests for each of the instrumented events
- [x] Decide where and how timestamp is added to events
- [x] Plugin hook documentation
- [x] Plugin hook tests
- [x] Documentation of events in core
- [x] Documentation in internals for the `datasette.track_event()` method

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2242.org.readthedocs.build/en/2242/

<!-- readthedocs-preview datasette end -->