### PR TITLE
skip over "queries" blocks when processing database-level metadata items

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -454,7 +454,7 @@ class Datasette:
         # step 2: database-level metadata
         for dbname, db in self._metadata_local.get("databases", {}).items():
             for key, value in db.items():
-                if key == "tables":
+                if key in ("tables", "queries"):
                     continue
                 await self.set_database_metadata(dbname, key, value)
 

--- a/tests/test_internals_datasette.py
+++ b/tests/test_internals_datasette.py
@@ -178,7 +178,6 @@ async def test_get_permission(ds_client):
 @pytest.mark.asyncio
 async def test_apply_metadata_json():
     ds = Datasette(
-        memory=True,
         metadata={
             "databases": {
                 "legislators": {
@@ -194,4 +193,3 @@ async def test_apply_metadata_json():
     )
     await ds.invoke_startup()
     assert (await ds.client.get("/")).status_code == 200
-    # print(root)

--- a/tests/test_internals_datasette.py
+++ b/tests/test_internals_datasette.py
@@ -173,3 +173,25 @@ async def test_get_permission(ds_client):
     # And test KeyError
     with pytest.raises(KeyError):
         ds.get_permission("missing-permission")
+
+
+@pytest.mark.asyncio
+async def test_apply_metadata_json():
+    ds = Datasette(
+        memory=True,
+        metadata={
+            "databases": {
+                "legislators": {
+                    "tables": {"offices": {"summary": "office address or sumtin"}},
+                    "queries": {
+                        "millenntial_represetatives": {
+                            "summary": "Social media accounts for current legislators"
+                        }
+                    },
+                }
+            }
+        },
+    )
+    await ds.invoke_startup()
+    assert (await ds.client.get("/")).status_code == 200
+    # print(root)


### PR DESCRIPTION
Before metadata that looked like:

```yaml
databases:
  legislators:
    tables:
      offices:
        summary: office address or sumtin
    queries:
      millenntial_represetatives:
        summary: Social media accounts for current legislators

```

Would error with:

![image](https://github.com/user-attachments/assets/a6bcf088-13f5-4dc0-b0ca-508e22b5ed8a)


That's because when processing `databases.legislators` items, we skip over `tables` but not `queries`. We "skip" them because we processing them separately as "table-level" metadata items. 

Don't merge yet, want to test this more. Shouldn't we also have a block to process `queries` separately too? 

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2386.org.readthedocs.build/en/2386/

<!-- readthedocs-preview datasette end -->