### PR TITLE
Initial alter table support for the JSON API

### DIFF
--- a/datasette/default_permissions.py
+++ b/datasette/default_permissions.py
@@ -8,7 +8,6 @@ from typing import Union, Tuple
 @hookimpl
 def register_permissions():
     return (
-        # name, abbr, description, takes_database, takes_resource, default
         Permission(
             name="view-instance",
             abbr="vi",
@@ -110,6 +109,14 @@ def register_permissions():
             default=False,
         ),
         Permission(
+            name="alter-table",
+            abbr="at",
+            description="Alter tables",
+            takes_database=True,
+            takes_resource=True,
+            default=False,
+        ),
+        Permission(
             name="drop-table",
             abbr="dt",
             description="Drop tables",
@@ -129,6 +136,7 @@ def permission_allowed_default(datasette, actor, action, resource):
             "debug-menu",
             "insert-row",
             "create-table",
+            "alter-table",
             "drop-table",
             "delete-row",
             "update-row",

--- a/datasette/events.py
+++ b/datasette/events.py
@@ -109,6 +109,30 @@ class DropTableEvent(Event):
 
 
 @dataclass
+class AlterTableEvent(Event):
+    """
+    Event name: ``alter-table``
+
+    A table has been altered.
+
+    :ivar database: The name of the database where the table was altered
+    :type database: str
+    :ivar table: The name of the table that was altered
+    :type table: str
+    :ivar before_schema: The table's SQL schema before the alteration
+    :type before_schema: str
+    :ivar after_schema: The table's SQL schema after the alteration
+    :type after_schema: str
+    """
+
+    name = "alter-table"
+    database: str
+    table: str
+    before_schema: str
+    after_schema: str
+
+
+@dataclass
 class InsertRowsEvent(Event):
     """
     Event name: ``insert-rows``
@@ -203,6 +227,7 @@ def register_events():
         LogoutEvent,
         CreateTableEvent,
         CreateTokenEvent,
+        AlterTableEvent,
         DropTableEvent,
         InsertRowsEvent,
         UpsertRowsEvent,

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -1217,6 +1217,18 @@ Actor is allowed to create a database table.
 
 Default *deny*.
 
+.. _permissions_alter_table:
+
+alter-table
+-----------
+
+Actor is allowed to alter a database table.
+
+``resource`` - tuple: (string, string)
+    The name of the database, then the name of the table
+
+Default *deny*.
+
 .. _permissions_drop_table:
 
 drop-table

--- a/docs/json_api.rst
+++ b/docs/json_api.rst
@@ -787,6 +787,8 @@ The returned JSON will look like this:
 
 Any errors will return ``{"errors": ["... descriptive message ..."], "ok": false}``, and a ``400`` status code for a bad input or a ``403`` status code for an authentication or permission error.
 
+Pass ``"alter: true`` to automatically add any missing columns to the table. This requires the :ref:`permissions_alter_table` permission.
+
 .. _RowDeleteView:
 
 Deleting a row

--- a/docs/json_api.rst
+++ b/docs/json_api.rst
@@ -618,6 +618,8 @@ Pass ``"ignore": true`` to ignore these errors and insert the other rows:
 
 Or you can pass ``"replace": true`` to replace any rows with conflicting primary keys with the new values.
 
+Pass ``"alter: true`` to automatically add any missing columns to the table. This requires the :ref:`permissions_alter_table` permission.
+
 .. _TableUpsertView:
 
 Upserting rows
@@ -727,6 +729,8 @@ When using upsert you must provide the primary key column (or columns if the tab
     }
 
 If your table does not have an explicit primary key you should pass the SQLite ``rowid`` key instead.
+
+Pass ``"alter: true`` to automatically add any missing columns to the table. This requires the :ref:`permissions_alter_table` permission.
 
 .. _RowUpdateView:
 
@@ -849,7 +853,7 @@ The JSON here describes the table that will be created:
 * ``pks`` can be used instead of ``pk`` to create a compound primary key. It should be a JSON list of column names to use in that primary key.
 * ``ignore`` can be set to ``true`` to ignore existing rows by primary key if the table already exists.
 * ``replace`` can be set to ``true`` to replace existing rows by primary key if the table already exists.
-* ``alter`` can be set to ``true`` if you want to  automatically add any missing columns to the table. This requires the :ref:`permissions_alter_table` permission.
+* ``alter`` can be set to ``true`` if you want to automatically add any missing columns to the table. This requires the :ref:`permissions_alter_table` permission.
 
 If the table is successfully created this will return a ``201`` status code and the following response:
 

--- a/docs/json_api.rst
+++ b/docs/json_api.rst
@@ -834,19 +834,22 @@ To create a table, make a ``POST`` to ``/<database>/-/create``. This requires th
 
 The JSON here describes the table that will be created:
 
-*   ``table`` is the name of the table to create. This field is required.
-*   ``columns`` is a list of columns to create. Each column is a dictionary with ``name`` and ``type`` keys.
+* ``table`` is the name of the table to create. This field is required.
+* ``columns`` is a list of columns to create. Each column is a dictionary with ``name`` and ``type`` keys.
 
-    -   ``name`` is the name of the column. This is required.
-    -   ``type`` is the type of the column. This is optional - if not provided, ``text`` will be assumed. The valid types are ``text``, ``integer``, ``float`` and ``blob``.
+  - ``name`` is the name of the column. This is required.
+  - ``type`` is the type of the column. This is optional - if not provided, ``text`` will be assumed. The valid types are ``text``, ``integer``, ``float`` and ``blob``.
 
-*   ``pk`` is the primary key for the table. This is optional - if not provided, Datasette will create a SQLite table with a hidden ``rowid`` column.
+* ``pk`` is the primary key for the table. This is optional - if not provided, Datasette will create a SQLite table with a hidden ``rowid`` column.
 
-    If the primary key is an integer column, it will be configured to automatically increment for each new record.
+  If the primary key is an integer column, it will be configured to automatically increment for each new record.
 
-    If you set this to ``id`` without including an ``id`` column in the list of ``columns``, Datasette will create an integer ID column for you.
+  If you set this to ``id`` without including an ``id`` column in the list of ``columns``, Datasette will create an auto-incrementing integer ID column for you.
 
-*   ``pks`` can be used instead of ``pk`` to create a compound primary key. It should be a JSON list of column names to use in that primary key.
+* ``pks`` can be used instead of ``pk`` to create a compound primary key. It should be a JSON list of column names to use in that primary key.
+* ``ignore`` can be set to ``true`` to ignore existing rows by primary key if the table already exists.
+* ``replace`` can be set to ``true`` to replace existing rows by primary key if the table already exists.
+* ``alter`` can be set to ``true`` if you want to  automatically add any missing columns to the table. This requires the :ref:`permissions_alter_table` permission.
 
 If the table is successfully created this will return a ``201`` status code and the following response:
 
@@ -924,6 +927,8 @@ If you pass a row to the create endpoint with a primary key that already exists 
 You can avoid this error by passing the same ``"ignore": true`` or ``"replace": true`` options to the create endpoint as you can to the :ref:`insert endpoint <TableInsertView>`.
 
 To use the ``"replace": true`` option you will also need the :ref:`permissions_update_row` permission.
+
+Pass ``"alter": true`` to automatically add any missing columns to the existing table that are present in the rows you are submitting. This requires the :ref:`permissions_alter_table` permission.
 
 .. _TableDropView:
 

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -1377,7 +1377,7 @@ async def test_create_uses_alter_by_default_for_new_table(ds_write):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("has_alter_permission", (True,))  # False))
+@pytest.mark.parametrize("has_alter_permission", (True, False))
 async def test_create_using_alter_against_existing_table(
     ds_write, has_alter_permission
 ):

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -499,10 +499,14 @@ async def test_upsert(ds_write, initial, input, expected_rows, should_return):
 
     # Analytics event
     event = last_event(ds_write)
-    assert event.name == "upsert-rows"
-    assert event.num_rows == 1
     assert event.database == "data"
     assert event.table == "upsert_test"
+    if input.get("alter"):
+        assert event.name == "alter-table"
+        assert "extra" in event.after_schema
+    else:
+        assert event.name == "upsert-rows"
+        assert event.num_rows == 1
 
     if should_return:
         # We only expect it to return rows corresponding to those we sent

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -633,7 +633,7 @@ async def test_update_row_check_permission(ds_write, scenario):
 
     pk = await _insert_row(ds_write)
 
-    path = "/data/{}/{}/-/delete".format(
+    path = "/data/{}/{}/-/update".format(
         "docs" if scenario != "bad_table" else "bad_table", pk
     )
 


### PR DESCRIPTION
Refs:
- #2101

TODO:
- [x] Treat initial table creation as `alter: true` for `/-/create` with rows
- [x] Allow `"alter": true` for subsequent calls to `/-/create` if user has `alter-table` permission
- [x] Document the above
- [x] `"alter": true` support for `/db/table/-/insert`
- [x] `"alter": true` support for `/db/table/-/upsert`
- [x] `"alter": true` support for `/db/table/rowid/-/update`

📚 Documentation preview 📚: https://datasette--2261.org.readthedocs.build/en/2261/