### PR TITLE
Add ETag header for static responses

### DIFF
--- a/datasette/utils/asgi.py
+++ b/datasette/utils/asgi.py
@@ -309,10 +309,14 @@ async def asgi_send_file(
 
 def asgi_static(root_path, chunk_size=4096, headers=None, content_type=None):
     root_path = Path(root_path)
-    headers = headers or {}
+    static_headers = {}
+
+    if headers:
+        static_headers = headers.copy()
 
     async def inner_static(request, send):
         path = request.scope["url_route"]["kwargs"]["path"]
+        headers = static_headers.copy()
         try:
             full_path = (root_path / path).resolve().absolute()
         except FileNotFoundError:

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -78,6 +78,10 @@ async def test_static(ds_client):
     response = await ds_client.get("/-/static/app.css")
     assert response.status_code == 200
     assert "text/css" == response.headers["content-type"]
+    assert "etag" in response.headers
+    etag = response.headers.get("etag")
+    response = await ds_client.get("/-/static/app.css", headers={"if-none-match": etag})
+    assert response.status_code == 304
 
 
 def test_static_mounts():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 Tests for various datasette helper functions.
 """
 
+from unittest import mock
 from datasette.app import Datasette
 from datasette import utils
 from datasette.utils.asgi import Request
@@ -706,3 +707,15 @@ def test_truncate_url(url, length, expected):
 def test_pairs_to_nested_config(pairs, expected):
     actual = utils.pairs_to_nested_config(pairs)
     assert actual == expected
+
+
+@pytest.mark.asyncio
+async def test_calculate_etag(tmp_path):
+    path = tmp_path / "test.txt"
+    path.write_text("hello")
+    etag = '"5d41402abc4b2a76b9719d911017c592"'
+    assert etag == await utils.calculate_etag(path)
+    assert utils._etag_cache[path] == etag
+    utils._etag_cache[path] = "hash"
+    assert "hash" == await utils.calculate_etag(path)
+    utils._etag_cache.clear()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@
 Tests for various datasette helper functions.
 """
 
-from unittest import mock
 from datasette.app import Datasette
 from datasette import utils
 from datasette.utils.asgi import Request


### PR DESCRIPTION
Related to https://github.com/simonw/datasette/issues/1645

This PR adds ETag headers for static responses. Adding cache-control headers was previously discussed but nothing done yet, so I've thought adding ETag headers would drastically reduce bandwidth meanwhile. Specially, when quickly deploying to Vercel or Fly, and you don't own a domain, required to add a CDN on front.

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2306.org.readthedocs.build/en/2306/

<!-- readthedocs-preview datasette end -->