### PR TITLE
1.0a8 release notes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,14 @@ Configuration
   Previously plugins were configured in ``metadata.yaml``, which was confusing as plugin settings were unrelated to database and table metadata.
 - The ``-s/--setting`` option can now be used to set plugin configuration as well. See :ref:`configuration_cli` for details. (:issue:`2252`)
 
+  The above YAML configuration example using ``-s/--setting`` looks like this:
+  
+  .. code-block:: bash
+
+        datasette mydatabase.db \
+          -s plugins.datasette-cluster-map.latitude_column xlat \
+          -s plugins.datasette-cluster-map.longitude_column xlon
+
 Plugin hooks
 ~~~~~~~~~~~~
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,7 +42,7 @@ Configuration
 
 - The new ``/-/config`` page shows the current instance configuration, after redacting keys that could contain sensitive data such as API keys or passwords. (:issue:`2254`)
 
-- Existing Datasette installations may already have configuration set in ``metadata.yaml`` that should be migrated to ``datasette.yaml``. To avoid breaking these installations, Datasette will silently treat table and plugin configuration in metadata as if it had been specified in configuration. (:issue:`2247`)
+- Existing Datasette installations may already have configuration set in ``metadata.yaml`` that should be migrated to ``datasette.yaml``. To avoid breaking these installations, Datasette will silently treat table configuration, plugin configuration and allow blocks in metadata as if they had been specified in configuration instead. (:issue:`2247`) (:issue:`2248`) (:issue:`2249`)
 
 JavaScript plugins
 ~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,6 +40,8 @@ Configuration
           -s plugins.datasette-cluster-map.latitude_column xlat \
           -s plugins.datasette-cluster-map.longitude_column xlon
 
+- The new ``/-/config`` page shows the current instance configuration, after redacting keys that could contain sensitive data such as API keys or passwords. (:issue:`2254`)
+
 JavaScript plugins
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1233,7 +1233,7 @@ Also in this release:
 0.40 (2020-04-21)
 -----------------
 
-* Datasette :ref:`metadata` can now be provided as a YAML file as an optional alternative to JSON. See :ref:`metadata_yaml`. (:issue:`713`)
+* Datasette :ref:`metadata` can now be provided as a YAML file as an optional alternative to JSON. (:issue:`713`)
 * Removed support for ``datasette publish now``, which used the the now-retired Zeit Now v1 hosting platform. A new plugin, `datasette-publish-now <https://github.com/simonw/datasette-publish-now>`__, can be installed to publish data to Zeit (`now Vercel <https://vercel.com/blog/zeit-is-now-vercel>`__) Now v2. (:issue:`710`)
 * Fixed a bug where the ``extra_template_vars(request, view_name)`` plugin hook was not receiving the correct ``view_name``. (:issue:`716`)
 * Variables added to the template context by the ``extra_template_vars()`` plugin hook are now shown in the ``?_context=1`` debugging mode (see :ref:`setting_template_debug`). (:issue:`693`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,6 +42,8 @@ Configuration
 
 - The new ``/-/config`` page shows the current instance configuration, after redacting keys that could contain sensitive data such as API keys or passwords. (:issue:`2254`)
 
+- Existing Datasette installations may already have configuration set in ``metadata.yaml`` that should be migrated to ``datasette.yaml``. To avoid breaking these installations, Datasette will silently treat table and plugin configuration in metadata as if it had been specified in configuration. (:issue:`2247`)
+
 JavaScript plugins
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,6 +40,18 @@ Configuration
           -s plugins.datasette-cluster-map.latitude_column xlat \
           -s plugins.datasette-cluster-map.longitude_column xlon
 
+JavaScript plugins
+~~~~~~~~~~~~~~~~~~
+
+Datasette now includes a :ref:`JavaScript plugins mechanism <javascript_plugins>`, allowing JavaScript to customize Datasette in a way that can collaborate with other plugins.
+
+This provides two initial hooks, with more to come in the future:
+
+- :ref:`makeAboveTablePanelConfigs() <javascript_plugins_makeAboveTablePanelConfigs>` can add additional panels to the top of the table page.
+- :ref:`makeColumnActions() <javascript_plugins_makeColumnActions>` can add additional actions to the column menu.
+
+Thanks `Cameron Yick <https://github.com/hydrosquall>`__ for contributing this feature. (`#2052 <https://github.com/simonw/datasette/pull/2052>`__)
+
 Plugin hooks
 ~~~~~~~~~~~~
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,8 +31,8 @@ Documentation
 - Documentation on how to :ref:`register a plugin for the duration of a test <testing_plugins_register_in_test>`. (:issue:`2234`)
 - The :ref:`configuration documentation <configuration>` now shows examples of both YAML and JSON for each setting.
 
-Minor
-~~~~~
+Minor fixes
+~~~~~~~~~~~
 
 - Datasette no longer attempts to run SQL queries in parallel when rendering a table page, as this was leading to some rare crashing bugs. (:issue:`2189`)
 - Fixed warning: ``DeprecationWarning: pkg_resources is deprecated as an API`` (:issue:`2057`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,8 @@ Plugin hooks
 Documentation
 ~~~~~~~~~~~~~
 
+- Documentation describing :ref:`how to write tests that use signed actor cookies <testing_datasette_client>` using ``datasette.client.actor_cookie()``. (:issue:`1830`)
+- Documentation on how to :ref:`register a plugin for the duration of a test <testing_plugins_register_in_test>`. (:issue:`2234`)
 - The :ref:`configuration documentation <configuration>` now shows examples of both YAML and JSON for each setting.
 
 Minor
@@ -34,6 +36,7 @@ Minor
 
 - Datasette no longer attempts to run SQL queries in parallel when rendering a table page, as this was leading to some rare crashing bugs. (:issue:`2189`)
 - Fixed warning: ``DeprecationWarning: pkg_resources is deprecated as an API`` (:issue:`2057`)
+- Fixed bug where ``?_extra=columns`` parameter returned an incorrectly shaped response. (:issue:`2230`)
 
 .. _v0_64_6:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ Configuration
         datasette -c datasette.yaml
 
   Previously these lived in ``metadata.yaml``, which was confusing as plugin settings were unrelated to database and table metadata.
+- The ``-s/--setting`` option can now be used to set plugin configuration as well. See :ref:`configuration_cli` for details. (:issue:`2252`)
 
 Plugin hooks
 ~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,13 +14,22 @@ This alpha release continues the migration of Datasette's configuration from ``m
 Configuration
 ~~~~~~~~~~~~~
 
-- Plugin configs and various other :ref:`Datasette configuration <configuration>` now live in the ``datasette.yaml`` configuration file, passed to Datasette using the ``-c/--config`` option. Thanks, Alex Garcia. (:issue:`2093`)
+- Plugin configuration now lives in the :ref:`datasette.yaml configuration file <configuration>`, passed to Datasette using the ``-c/--config`` option. Thanks, Alex Garcia. (:issue:`2093`)
 
   .. code-block:: bash
 
         datasette -c datasette.yaml
 
-  Previously these lived in ``metadata.yaml``, which was confusing as plugin settings were unrelated to database and table metadata.
+  Where ``datasette.yaml`` contains configuration that looks like this:
+
+  .. code-block:: yaml
+
+        plugins:
+          datasette-cluster-map:
+            latitude_column: xlat
+            longitude_column: xlon
+
+  Previously plugins were configured in ``metadata.yaml``, which was confusing as plugin settings were unrelated to database and table metadata.
 - The ``-s/--setting`` option can now be used to set plugin configuration as well. See :ref:`configuration_cli` for details. (:issue:`2252`)
 
 Plugin hooks

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,23 @@
 Changelog
 =========
 
+.. _v1_0_a8:
+
+1.0a8 (2024-02-01)
+------------------
+
+- Plugin configs and various other :ref:`Datasette configuration <configuration>` now live in the ``datasette.yaml`` configuration file, passed to Datasette using the ``-c/--config`` option. Thanks, Alex Garcia. (:issue:`2093`)
+
+  .. code-block:: bash
+
+        datasette -c datasette.yaml
+
+  Previously these lived in ``metadata.yaml``, which was confusing as plugin settings were unrelated to database and table metadata.
+
+- The :ref:`configuration documentation <configuration>` now shows examples of both YAML and JSON for each setting.
+
+- Datasette no longer attempts to run SQL queries in parallel when rendering a table page, as this was leading to some rare crashing bugs. (:issue:`2189`)
+
 .. _v0_64_6:
 
 0.64.6 (2023-12-22)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,11 @@ Changelog
 1.0a8 (2024-02-01)
 ------------------
 
+This alpha release continues the migration of Datasette's configuration from ``metadata.yaml`` to the new ``datasette.yaml`` configuration file, and adds several new plugin hooks.
+
+Configuration
+~~~~~~~~~~~~~
+
 - Plugin configs and various other :ref:`Datasette configuration <configuration>` now live in the ``datasette.yaml`` configuration file, passed to Datasette using the ``-c/--config`` option. Thanks, Alex Garcia. (:issue:`2093`)
 
   .. code-block:: bash
@@ -22,6 +27,10 @@ Plugin hooks
 
 - New :ref:`plugin_hook_jinja2_environment_from_request` plugin hook, which can be used to customize the current Jinja environment based on the incoming request. This can be used to modify the template lookup path based on the incoming request hostname, among other things. (:issue:`2225`)
 - New :ref:`family of template slot plugin hooks <plugin_hook_slots>`: ``top_homepage``, ``top_database``, ``top_table``, ``top_row``, ``top_query``, ``top_canned_query``. Plugins can use these to provide additional HTML to be injected at the top of the corresponding pages. (:issue:`1191`)
+- New :ref:`track_event() mechanism <plugin_event_tracking>` for plugins to emit and receive events when certain events occur within Datasette. (:issue:`2240`)
+    - Plugins can register additional events using :ref:`plugin_hook_register_events`.
+    - They can then trigger those events with the :ref:`datasette.track_event(event) <datasette_track_event>` internal method.
+    - Plugins can subscribe to notifications of events using the :ref:`plugin_hook_track_event` plugin hook.
 - New internal function for plugin authors: :ref:`database_execute_isolated_fn`, for creating a new SQLite connection, executing code and then closing that connection, all while preventing other code from writing to that particular database. This connection will not have the :ref:`prepare_connection() <plugin_hook_prepare_connection>` plugin hook executed against it, allowing plugins to perform actions that might otherwise be blocked by existing connection configuration. (:issue:`2218`)
 
 Documentation

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,11 @@ Changelog
 
   Previously these lived in ``metadata.yaml``, which was confusing as plugin settings were unrelated to database and table metadata.
 
+Plugin hooks
+~~~~~~~~~~~~
+
+- New :ref:`plugin_hook_jinja2_environment_from_request` plugin hook, which can be used to customize the current Jinja environment based on the incoming request. This can be used to modify the template lookup path based on the incoming request hostname, among other things. (:issue:`2225`)
+- New :ref:`family of template slot plugin hooks <plugin_hook_slots>`: ``top_homepage``, ``top_database``, ``top_table``, ``top_row``, ``top_query``, ``top_canned_query``. Plugins can use these to provide additional HTML to be injected at the top of the corresponding pages. (:issue:`1191`)
 - New internal function for plugin authors: :ref:`database_execute_isolated_fn`, for creating a new SQLite connection, executing code and then closing that connection, all while preventing other code from writing to that particular database. This connection will not have the :ref:`prepare_connection() <plugin_hook_prepare_connection>` plugin hook executed against it, allowing plugins to perform actions that might otherwise be blocked by existing connection configuration. (:issue:`2218`)
 
 Documentation

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,7 +38,7 @@ Plugin hooks
 - New :ref:`plugin_hook_jinja2_environment_from_request` plugin hook, which can be used to customize the current Jinja environment based on the incoming request. This can be used to modify the template lookup path based on the incoming request hostname, among other things. (:issue:`2225`)
 - New :ref:`family of template slot plugin hooks <plugin_hook_slots>`: ``top_homepage``, ``top_database``, ``top_table``, ``top_row``, ``top_query``, ``top_canned_query``. Plugins can use these to provide additional HTML to be injected at the top of the corresponding pages. (:issue:`1191`)
 - New :ref:`track_event() mechanism <plugin_event_tracking>` for plugins to emit and receive events when certain events occur within Datasette. (:issue:`2240`)
-    - Plugins can register additional events using :ref:`plugin_hook_register_events`.
+    - Plugins can register additional event classes using :ref:`plugin_hook_register_events`.
     - They can then trigger those events with the :ref:`datasette.track_event(event) <datasette_track_event>` internal method.
     - Plugins can subscribe to notifications of events using the :ref:`plugin_hook_track_event` plugin hook.
 - New internal function for plugin authors: :ref:`database_execute_isolated_fn`, for creating a new SQLite connection, executing code and then closing that connection, all while preventing other code from writing to that particular database. This connection will not have the :ref:`prepare_connection() <plugin_hook_prepare_connection>` plugin hook executed against it, allowing plugins to perform actions that might otherwise be blocked by existing connection configuration. (:issue:`2218`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,9 +17,18 @@ Changelog
 
   Previously these lived in ``metadata.yaml``, which was confusing as plugin settings were unrelated to database and table metadata.
 
+- New internal function for plugin authors: :ref:`database_execute_isolated_fn`, for creating a new SQLite connection, executing code and then closing that connection, all while preventing other code from writing to that particular database. This connection will not have the :ref:`prepare_connection() <plugin_hook_prepare_connection>` plugin hook executed against it, allowing plugins to perform actions that might otherwise be blocked by existing connection configuration. (:issue:`2218`)
+
+Documentation
+~~~~~~~~~~~~~
+
 - The :ref:`configuration documentation <configuration>` now shows examples of both YAML and JSON for each setting.
 
+Minor
+~~~~~
+
 - Datasette no longer attempts to run SQL queries in parallel when rendering a table page, as this was leading to some rare crashing bugs. (:issue:`2189`)
+- Fixed warning: ``DeprecationWarning: pkg_resources is deprecated as an API`` (:issue:`2057`)
 
 .. _v0_64_6:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -5,7 +5,7 @@ Configuration
 
 Datasette offers several ways to configure your Datasette instances: server settings, plugin configuration, authentication, and more.
 
-Most configuration can be handled using a ``datasette.yaml`` configuration file, passed to datasette using the ``--config``/ ``-c`` flag:
+Most configuration can be handled using a ``datasette.yaml`` configuration file, passed to datasette using the ``-c/--config`` flag:
 
 .. code-block:: bash
 
@@ -13,12 +13,86 @@ Most configuration can be handled using a ``datasette.yaml`` configuration file,
 
 This file can also use JSON, as ``datasette.json``. YAML is recommended over JSON due to its support for comments and multi-line strings.
 
+.. _configuration_cli:
+
+Configuration via the command-line
+----------------------------------
+
+The recommended way to configure Datasette is using a ``datasette.yaml`` file passed to ``-c/--config``. You can also pass individual settings to Datasette using the ``-s/--setting`` option, which can be used multiple times:
+
+.. code-block:: bash
+
+    datasette mydatabase.db \
+      --setting settings.default_page_size 50 \
+      --setting settings.sql_time_limit_ms 3500
+
+This option takes dotted-notation for the first argument and a value for the second argument. This means you can use it to set any configuration value that would be valid in a ``datasette.yaml`` file.
+
+It also works for plugin configuration, for example for `datasette-cluster-map <https://datasette.io/plugins/datasette-cluster-map>`_:
+
+.. code-block:: bash
+
+    datasette mydatabase.db \
+      --setting plugins.datasette-cluster-map.latitude_column xlat \
+      --setting plugins.datasette-cluster-map.longitude_column xlon
+
+If the value you provide is a valid JSON object or list it will be treated as nested data, allowing you to configure plugins that accept lists such as `datasette-proxy-url <https://datasette.io/plugins/datasette-proxy-url>`_:
+
+.. code-block:: bash
+
+    datasette mydatabase.db \
+      -s plugins.datasette-proxy-url.paths '[{"path": "/proxy", "backend": "http://example.com/"}]'
+
+This is equivalent to a ``datasette.yaml`` file containing the following:
+
+.. [[[cog
+    from metadata_doc import config_example
+    import textwrap
+    config_example(cog, textwrap.dedent(
+      """
+      plugins:
+        datasette-proxy-url:
+          paths:
+          - path: /proxy
+            backend: http://example.com/
+      """).strip()
+      )
+.. ]]]
+
+.. tab:: datasette.yaml
+
+    .. code-block:: yaml
+
+        plugins:
+          datasette-proxy-url:
+            paths:
+            - path: /proxy
+              backend: http://example.com/
+
+.. tab:: datasette.json
+
+    .. code-block:: json
+
+        {
+          "plugins": {
+            "datasette-proxy-url": {
+              "paths": [
+                {
+                  "path": "/proxy",
+                  "backend": "http://example.com/"
+                }
+              ]
+            }
+          }
+        }
+.. [[[end]]]
+
 .. _configuration_reference:
 
 ``datasette.yaml`` reference
 ----------------------------
 
-This example shows many of the valid configuration options that can exist inside ``datasette.yaml``.
+The following example shows some of the valid configuration options that can exist inside ``datasette.yaml``.
 
 .. [[[cog
     from metadata_doc import config_example

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -53,7 +53,7 @@ Your ``metadata.yaml`` file can look something like this:
 .. [[[end]]]
 
 
-Choosing YAML over JSON adds support for multi-line strings and comments, see :ref:`metadata_yaml`.
+Choosing YAML over JSON adds support for multi-line strings and comments.
 
 The above metadata will be displayed on the index page of your Datasette-powered
 site. The source and license information will also be included in the footer of
@@ -663,33 +663,6 @@ SpatiaLite tables are automatically hidden) using ``"hidden": true``:
           }
         }
 .. [[[end]]]
-
-.. _metadata_yaml:
-
-Using YAML for metadata
------------------------
-
-Datasette accepts YAML as an alternative to JSON for your metadata configuration file.
-YAML is particularly useful for including multiline HTML and SQL strings, plus inline comments.
-
-Here's an example of a ``metadata.yml`` file, re-using an example from :ref:`canned_queries`.
-
-.. code-block:: yaml
-
-    title: Demonstrating Metadata from YAML
-    description_html: |-
-      <p>This description includes a long HTML string</p>
-      <ul>
-        <li>YAML is better for embedding HTML strings than JSON!</li>
-      </ul>
-    license: ODbL
-    license_url: https://opendatacommons.org/licenses/odbl/
-    databases:
-      fixtures:
-        tables:
-          no_primary_key:
-            hidden: true
-
 
 .. _metadata_reference:
 


### PR DESCRIPTION
Refs:
- #2243

https://github.com/simonw/datasette/compare/1.0a7...503545b20363ac15d3664bec7e6c4522ff271668

Preview: https://datasette--2251.org.readthedocs.build/en/2251/changelog.html

To cover:

- [x] Plugin configuration in `datasette.yml`
- [x] JSON/YAML examples in docs
- [x] No more parallel query execution
- [x] #2057
- [x] https://github.com/simonw/datasette/pull/2052
- [x] #2220 
- [x] #2214
- [x] #2225
- [x] #2230 
- [x] #1830
- [x] #2234
- [x] #1191
- [x] #2240

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2251.org.readthedocs.build/en/2251/

<!-- readthedocs-preview datasette end -->