### PR TITLE
Introduce new `/$DB/-/query` endpoint, soft replaces `/$DB?sql=...`

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -37,7 +37,7 @@ from jinja2.exceptions import TemplateNotFound
 from .events import Event
 from .views import Context
 from .views.base import ureg
-from .views.database import database_download, DatabaseView, TableCreateView
+from .views.database import database_download, DatabaseView, TableCreateView, QueryView
 from .views.index import IndexView
 from .views.special import (
     JsonDataView,
@@ -1578,6 +1578,10 @@ class Datasette:
             r"/(?P<database>[^\/\.]+)(\.(?P<format>\w+))?$",
         )
         add_route(TableCreateView.as_view(self), r"/(?P<database>[^\/\.]+)/-/create$")
+        add_route(
+            wrap_view(QueryView, self),
+            r"/(?P<database>[^\/\.]+)/-/query(\.(?P<format>\w+))?$",
+        )
         add_route(
             wrap_view(table_view, self),
             r"/(?P<database>[^\/\.]+)/(?P<table>[^\/\.]+)(\.(?P<format>\w+))?$",

--- a/datasette/templates/database.html
+++ b/datasette/templates/database.html
@@ -21,7 +21,7 @@
 {% block description_source_license %}{% include "_description_source_license.html" %}{% endblock %}
 
 {% if allow_execute_sql %}
-    <form class="sql" action="{{ urls.database(database) }}" method="get">
+    <form class="sql" action="{{ urls.database(database) }}/-/query" method="get">
         <h3>Custom SQL query</h3>
         <p><textarea id="sql-editor" name="sql">{% if tables %}select * from {{ tables[0].name|escape_sqlite }}{% else %}select sqlite_version(){% endif %}</textarea></p>
         <p>
@@ -36,7 +36,7 @@
         <p>The following databases are attached to this connection, and can be used for cross-database joins:</p>
         <ul class="bullets">
             {% for db_name in attached_databases %}
-                <li><strong>{{ db_name }}</strong> - <a href="?sql=select+*+from+[{{ db_name }}].sqlite_master+where+type='table'">tables</a></li>
+                <li><strong>{{ db_name }}</strong> - <a href="{{ urls.database(db_name) }}/-/query?sql=select+*+from+[{{ db_name }}].sqlite_master+where+type='table'">tables</a></li>
             {% endfor %}
         </ul>
     </div>

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -58,6 +58,11 @@ class DatabaseView(View):
 
         sql = (request.args.get("sql") or "").strip()
         if sql:
+            redirect_url = "/" + request.url_vars.get("database") + "/-/query"
+            if request.url_vars.get("format"):
+                redirect_url += "." + request.url_vars.get("format")
+            redirect_url += "?" + request.query_string
+            return Response.redirect(redirect_url)
             return await QueryView()(request, datasette)
 
         if format_ not in ("html", "json"):
@@ -433,6 +438,8 @@ class QueryView(View):
     async def get(self, request, datasette):
         from datasette.app import TableNotFound
 
+        await datasette.refresh_schemas()
+
         db = await datasette.resolve_database(request)
         database = db.name
 
@@ -686,6 +693,7 @@ class QueryView(View):
             if allow_execute_sql and is_validated_sql and ":_" not in sql:
                 edit_sql_url = (
                     datasette.urls.database(database)
+                    + "/-/query"
                     + "?"
                     + urlencode(
                         {

--- a/docs/pages.rst
+++ b/docs/pages.rst
@@ -40,6 +40,12 @@ The JSON version of this page provides programmatic access to the underlying dat
 * `fivethirtyeight.datasettes.com/fivethirtyeight.json <https://fivethirtyeight.datasettes.com/fivethirtyeight.json>`_
 * `global-power-plants.datasettes.com/global-power-plants.json <https://global-power-plants.datasettes.com/global-power-plants.json>`_
 
+.. _QueryView:
+
+Queries
+========
+
+TODO
 .. _DatabaseView_hidden:
 
 Hidden tables

--- a/docs/pages.rst
+++ b/docs/pages.rst
@@ -40,12 +40,6 @@ The JSON version of this page provides programmatic access to the underlying dat
 * `fivethirtyeight.datasettes.com/fivethirtyeight.json <https://fivethirtyeight.datasettes.com/fivethirtyeight.json>`_
 * `global-power-plants.datasettes.com/global-power-plants.json <https://global-power-plants.datasettes.com/global-power-plants.json>`_
 
-.. _QueryView:
-
-Queries
-========
-
-TODO
 .. _DatabaseView_hidden:
 
 Hidden tables
@@ -60,6 +54,21 @@ The following tables are hidden by default:
 - ``*_fts`` tables that implement SQLite full-text search indexes.
 - Tables relating to the inner workings of the SpatiaLite SQLite extension.
 - ``sqlite_stat`` tables used to store statistics used by the query optimizer.
+
+.. _QueryView:
+
+Queries
+=======
+
+The ``/database-name/-/query`` page can be used to execute an arbitrary SQL query against that database, if the :ref:`permissions_execute_sql` permission is enabled. This query is passed as the ``?sql=`` query string parameter.
+
+This means you can link directly to a query by constructing the following URL:
+
+``/database-name/-/query?sql=SELECT+*+FROM+table_name``
+
+Each configured :ref:`canned query <canned_queries>` has its own page, at ``/database-name/query-name``. Viewing this page will execute the query and display the results.
+
+In both cases adding a ``.json`` extension to the URL will return the results as JSON.
 
 .. _TableView:
 

--- a/test-in-pyodide-with-shot-scraper.sh
+++ b/test-in-pyodide-with-shot-scraper.sh
@@ -40,7 +40,7 @@ async () => {
     import setuptools
     from datasette.app import Datasette
     ds = Datasette(memory=True, settings={'num_sql_threads': 0})
-    (await ds.client.get('/_memory.json?sql=select+55+as+itworks&_shape=array')).text
+    (await ds.client.get('/_memory/-/query.json?sql=select+55+as+itworks&_shape=array')).text
   \`);
   if (JSON.parse(output)[0].itworks != 55) {
     throw 'Got ' + output + ', expected itworks: 55';

--- a/tests/plugins/my_plugin.py
+++ b/tests/plugins/my_plugin.py
@@ -411,6 +411,7 @@ def query_actions(datasette, database, query_name, sql):
     return [
         {
             "href": datasette.urls.database(database)
+            + "/-/query"
             + "?"
             + urllib.parse.urlencode(
                 {

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -637,7 +637,9 @@ async def test_delete_row(ds_write, table, row_for_create, pks, delete_path):
     # Should be a single row
     assert (
         await ds_write.client.get(
-            "/data.json?_shape=arrayfirst&sql=select+count(*)+from+{}".format(table)
+            "/data/-/query.json?_shape=arrayfirst&sql=select+count(*)+from+{}".format(
+                table
+            )
         )
     ).json() == [1]
     # Now delete the row
@@ -645,7 +647,9 @@ async def test_delete_row(ds_write, table, row_for_create, pks, delete_path):
         # Special case for that rowid table
         delete_path = (
             await ds_write.client.get(
-                "/data.json?_shape=arrayfirst&sql=select+rowid+from+{}".format(table)
+                "/data/-/query.json?_shape=arrayfirst&sql=select+rowid+from+{}".format(
+                    table
+                )
             )
         ).json()[0]
 
@@ -663,7 +667,9 @@ async def test_delete_row(ds_write, table, row_for_create, pks, delete_path):
     assert event.pks == str(delete_path).split(",")
     assert (
         await ds_write.client.get(
-            "/data.json?_shape=arrayfirst&sql=select+count(*)+from+{}".format(table)
+            "/data/-/query.json?_shape=arrayfirst&sql=select+count(*)+from+{}".format(
+                table
+            )
         )
     ).json() == [0]
 

--- a/tests/test_canned_queries.py
+++ b/tests/test_canned_queries.py
@@ -412,7 +412,7 @@ def test_magic_parameters_csrf_json(magic_parameters_client, use_csrf, return_js
 
 def test_magic_parameters_cannot_be_used_in_arbitrary_queries(magic_parameters_client):
     response = magic_parameters_client.get(
-        "/data.json?sql=select+:_header_host&_shape=array"
+        "/data/-/query.json?sql=select+:_header_host&_shape=array"
     )
     assert 400 == response.status
     assert response.json["error"].startswith("You did not supply a value for binding")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -250,7 +250,7 @@ def test_plugin_s_overwrite():
             "--plugins-dir",
             plugins_dir,
             "--get",
-            "/_memory.json?sql=select+prepare_connection_args()",
+            "/_memory/-/query.json?sql=select+prepare_connection_args()",
         ],
     )
     assert result.exit_code == 0, result.output
@@ -265,7 +265,7 @@ def test_plugin_s_overwrite():
             "--plugins-dir",
             plugins_dir,
             "--get",
-            "/_memory.json?sql=select+prepare_connection_args()",
+            "/_memory/-/query.json?sql=select+prepare_connection_args()",
             "-s",
             "plugins.name-of-plugin",
             "OVERRIDE",
@@ -295,7 +295,7 @@ def test_setting_default_allow_sql(default_allow_sql):
             "default_allow_sql",
             "on" if default_allow_sql else "off",
             "--get",
-            "/_memory.json?sql=select+21&_shape=objects",
+            "/_memory/-/query.json?sql=select+21&_shape=objects",
         ],
     )
     if default_allow_sql:
@@ -309,7 +309,7 @@ def test_setting_default_allow_sql(default_allow_sql):
 
 def test_sql_errors_logged_to_stderr():
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(cli, ["--get", "/_memory.json?sql=select+blah"])
+    result = runner.invoke(cli, ["--get", "/_memory/-/query.json?sql=select+blah"])
     assert result.exit_code == 1
     assert "sql = 'select blah', params = {}: no such column: blah\n" in result.stderr
 

--- a/tests/test_cli_serve_get.py
+++ b/tests/test_cli_serve_get.py
@@ -31,7 +31,7 @@ def test_serve_with_get(tmp_path_factory):
             "--plugins-dir",
             str(plugins_dir),
             "--get",
-            "/_memory.json?sql=select+sqlite_version()",
+            "/_memory/-/query.json?sql=select+sqlite_version()",
         ],
     )
     assert result.exit_code == 0, result.output

--- a/tests/test_crossdb.py
+++ b/tests/test_crossdb.py
@@ -68,9 +68,10 @@ def test_crossdb_attached_database_list_display(
 ):
     app_client = app_client_two_attached_databases_crossdb_enabled
     response = app_client.get("/_memory")
+    response2 = app_client.get("/")
     for fragment in (
         "databases are attached to this connection",
         "<li><strong>fixtures</strong> - ",
-        "<li><strong>extra database</strong> - ",
+        '<li><strong>extra database</strong> - <a href="/extra+database/-/query?sql=',
     ):
         assert fragment in response.text

--- a/tests/test_crossdb.py
+++ b/tests/test_crossdb.py
@@ -25,7 +25,8 @@ def test_crossdb_join(app_client_two_attached_databases_crossdb_enabled):
       fixtures.searchable
     """
     response = app_client.get(
-        "/_memory.json?" + urllib.parse.urlencode({"sql": sql, "_shape": "array"})
+        "/_memory/-/query.json?"
+        + urllib.parse.urlencode({"sql": sql, "_shape": "array"})
     )
     assert response.status == 200
     assert response.json == [

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -146,14 +146,14 @@ async def test_table_csv_blob_columns(ds_client):
 @pytest.mark.asyncio
 async def test_custom_sql_csv_blob_columns(ds_client):
     response = await ds_client.get(
-        "/fixtures.csv?sql=select+rowid,+data+from+binary_data"
+        "/fixtures/-/query.csv?sql=select+rowid,+data+from+binary_data"
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/plain; charset=utf-8"
     assert response.text == (
         "rowid,data\r\n"
-        '1,"http://localhost/fixtures.blob?sql=select+rowid,+data+from+binary_data&_blob_column=data&_blob_hash=f3088978da8f9aea479ffc7f631370b968d2e855eeb172bea7f6c7a04262bb6d"\r\n'
-        '2,"http://localhost/fixtures.blob?sql=select+rowid,+data+from+binary_data&_blob_column=data&_blob_hash=b835b0483cedb86130b9a2c280880bf5fadc5318ddf8c18d0df5204d40df1724"\r\n'
+        '1,"http://localhost/fixtures/-/query.blob?sql=select+rowid,+data+from+binary_data&_blob_column=data&_blob_hash=f3088978da8f9aea479ffc7f631370b968d2e855eeb172bea7f6c7a04262bb6d"\r\n'
+        '2,"http://localhost/fixtures/-/query.blob?sql=select+rowid,+data+from+binary_data&_blob_column=data&_blob_hash=b835b0483cedb86130b9a2c280880bf5fadc5318ddf8c18d0df5204d40df1724"\r\n'
         "3,\r\n"
     )
 
@@ -161,7 +161,7 @@ async def test_custom_sql_csv_blob_columns(ds_client):
 @pytest.mark.asyncio
 async def test_custom_sql_csv(ds_client):
     response = await ds_client.get(
-        "/fixtures.csv?sql=select+content+from+simple_primary_key+limit+2"
+        "/fixtures/-/query.csv?sql=select+content+from+simple_primary_key+limit+2"
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/plain; charset=utf-8"
@@ -182,7 +182,7 @@ async def test_table_csv_download(ds_client):
 @pytest.mark.asyncio
 async def test_csv_with_non_ascii_characters(ds_client):
     response = await ds_client.get(
-        "/fixtures.csv?sql=select%0D%0A++%27%F0%9D%90%9C%F0%9D%90%A2%F0%9D%90%AD%F0%9D%90%A2%F0%9D%90%9E%F0%9D%90%AC%27+as+text%2C%0D%0A++1+as+number%0D%0Aunion%0D%0Aselect%0D%0A++%27bob%27+as+text%2C%0D%0A++2+as+number%0D%0Aorder+by%0D%0A++number"
+        "/fixtures/-/query.csv?sql=select%0D%0A++%27%F0%9D%90%9C%F0%9D%90%A2%F0%9D%90%AD%F0%9D%90%A2%F0%9D%90%9E%F0%9D%90%AC%27+as+text%2C%0D%0A++1+as+number%0D%0Aunion%0D%0Aselect%0D%0A++%27bob%27+as+text%2C%0D%0A++2+as+number%0D%0Aorder+by%0D%0A++number"
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/plain; charset=utf-8"

--- a/tests/test_load_extensions.py
+++ b/tests/test_load_extensions.py
@@ -25,15 +25,15 @@ async def test_load_extension_default_entrypoint():
     # should fail.
     ds = Datasette(sqlite_extensions=[COMPILED_EXTENSION_PATH])
 
-    response = await ds.client.get("/_memory.json?_shape=arrays&sql=select+a()")
+    response = await ds.client.get("/_memory/-/query.json?_shape=arrays&sql=select+a()")
     assert response.status_code == 200
     assert response.json()["rows"][0][0] == "a"
 
-    response = await ds.client.get("/_memory.json?_shape=arrays&sql=select+b()")
+    response = await ds.client.get("/_memory/-/query.json?_shape=arrays&sql=select+b()")
     assert response.status_code == 400
     assert response.json()["error"] == "no such function: b"
 
-    response = await ds.client.get("/_memory.json?_shape=arrays&sql=select+c()")
+    response = await ds.client.get("/_memory/-/query.json?_shape=arrays&sql=select+c()")
     assert response.status_code == 400
     assert response.json()["error"] == "no such function: c"
 
@@ -51,14 +51,14 @@ async def test_load_extension_multiple_entrypoints():
         ]
     )
 
-    response = await ds.client.get("/_memory.json?_shape=arrays&sql=select+a()")
+    response = await ds.client.get("/_memory/-/query.json?_shape=arrays&sql=select+a()")
     assert response.status_code == 200
     assert response.json()["rows"][0][0] == "a"
 
-    response = await ds.client.get("/_memory.json?_shape=arrays&sql=select+b()")
+    response = await ds.client.get("/_memory/-/query.json?_shape=arrays&sql=select+b()")
     assert response.status_code == 200
     assert response.json()["rows"][0][0] == "b"
 
-    response = await ds.client.get("/_memory.json?_shape=arrays&sql=select+c()")
+    response = await ds.client.get("/_memory/-/query.json?_shape=arrays&sql=select+c()")
     assert response.status_code == 200
     assert response.json()["rows"][0][0] == "c"

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -12,7 +12,7 @@ import pytest
     ],
 )
 async def test_add_message_sets_cookie(ds_client, qs, expected):
-    response = await ds_client.get(f"/fixtures.message?sql=select+1&{qs}")
+    response = await ds_client.get(f"/fixtures/-/query.message?sql=select+1&{qs}")
     signed = response.cookies["ds_messages"]
     decoded = ds_client.ds.unsign(signed, "messages")
     assert expected == decoded
@@ -22,7 +22,7 @@ async def test_add_message_sets_cookie(ds_client, qs, expected):
 async def test_messages_are_displayed_and_cleared(ds_client):
     # First set the message cookie
     set_msg_response = await ds_client.get(
-        "/fixtures.message?sql=select+1&add_msg=xmessagex"
+        "/fixtures/-/query.message?sql=select+1&add_msg=xmessagex"
     )
     # Now access a page that displays messages
     response = await ds_client.get("/", cookies=set_msg_response.cookies)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -268,7 +268,7 @@ def test_view_query(allow, expected_anon, expected_auth):
 def test_execute_sql(config):
     schema_re = re.compile("const schema = ({.*?});", re.DOTALL)
     with make_app_client(config=config) as client:
-        form_fragment = '<form class="sql" action="/fixtures"'
+        form_fragment = '<form class="sql" action="/fixtures/-/query"'
 
         # Anonymous users - should not display the form:
         anon_html = client.get("/fixtures").text

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -276,7 +276,7 @@ def test_execute_sql(config):
         # And const schema should be an empty object:
         assert "const schema = {};" in anon_html
         # This should 403:
-        assert client.get("/fixtures?sql=select+1").status == 403
+        assert client.get("/fixtures/-/query?sql=select+1").status == 403
         # ?_where= not allowed on tables:
         assert client.get("/fixtures/facet_cities?_where=id=3").status == 403
 
@@ -289,7 +289,7 @@ def test_execute_sql(config):
         assert set(schema["attraction_characteristic"]) == {"name", "pk"}
         assert schema["paginated_view"] == []
         assert form_fragment in response_text
-        query_response = client.get("/fixtures?sql=select+1", cookies=cookies)
+        query_response = client.get("/fixtures/-/query?sql=select+1", cookies=cookies)
         assert query_response.status == 200
         schema2 = json.loads(schema_re.search(query_response.text).group(1))
         assert set(schema2["attraction_characteristic"]) == {"name", "pk"}
@@ -337,7 +337,7 @@ def test_query_list_respects_view_query():
             ],
         ),
         (
-            "/fixtures?sql=select+1",
+            "/fixtures/-/query?sql=select+1",
             [
                 "view-instance",
                 ("view-database", "fixtures"),

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -95,7 +95,7 @@ async def test_db_with_route_databases(ds_with_route):
         ("/original-name/t", 404),
         ("/original-name/t/1", 404),
         ("/custom-route-name", 200),
-        ("/custom-route-name?sql=select+id+from+t", 200),
+        ("/custom-route-name/-/query?sql=select+id+from+t", 200),
         ("/custom-route-name/t", 200),
         ("/custom-route-name/t/1", 200),
     ),

--- a/tests/test_table_api.py
+++ b/tests/test_table_api.py
@@ -57,7 +57,7 @@ async def test_table_shape_arrays(ds_client):
 @pytest.mark.asyncio
 async def test_table_shape_arrayfirst(ds_client):
     response = await ds_client.get(
-        "/fixtures.json?"
+        "/fixtures/-/query.json?"
         + urllib.parse.urlencode(
             {
                 "sql": "select content from simple_primary_key order by id",
@@ -699,7 +699,7 @@ async def test_table_through(ds_client):
 @pytest.mark.asyncio
 async def test_max_returned_rows(ds_client):
     response = await ds_client.get(
-        "/fixtures.json?sql=select+content+from+no_primary_key"
+        "/fixtures/-query/.json?sql=select+content+from+no_primary_key"
     )
     data = response.json()
     assert data["truncated"]

--- a/tests/test_table_api.py
+++ b/tests/test_table_api.py
@@ -699,7 +699,7 @@ async def test_table_through(ds_client):
 @pytest.mark.asyncio
 async def test_max_returned_rows(ds_client):
     response = await ds_client.get(
-        "/fixtures/-query/.json?sql=select+content+from+no_primary_key"
+        "/fixtures/-/query.json?sql=select+content+from+no_primary_key"
     )
     data = response.json()
     assert data["truncated"]

--- a/tests/test_table_html.py
+++ b/tests/test_table_html.py
@@ -1199,7 +1199,9 @@ async def test_format_of_binary_links(size, title, length_bytes):
     expected = "{}>&lt;Binary:&nbsp;{}&nbsp;bytes&gt;</a>".format(title, length_bytes)
     assert expected in response.text
     # And test with arbitrary SQL query too
-    sql_response = await ds.client.get("{}/-/query".format(db_name), params={"sql": sql})
+    sql_response = await ds.client.get(
+        "{}/-/query".format(db_name), params={"sql": sql}
+    )
     assert sql_response.status_code == 200
     assert expected in sql_response.text
 

--- a/tests/test_table_html.py
+++ b/tests/test_table_html.py
@@ -1199,7 +1199,7 @@ async def test_format_of_binary_links(size, title, length_bytes):
     expected = "{}>&lt;Binary:&nbsp;{}&nbsp;bytes&gt;</a>".format(title, length_bytes)
     assert expected in response.text
     # And test with arbitrary SQL query too
-    sql_response = await ds.client.get("/{}".format(db_name), params={"sql": sql})
+    sql_response = await ds.client.get("{}/-/query".format(db_name), params={"sql": sql})
     assert sql_response.status_code == 200
     assert expected in sql_response.text
 


### PR DESCRIPTION
refs #2360 

This PR adds a new dedicated endpoint to querying a database in Datasette with SQL. Previously, one would use the `/dbname?sql=select...` convention to do this, but it shared the same endpoints as normal database. So this PR adds a dedicated `/dbname/-/query?sql=...` route specifically for this task. 

Old URLs that use the previous `/dbname?sql=...` endpoint will still work - we internally just redirect that to the new URL. 

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2363.org.readthedocs.build/en/2363/

<!-- readthedocs-preview datasette end -->