### PR TITLE
fix (typo): Corrected spelling of 'environments'

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -24,3 +24,4 @@ jobs:
         codespell README.md --ignore-words docs/codespell-ignore-words.txt
         codespell docs/*.rst --ignore-words docs/codespell-ignore-words.txt
         codespell datasette -S datasette/static --ignore-words docs/codespell-ignore-words.txt
+        codespell tests --ignore-words docs/codespell-ignore-words.txt

--- a/Justfile
+++ b/Justfile
@@ -15,6 +15,7 @@ export DATASETTE_SECRET := "not_a_secret"
   pipenv run codespell README.md --ignore-words docs/codespell-ignore-words.txt
   pipenv run codespell docs/*.rst --ignore-words docs/codespell-ignore-words.txt
   pipenv run codespell datasette -S datasette/static --ignore-words docs/codespell-ignore-words.txt
+  pipenv run tests --ignore-words docs/codespell-ignore-words.txt
 
 # Run linters: black, flake8, mypy, cog
 @lint: codespell

--- a/docs/codespell-ignore-words.txt
+++ b/docs/codespell-ignore-words.txt
@@ -1,2 +1,5 @@
-ro
 alls
+fo
+ro
+te
+ths

--- a/tests/test-datasette-load-plugins.sh
+++ b/tests/test-datasette-load-plugins.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This should only run in environemnts where both
+# This should only run in environments where both
 # datasette-init and datasette-json-html are installed
 
 PLUGINS=$(datasette plugins)


### PR DESCRIPTION
I changed `environemnts`  to `environments` and added the `tests` folder to the [spellcheck GitHub workflow](https://github.com/simonw/datasette/blob/d3a1238109f8dfaca2d88a907a0045e00bef1a87/.github/workflows/spellcheck.yml#L27) and the [Justfile](https://github.com/simonw/datasette/blob/d3a1238109f8dfaca2d88a907a0045e00bef1a87/Justfile#L18) so that that typos in this folder can also be caught in the future.

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2268.org.readthedocs.build/en/2268/

<!-- readthedocs-preview datasette end -->