### PR TITLE
Move Metadata to `--internal` database

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -707,7 +707,7 @@ class Datasette:
                 orig[key] = upd_value
         return orig
 
-    async def get_instance_metadata(self) -> dict[str, any]:
+    async def get_instance_metadata(self):
         rows = await self.get_internal_database().execute(
             """
               SELECT
@@ -718,7 +718,7 @@ class Datasette:
         )
         return dict(rows)
 
-    async def get_database_metadata(self, database_name: str) -> dict[str, any]:
+    async def get_database_metadata(self, database_name: str):
         rows = await self.get_internal_database().execute(
             """
               SELECT
@@ -731,9 +731,7 @@ class Datasette:
         )
         return dict(rows)
 
-    async def get_resource_metadata(
-        self, database_name: str, resource_name: str
-    ) -> dict[str, any]:
+    async def get_resource_metadata(self, database_name: str, resource_name: str):
         rows = await self.get_internal_database().execute(
             """
               SELECT
@@ -749,7 +747,7 @@ class Datasette:
 
     async def get_column_metadata(
         self, database_name: str, resource_name: str, column_name: str
-    ) -> dict[str, any]:
+    ):
         rows = await self.get_internal_database().execute(
             """
               SELECT

--- a/datasette/app.py
+++ b/datasette/app.py
@@ -482,9 +482,18 @@ class Datasette:
             if key == "databases":
                 continue
             await self.set_instance_metadata(key, self._metadata_local[key])
+
+        for dbname, db in self._metadata_local.get("databases", {}).items():
+            for key, value in db.items():
+                # TODO(alex) handle table metadata
+                if key == "tables":
+                    continue
+                await self.set_database_metadata(dbname, key, value)
             # else:
             #  self.set_database_metadata(database, key, value)
             #  self.set_database_metadata(database, key, value)
+            # TODO(alex) is metadata.json was loaded in, and --internal is not memory, then log
+            # a warning to user that they should delete their metadata.json file
 
     def get_jinja_environment(self, request: Request = None) -> Environment:
         environment = self._jinja_env
@@ -1509,8 +1518,6 @@ class Datasette:
         return redact_keys(
             self.config, ("secret", "key", "password", "token", "hash", "dsn")
         )
-    async def _metadata(self):
-        return {"lox": "lol"}
 
     def _routes(self):
         routes = []

--- a/datasette/default_menu_links.py
+++ b/datasette/default_menu_links.py
@@ -18,10 +18,6 @@ def menu_links(datasette, actor):
                 "label": "Version info",
             },
             {
-                "href": datasette.urls.path("/-/metadata"),
-                "label": "Metadata",
-            },
-            {
                 "href": datasette.urls.path("/-/settings"),
                 "label": "Settings",
             },

--- a/datasette/facets.py
+++ b/datasette/facets.py
@@ -98,13 +98,14 @@ class Facet:
         # [('_foo', 'bar'), ('_foo', '2'), ('empty', '')]
         return urllib.parse.parse_qsl(self.request.query_string, keep_blank_values=True)
 
-    def get_facet_size(self):
+    async def get_facet_size(self):
         facet_size = self.ds.setting("default_facet_size")
         max_returned_rows = self.ds.setting("max_returned_rows")
         table_facet_size = None
         if self.table:
-            tables_metadata = self.ds.metadata("tables", database=self.database) or {}
-            table_metadata = tables_metadata.get(self.table) or {}
+            table_metadata = await self.ds.get_resource_metadata(
+                self.database, self.table
+            )
             if table_metadata:
                 table_facet_size = table_metadata.get("facet_size")
         custom_facet_size = self.request.args.get("_facet_size")
@@ -158,7 +159,7 @@ class ColumnFacet(Facet):
     async def suggest(self):
         row_count = await self.get_row_count()
         columns = await self.get_columns(self.sql, self.params)
-        facet_size = self.get_facet_size()
+        facet_size = await self.get_facet_size()
         suggested_facets = []
         already_enabled = [c["config"]["simple"] for c in self.get_configs()]
         for column in columns:
@@ -212,7 +213,7 @@ class ColumnFacet(Facet):
 
         qs_pairs = self.get_querystring_pairs()
 
-        facet_size = self.get_facet_size()
+        facet_size = await self.get_facet_size()
         for source_and_config in self.get_configs():
             config = source_and_config["config"]
             source = source_and_config["source"]
@@ -371,7 +372,7 @@ class ArrayFacet(Facet):
         facet_results = []
         facets_timed_out = []
 
-        facet_size = self.get_facet_size()
+        facet_size = await self.get_facet_size()
         for source_and_config in self.get_configs():
             config = source_and_config["config"]
             source = source_and_config["source"]
@@ -503,7 +504,7 @@ class DateFacet(Facet):
         facet_results = []
         facets_timed_out = []
         args = dict(self.get_querystring_pairs())
-        facet_size = self.get_facet_size()
+        facet_size = await self.get_facet_size()
         for source_and_config in self.get_configs():
             config = source_and_config["config"]
             source = source_and_config["source"]

--- a/datasette/hookspecs.py
+++ b/datasette/hookspecs.py
@@ -11,11 +11,6 @@ def startup(datasette):
 
 
 @hookspec
-def get_metadata(datasette, key, database, table):
-    """Return metadata to be merged into Datasette's metadata dictionary"""
-
-
-@hookspec
 def asgi_wrapper(datasette):
     """Returns an ASGI middleware callable to wrap our ASGI application with"""
 

--- a/datasette/renderer.py
+++ b/datasette/renderer.py
@@ -56,7 +56,6 @@ def json_renderer(request, args, data, error, truncated=None):
 
     if truncated is not None:
         data["truncated"] = truncated
-
     if shape == "arrayfirst":
         if not data["rows"]:
             data = []

--- a/datasette/utils/internal_db.py
+++ b/datasette/utils/internal_db.py
@@ -63,6 +63,43 @@ async def init_internal_db(db):
     """
     ).strip()
     await db.execute_write_script(create_tables_sql)
+    await initialize_metadata_tables(db)
+
+
+async def initialize_metadata_tables(db):
+    await db.execute_write_script(
+        """
+              CREATE TABLE IF NOT EXISTS datasette_metadata_instance_entries(
+                key text,
+                value text,
+                unique(key)
+              );
+
+              CREATE TABLE IF NOT EXISTS datasette_metadata_database_entries(
+                database_name text,
+                key text,
+                value text,
+                unique(database_name, key)
+              );
+
+              CREATE TABLE IF NOT EXISTS datasette_metadata_resource_entries(
+                database_name text,
+                resource_name text,
+                key text,
+                value text,
+                unique(database_name, resource_name, key)
+              );
+
+              CREATE TABLE IF NOT EXISTS datasette_metadata_column_entries(
+                database_name text,
+                resource_name text,
+                column_name text,
+                key text,
+                value text,
+                unique(database_name, resource_name, column_name, key)
+              );
+            """
+    )
 
 
 async def populate_schema_tables(internal_db, db):

--- a/datasette/views/base.py
+++ b/datasette/views/base.py
@@ -274,10 +274,10 @@ class DataView(BaseView):
 
         end = time.perf_counter()
         data["query_ms"] = (end - start) * 1000
-        for key in ("source", "source_url", "license", "license_url"):
-            value = self.ds.metadata(key)
-            if value:
-                data[key] = value
+        # for key in ("source", "source_url", "license", "license_url"):
+        #    value = self.ds.metadata z(key)
+        #    if value:
+        #        data[key] = value
 
         # Special case for .jsono extension - redirect to _shape=objects
         if _format == "jsono":
@@ -385,7 +385,7 @@ class DataView(BaseView):
                 },
             }
             if "metadata" not in context:
-                context["metadata"] = self.ds.metadata()
+                context["metadata"] = {}
             r = await self.render(templates, request=request, context=context)
             if status_code is not None:
                 r.status = status_code

--- a/datasette/views/base.py
+++ b/datasette/views/base.py
@@ -385,7 +385,7 @@ class DataView(BaseView):
                 },
             }
             if "metadata" not in context:
-                context["metadata"] = {}
+                context["metadata"] = await self.ds.get_instance_metadata()
             r = await self.render(templates, request=request, context=context)
             if status_code is not None:
                 r.status = status_code

--- a/datasette/views/base.py
+++ b/datasette/views/base.py
@@ -274,10 +274,6 @@ class DataView(BaseView):
 
         end = time.perf_counter()
         data["query_ms"] = (end - start) * 1000
-        # for key in ("source", "source_url", "license", "license_url"):
-        #    value = self.ds.metadata z(key)
-        #    if value:
-        #        data[key] = value
 
         # Special case for .jsono extension - redirect to _shape=objects
         if _format == "jsono":

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -63,8 +63,7 @@ class DatabaseView(View):
         if format_ not in ("html", "json"):
             raise NotFound("Invalid format: {}".format(format_))
 
-        metadata = (datasette.metadata("databases") or {}).get(database, {})
-        datasette.update_with_inherited_metadata(metadata)
+        metadata = await datasette.get_database_metadata(database)
 
         sql_views = []
         for view_name in await db.view_names():
@@ -625,8 +624,7 @@ class QueryView(View):
                     )
                 }
             )
-            metadata = (datasette.metadata("databases") or {}).get(database, {})
-            datasette.update_with_inherited_metadata(metadata)
+            metadata = await datasette.get_database_metadata(database)
 
             renderers = {}
             for key, (_, can_render) in datasette.renderers.items():

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -130,6 +130,7 @@ class DatabaseView(View):
             "table_columns": (
                 await _table_columns(datasette, database) if allow_execute_sql else {}
             ),
+            "metadata": await datasette.get_database_metadata(database),
         }
 
         if format_ == "json":

--- a/datasette/views/index.py
+++ b/datasette/views/index.py
@@ -151,7 +151,7 @@ class IndexView(BaseView):
                 request=request,
                 context={
                     "databases": databases,
-                    "metadata": self.ds.metadata(),
+                    "metadata": {},
                     "datasette_version": __version__,
                     "private": not await self.ds.permission_allowed(
                         None, "view-instance"

--- a/datasette/views/index.py
+++ b/datasette/views/index.py
@@ -132,7 +132,13 @@ class IndexView(BaseView):
             if self.ds.cors:
                 add_cors_headers(headers)
             return Response(
-                json.dumps({db["name"]: db for db in databases}, cls=CustomJSONEncoder),
+                json.dumps(
+                    {
+                        "databases": {db["name"]: db for db in databases},
+                        "metadata": await self.ds.get_instance_metadata(),
+                    },
+                    cls=CustomJSONEncoder,
+                ),
                 content_type="application/json; charset=utf-8",
                 headers=headers,
             )
@@ -151,7 +157,7 @@ class IndexView(BaseView):
                 request=request,
                 context={
                     "databases": databases,
-                    "metadata": {},
+                    "metadata": await self.ds.get_instance_metadata(),
                     "datasette_version": __version__,
                     "private": not await self.ds.permission_allowed(
                         None, "view-instance"

--- a/datasette/views/row.py
+++ b/datasette/views/row.py
@@ -85,18 +85,7 @@ class RowView(DataView):
                     "_table.html",
                 ],
                 "row_actions": row_actions,
-                "metadata": (self.ds.metadata("databases") or {})
-                .get(database, {})
-                .get("tables", {})
-                .get(table, {}),
-                "top_row": make_slot_function(
-                    "top_row",
-                    self.ds,
-                    request,
-                    database=resolved.db.name,
-                    table=resolved.table,
-                    row=rows[0],
-                ),
+                "metadata": {},
             }
 
         data = {

--- a/datasette/views/row.py
+++ b/datasette/views/row.py
@@ -85,6 +85,14 @@ class RowView(DataView):
                     "_table.html",
                 ],
                 "row_actions": row_actions,
+                "top_row": make_slot_function(
+                    "top_row",
+                    self.ds,
+                    request,
+                    database=resolved.db.name,
+                    table=resolved.table,
+                    row=rows[0],
+                ),
                 "metadata": {},
             }
 

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -1492,7 +1492,22 @@ async def table_view_data(
 
     async def extra_metadata():
         "Metadata about the table and database"
-        return await datasette.get_resource_metadata(database_name, table_name)
+        tablemetadata = await datasette.get_resource_metadata(database_name, table_name)
+
+        rows = await datasette.get_internal_database().execute(
+            """
+              SELECT
+                column_name,
+                value
+              FROM datasette_metadata_column_entries
+              WHERE database_name = ?
+                AND resource_name = ?
+                AND key = 'description'
+            """,
+            [database_name, table_name],
+        )
+        tablemetadata["columns"] = dict(rows)
+        return tablemetadata
 
     async def extra_database():
         return database_name

--- a/docs/codespell-ignore-words.txt
+++ b/docs/codespell-ignore-words.txt
@@ -3,3 +3,4 @@ fo
 ro
 te
 ths
+notin

--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -2002,6 +2002,7 @@ This example logs events to a `datasette_events` table in a database called `eve
     from datasette import hookimpl
     import json
 
+
     @hookimpl
     def startup(datasette):
         async def inner():
@@ -2031,7 +2032,11 @@ This example logs events to a `datasette_events` table in a database called `eve
                 insert into datasette_events (event_type, created, actor, properties)
                 values (?, strftime('%Y-%m-%d %H:%M:%S', 'now'), ?, ?)
             """,
-                (event.name, json.dumps(event.actor), json.dumps(properties)),
+                (
+                    event.name,
+                    json.dumps(event.actor),
+                    json.dumps(properties),
+                ),
             )
 
         return inner

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -769,6 +769,7 @@ def test_databases_json(app_client_two_attached_databases_one_immutable):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="asdf")
 async def test_metadata_json(ds_client):
     response = await ds_client.get("/-/metadata.json")
     assert response.json() == ds_client.ds.metadata()
@@ -1083,6 +1084,7 @@ async def test_config_json(config, expected):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="rm?")
 @pytest.mark.parametrize(
     "metadata,expected_config,expected_metadata",
     (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,8 +29,19 @@ async def test_homepage(ds_client):
     assert response.status_code == 200
     assert "application/json; charset=utf-8" == response.headers["content-type"]
     data = response.json()
-    assert data.keys() == {"fixtures": 0}.keys()
-    d = data["fixtures"]
+    assert sorted(list(data.get("metadata").keys())) == [
+        "about",
+        "about_url",
+        "description_html",
+        "license",
+        "license_url",
+        "source",
+        "source_url",
+        "title",
+    ]
+    databases = data.get("databases")
+    assert databases.keys() == {"fixtures": 0}.keys()
+    d = databases["fixtures"]
     assert d["name"] == "fixtures"
     assert isinstance(d["tables_count"], int)
     assert isinstance(len(d["tables_and_views_truncated"]), int)
@@ -45,7 +56,8 @@ async def test_homepage_sort_by_relationships(ds_client):
     response = await ds_client.get("/.json?_sort=relationships")
     assert response.status_code == 200
     tables = [
-        t["name"] for t in response.json()["fixtures"]["tables_and_views_truncated"]
+        t["name"]
+        for t in response.json()["databases"]["fixtures"]["tables_and_views_truncated"]
     ]
     assert tables == [
         "simple_primary_key",
@@ -590,21 +602,24 @@ def test_no_files_uses_memory_database(app_client_no_files):
     response = app_client_no_files.get("/.json")
     assert response.status == 200
     assert {
-        "_memory": {
-            "name": "_memory",
-            "hash": None,
-            "color": "a6c7b9",
-            "path": "/_memory",
-            "tables_and_views_truncated": [],
-            "tables_and_views_more": False,
-            "tables_count": 0,
-            "table_rows_sum": 0,
-            "show_table_row_counts": False,
-            "hidden_table_rows_sum": 0,
-            "hidden_tables_count": 0,
-            "views_count": 0,
-            "private": False,
-        }
+        "databases": {
+            "_memory": {
+                "name": "_memory",
+                "hash": None,
+                "color": "a6c7b9",
+                "path": "/_memory",
+                "tables_and_views_truncated": [],
+                "tables_and_views_more": False,
+                "tables_count": 0,
+                "table_rows_sum": 0,
+                "show_table_row_counts": False,
+                "hidden_table_rows_sum": 0,
+                "hidden_tables_count": 0,
+                "views_count": 0,
+                "private": False,
+            },
+        },
+        "metadata": {},
     } == response.json
     # Try that SQL query
     response = app_client_no_files.get(
@@ -766,13 +781,6 @@ def test_databases_json(app_client_two_attached_databases_one_immutable):
     assert fixtures_database["hash"] is not None
     assert False == fixtures_database["is_mutable"]
     assert False == fixtures_database["is_memory"]
-
-
-@pytest.mark.asyncio
-@pytest.mark.skip(reason="asdf")
-async def test_metadata_json(ds_client):
-    response = await ds_client.get("/-/metadata.json")
-    assert response.json() == ds_client.ds.metadata()
 
 
 @pytest.mark.asyncio
@@ -1040,8 +1048,8 @@ async def test_tilde_encoded_database_names(db_name):
     ds = Datasette()
     ds.add_memory_database(db_name)
     response = await ds.client.get("/.json")
-    assert db_name in response.json().keys()
-    path = response.json()[db_name]["path"]
+    assert db_name in response.json()["databases"].keys()
+    path = response.json()["databases"][db_name]["path"]
     # And the JSON for that database
     response2 = await ds.client.get(path + ".json")
     assert response2.status_code == 200

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -159,8 +159,8 @@ def test_metadata_yaml():
         internal=None,
     )
     client = _TestClient(ds)
-    response = client.get("/-/metadata.json")
-    assert {"title": "Hello from YAML"} == response.json
+    response = client.get("/.json")
+    assert {"title": "Hello from YAML"} == response.json["metadata"]
 
 
 @mock.patch("datasette.cli.run_module")

--- a/tests/test_config_dir.py
+++ b/tests/test_config_dir.py
@@ -99,12 +99,6 @@ def config_dir_client(config_dir):
     yield _TestClient(ds)
 
 
-def test_metadata(config_dir_client):
-    response = config_dir_client.get("/-/metadata.json")
-    assert 200 == response.status
-    assert METADATA == response.json
-
-
 def test_settings(config_dir_client):
     response = config_dir_client.get("/-/settings.json")
     assert 200 == response.status
@@ -147,17 +141,6 @@ def test_databases(config_dir_client):
     for db, expected_name in zip(databases, ("demo", "immutable", "j", "k")):
         assert expected_name == db["name"]
         assert db["is_mutable"] == (expected_name != "immutable")
-
-
-@pytest.mark.parametrize("filename", ("metadata.yml", "metadata.yaml"))
-def test_metadata_yaml(tmp_path_factory, filename):
-    config_dir = tmp_path_factory.mktemp("yaml-config-dir")
-    (config_dir / filename).write_text("title: Title from metadata", "utf-8")
-    ds = Datasette([], config_dir=config_dir)
-    client = _TestClient(ds)
-    response = client.get("/-/metadata.json")
-    assert 200 == response.status
-    assert {"title": "Title from metadata"} == response.json
 
 
 def test_store_config_dir(config_dir_client):

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -584,9 +584,9 @@ async def test_facet_size():
     data5 = response5.json()
     assert len(data5["facet_results"]["results"]["city"]["results"]) == 20
     # Now try messing with facet_size in the table metadata
-    orig_metadata = ds._metadata_local
+    orig_config = ds.config
     try:
-        ds._metadata_local = {
+        ds.config = {
             "databases": {
                 "test_facet_size": {"tables": {"neighbourhoods": {"facet_size": 6}}}
             }
@@ -597,7 +597,7 @@ async def test_facet_size():
         data6 = response6.json()
         assert len(data6["facet_results"]["results"]["city"]["results"]) == 6
         # Setting it to max bumps it up to 50 again
-        ds._metadata_local["databases"]["test_facet_size"]["tables"]["neighbourhoods"][
+        ds.config["databases"]["test_facet_size"]["tables"]["neighbourhoods"][
             "facet_size"
         ] = "max"
         data7 = (
@@ -605,7 +605,7 @@ async def test_facet_size():
         ).json()
         assert len(data7["facet_results"]["results"]["city"]["results"]) == 20
     finally:
-        ds._metadata_local = orig_metadata
+        ds.config = orig_config
 
 
 def test_other_types_of_facet_in_metadata():
@@ -655,7 +655,6 @@ async def test_facet_against_in_memory_database():
     to_insert = [{"name": "one", "name2": "1"} for _ in range(800)] + [
         {"name": "two", "name2": "2"} for _ in range(300)
     ]
-    print(to_insert)
     await db.execute_write_many(
         "insert into t (name, name2) values (:name, :name2)", to_insert
     )

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -446,7 +446,7 @@ async def test_database_metadata(ds_client):
         soup.find("div", {"class": "metadata-description"})
     )
     # The source/license should be inherited
-    assert_footer_links(soup)
+    # assert_footer_links(soup) TODO(alex) ensure
 
 
 @pytest.mark.asyncio
@@ -459,7 +459,7 @@ async def test_database_metadata_with_custom_sql(ds_client):
     # Description should be custom
     assert "Custom SQL query returning" in soup.find("h3").text
     # The source/license should be inherited
-    assert_footer_links(soup)
+    # assert_footer_links(soup)TODO(alex) ensure
 
 
 def test_database_download_for_immutable():
@@ -753,14 +753,6 @@ async def test_blob_download_invalid_messages(ds_client, path, expected_message)
 
 
 @pytest.mark.asyncio
-async def test_metadata_json_html(ds_client):
-    response = await ds_client.get("/-/metadata")
-    assert response.status_code == 200
-    pre = Soup(response.content, "html.parser").find("pre")
-    assert ds_client.ds.metadata() == json.loads(pre.text)
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "path",
     [
@@ -931,7 +923,7 @@ def test_edit_sql_link_not_shown_if_user_lacks_permission(permission_allowed):
     [
         (None, None, None),
         ("test", None, ["/-/permissions"]),
-        ("root", ["/-/permissions", "/-/allow-debug", "/-/metadata"], None),
+        ("root", ["/-/permissions", "/-/allow-debug"], None),
     ],
 )
 async def test_navigation_menu_links(

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -453,7 +453,6 @@ def view_instance_client():
         "/",
         "/fixtures",
         "/fixtures/facetable",
-        "/-/metadata",
         "/-/versions",
         "/-/plugins",
         "/-/settings",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -43,7 +43,6 @@ def routes():
             "RowView",
             {"format": "json", "database": "foo", "pks": "1", "table": "humbug"},
         ),
-        ("/-/metadata", "JsonDataView", {"format": None}),
     ),
 )
 def test_routes(routes, path, expected_name, expected_matches):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -43,7 +43,6 @@ def routes():
             "RowView",
             {"format": "json", "database": "foo", "pks": "1", "table": "humbug"},
         ),
-        ("/-/metadata.json", "JsonDataView", {"format": "json"}),
         ("/-/metadata", "JsonDataView", {"format": None}),
     ),
 )

--- a/tests/test_table_html.py
+++ b/tests/test_table_html.py
@@ -792,8 +792,6 @@ async def test_table_metadata(ds_client):
     assert "Simple <em>primary</em> key" == inner_html(
         soup.find("div", {"class": "metadata-description"})
     )
-    # The source/license should be inherited
-    assert_footer_links(soup)
 
 
 @pytest.mark.asyncio
@@ -1101,8 +1099,8 @@ async def test_column_metadata(ds_client):
     soup = Soup(response.text, "html.parser")
     dl = soup.find("dl")
     assert [(dt.text, dt.nextSibling.text) for dt in dl.findAll("dt")] == [
-        ("name", "The name of the attraction"),
         ("address", "The street address for the attraction"),
+        ("name", "The name of the attraction"),
     ]
     assert (
         soup.select("th[data-column=name]")[0]["data-column-description"]


### PR DESCRIPTION
Work-in-progress, not ready for review. refs #2341 

- Removes `.metadata()` and `._metadata()` fields from the Datasette class
- Removes `/-/metadata.json` endpoint
- Removes metadata "fallback"
- Removes the `get_metadata()` hook
- Adds the following methods to Datasette:
  - `get_instance_metadata()`
  - `get_database_metadata()`
  - `get_resource_metadata()`
  - `get_column_metadata()`
  - `set_instance_metadata()`
  - `set_database_metadata()`
  - `set_resource_metadata()`
  - `set_column_metadata()`
- Adds the following tables to `internal.db`
  - `datasette_metadata_instance_entries`
  - `datasette_metadata_database_entries`
  - `datasette_metadata_resource_entries`
  - `datasette_metadata_column_entries`


## TODO
- [ ] Support `metadata.json`
- [ ] Don't change facet logic, move `facet_size` to synchronous config
- [ ] Docs!

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2343.org.readthedocs.build/en/2343/

<!-- readthedocs-preview datasette end -->