### PR TITLE
Keep GitHub Actions up to date with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     python-packages:
       patterns:
         - "*"
+- package-ecosystem: github-actions
+  directory: /
+  groups:
+    github-actions:
+      patterns:
+        - "*"  # Group all Actions updates into a single larger pull request
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Autogenerates pull requests like
* https://github.com/pytest-dev/pytest-xdist/pull/1016

That will fix warnings like at the bottom right of https://github.com/simonw/datasette/actions/runs/7839526103

* https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2266.org.readthedocs.build/en/2266/

<!-- readthedocs-preview datasette end -->