### PR TITLE
Proposed code to fix issue #2198 finding the spatialite dll in Windows

### DIFF
--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -878,7 +878,7 @@ class LoadExtension(click.ParamType):
             path_entry = value.split(":", 2)
             if len(path_entry) < 3:
                 return value
-            #argument contains a Windows/DOS path and an entry point
+            # argument contains a Windows/DOS path and an entry point
             path = path_entry[0] + ":" + path_entry[1]
             entrypoint = path_entry[-1]
             return path, entrypoint

--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -873,6 +873,15 @@ class LoadExtension(click.ParamType):
     name = "path:entrypoint?"
 
     def convert(self, value, param, ctx):
+        #:\ indicates we're on a Windows machine study the argument a bit more
+        if ":\\" in r"%r" % value:
+            path_entry = value.split(":", 2)
+            if len(path_entry) < 3:
+                return value
+            #argument contains a Windows/DOS path and an entry point
+            path = path_entry[0] + ":" + path_entry[1]
+            entrypoint = path_entry[-1]
+            return path, entrypoint
         if ":" not in value:
             return value
         path, entrypoint = value.split(":", 1)

--- a/docs/spatialite.rst
+++ b/docs/spatialite.rst
@@ -70,6 +70,11 @@ Depending on your distribution, you should be able to run Datasette something li
 
 If you are unsure of the location of the module, try running ``locate mod_spatialite`` and see what comes back.
 
+Installing SpatiaLite on Windows
+-----------------------------
+
+For Windows, you may find binaries on the `Gaia-SINS <https://www.gaia-gis.it/gaia-sins/>`_ home page.
+
 Spatial indexing latitude/longitude columns
 ===========================================
 

--- a/tests/test_loadextension.py
+++ b/tests/test_loadextension.py
@@ -1,0 +1,28 @@
+from datasette.utils import LoadExtension
+
+def test_dos_path():
+    path_string = "C:\Windows\System32\mod_spatialite.dll"
+    le = LoadExtension()
+    path = le.convert(path_string, None, None)
+    assert path == "C:\Windows\System32\mod_spatialite.dll"
+    
+def test_dos_pathentry():
+    path_entry = "C:\Windows\System32\mod_spatialite.dll:testentry"
+    le = LoadExtension()
+    pathen, entry = le.convert(path_entry, None, None)
+    assert pathen == "C:\Windows\System32\mod_spatialite.dll"
+    assert entry == "testentry"
+    
+def test_linux_path():
+    path_string = "/base/test/test2"
+    le = LoadExtension()
+    path = le.convert(path_string, None, None)
+    assert path == path_string
+
+def test_linux_path_entry():
+    path_string = "/base/test/test2:testentry"
+    le = LoadExtension()
+    path, entry = le.convert(path_string, None, None)
+    assert path == "/base/test/test2"
+    assert entry == "testentry"
+    

--- a/tests/test_loadextension.py
+++ b/tests/test_loadextension.py
@@ -1,23 +1,27 @@
 from datasette.utils import LoadExtension
 
+
 def test_dos_path():
     path_string = "C:\Windows\System32\mod_spatialite.dll"
     le = LoadExtension()
     path = le.convert(path_string, None, None)
     assert path == "C:\Windows\System32\mod_spatialite.dll"
-    
+
+
 def test_dos_pathentry():
     path_entry = "C:\Windows\System32\mod_spatialite.dll:testentry"
     le = LoadExtension()
     pathen, entry = le.convert(path_entry, None, None)
     assert pathen == "C:\Windows\System32\mod_spatialite.dll"
     assert entry == "testentry"
-    
+
+
 def test_linux_path():
     path_string = "/base/test/test2"
     le = LoadExtension()
     path = le.convert(path_string, None, None)
     assert path == path_string
+
 
 def test_linux_path_entry():
     path_string = "/base/test/test2:testentry"
@@ -25,4 +29,3 @@ def test_linux_path_entry():
     path, entry = le.convert(path_string, None, None)
     assert path == "/base/test/test2"
     assert entry == "testentry"
-    


### PR DESCRIPTION
Code fix addressing #2198 . The pull request modifies datasette `/utils/__init__.py` by adding code to handle the presence of `:` characters in Windows\DOS paths. The proposed fix maintains handling of `:` separated entry points in both Windows and Linux. This is demonstrated by the added pytest test cases. Documentation has been modified to include a line about installing Spatialite on Windows taken [from](https://docs.djangoproject.com/en/5.0/ref/contrib/gis/install/spatialite/) the django documentation.

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2339.org.readthedocs.build/en/2339/

<!-- readthedocs-preview datasette end -->