### PR TITLE
bugfix: correctly detect json1 in versions.json

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -68,6 +68,7 @@ from .utils import (
     async_call_with_supported_arguments,
     await_me_maybe,
     call_with_supported_arguments,
+    detect_json1,
     display_actor,
     escape_css_string,
     escape_sqlite,
@@ -1102,9 +1103,8 @@ class Datasette:
         conn = sqlite3.connect(":memory:")
         self._prepare_connection(conn, "_memory")
         sqlite_version = conn.execute("select sqlite_version()").fetchone()[0]
-        sqlite_extensions = {}
+        sqlite_extensions = {"json1": detect_json1(conn)}
         for extension, testsql, hasversion in (
-            ("json1", "SELECT json('{}')", False),
             ("spatialite", "SELECT spatialite_version()", True),
         ):
             try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -818,6 +818,10 @@ async def test_versions_json(ds_client):
     assert "version" in data["sqlite"]
     assert "fts_versions" in data["sqlite"]
     assert "compile_options" in data["sqlite"]
+    # By default, the json1 extension is enabled in the SQLite 
+    # provided by the `ubuntu-latest` github actions runner, and 
+    # all versions of SQLite from 3.38.0 onwards
+    assert data["sqlite"]["extensions"]["json1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes simonw/datasette#2326

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2327.org.readthedocs.build/en/2327/

<!-- readthedocs-preview datasette end -->