### PR TITLE
don't hide virtual table, hide shadow tables.

### DIFF
--- a/datasette/database.py
+++ b/datasette/database.py
@@ -506,8 +506,8 @@ class Database:
                           OR substr(name, 1, 1) == '_'
                       ),
                       fts_suffixes AS (
-                        select column1 as suffix
-                        from (VALUES ('_data'), ('_idx'), ('_docsize'), ('_content'))
+                        SELECT column1 AS suffix
+                        FROM (VALUES ('_data'), ('_idx'), ('_docsize'), ('_content'), ('_config'))
                       ),
                       fts_names AS (
                         SELECT name
@@ -516,13 +516,17 @@ class Database:
                       ),
                       fts_shadow_tables AS (
                         SELECT
-                          printf('%s%s', fts_tables.name, fts_suffixes.suffix) AS name
+                          printf('%s%s', fts_names.name, fts_suffixes.suffix) AS name
                         FROM fts_names
                         JOIN fts_suffixes
+                      ),
+                      final AS (
+                        SELECT name FROM base
+                        UNION ALL
+                        SELECT name FROM fts_shadow_tables
                       )
-                      SELECT name FROM base
-                      UNION ALL
-                      SELECT name FROM fts_shadow_tables
+                      SELECT name FROM final ORDER BY 1
+
                     """
                 )
             ]

--- a/datasette/database.py
+++ b/datasette/database.py
@@ -509,21 +509,39 @@ class Database:
                         SELECT column1 AS suffix
                         FROM (VALUES ('_data'), ('_idx'), ('_docsize'), ('_content'), ('_config'))
                       ),
-                      fts_names AS (
+                      fts5_names AS (
                         SELECT name
                         FROM sqlite_master
                         WHERE sql LIKE '%VIRTUAL TABLE%USING FTS%'
                       ),
-                      fts_shadow_tables AS (
+                      fts5_shadow_tables AS (
                         SELECT
-                          printf('%s%s', fts_names.name, fts_suffixes.suffix) AS name
-                        FROM fts_names
+                          printf('%s%s', fts5_names.name, fts_suffixes.suffix) AS name
+                        FROM fts5_names
                         JOIN fts_suffixes
+                      ),
+                      fts3_suffixes AS (
+                        SELECT column1 AS suffix
+                        FROM (VALUES ('_content'), ('_segdir'), ('_segments'), ('_stat'), ('_docsize'))
+                      ),
+                      fts3_names AS (
+                        SELECT name
+                        FROM sqlite_master
+                        WHERE sql LIKE '%VIRTUAL TABLE%USING FTS3%'
+                          OR sql LIKE '%VIRTUAL TABLE%USING FTS4%'
+                      ),
+                      fts3_shadow_tables AS (
+                        SELECT
+                          printf('%s%s', fts3_names.name, fts3_suffixes.suffix) AS name
+                        FROM fts3_names
+                        JOIN fts3_suffixes
                       ),
                       final AS (
                         SELECT name FROM base
                         UNION ALL
-                        SELECT name FROM fts_shadow_tables
+                        SELECT name FROM fts5_shadow_tables
+                        UNION ALL
+                        SELECT name FROM fts3_shadow_tables
                       )
                       SELECT name FROM final ORDER BY 1
 

--- a/datasette/database.py
+++ b/datasette/database.py
@@ -499,13 +499,11 @@ class Database:
                 x[0]
                 for x in await self.execute(
                     """
-                      with final as (
-                        select name
-                        from sqlite_master
-                        WHERE  name in ('sqlite_stat1', 'sqlite_stat2', 'sqlite_stat3', 'sqlite_stat4')
-                          OR substr(name, 1, 1) == '_'
-                      ),
-                      select name from final order by 1
+                      SELECT name
+                      FROM sqlite_master
+                      WHERE  name IN ('sqlite_stat1', 'sqlite_stat2', 'sqlite_stat3', 'sqlite_stat4')
+                        OR substr(name, 1, 1) == '_'
+                      ORDER BY 1
                     """
                 )
             ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -390,6 +390,29 @@ async def test_database_page(ds_client):
             "private": False,
         },
         {
+            "name": "searchable_fts",
+            "columns": [
+                "text1",
+                "text2",
+                "name with . and spaces",
+            ]
+            + (
+                [
+                    "searchable_fts",
+                    "docid",
+                    "__langid",
+                ]
+                if supports_table_xinfo()
+                else []
+            ),
+            "primary_keys": [],
+            "count": 2,
+            "hidden": False,
+            "fts_table": "searchable_fts",
+            "foreign_keys": {"incoming": [], "outgoing": []},
+            "private": False,
+        },
+        {
             "name": "searchable_tags",
             "columns": ["searchable_id", "tag"],
             "primary_keys": ["searchable_id", "tag"],
@@ -522,29 +545,6 @@ async def test_database_page(ds_client):
             "count": 201,
             "hidden": True,
             "fts_table": None,
-            "foreign_keys": {"incoming": [], "outgoing": []},
-            "private": False,
-        },
-        {
-            "name": "searchable_fts",
-            "columns": [
-                "text1",
-                "text2",
-                "name with . and spaces",
-            ]
-            + (
-                [
-                    "searchable_fts",
-                    "docid",
-                    "__langid",
-                ]
-                if supports_table_xinfo()
-                else []
-            ),
-            "primary_keys": [],
-            "count": 2,
-            "hidden": True,
-            "fts_table": "searchable_fts",
             "foreign_keys": {"incoming": [], "outgoing": []},
             "private": False,
         },

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -39,13 +39,14 @@ def test_homepage(app_client_two_attached_databases):
     assert "extra database" == h2.text.strip()
     counts_p, links_p = h2.find_all_next("p")[:2]
     assert (
-        "2 rows in 1 table, 5 rows in 4 hidden tables, 1 view" == counts_p.text.strip()
+        "4 rows in 2 tables, 3 rows in 3 hidden tables, 1 view" == counts_p.text.strip()
     )
     # We should only show visible, not hidden tables here:
     table_links = [
         {"href": a["href"], "text": a.text.strip()} for a in links_p.findAll("a")
     ]
     assert [
+        {"href": r"/extra+database/searchable_fts", "text": "searchable_fts"},
         {"href": r"/extra+database/searchable", "text": "searchable"},
         {"href": r"/extra+database/searchable_view", "text": "searchable_view"},
     ] == table_links

--- a/tests/test_internals_database.py
+++ b/tests/test_internals_database.py
@@ -671,7 +671,9 @@ def pragma_table_list_supported():
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(not pragma_table_list_supported(), reason="Requires PRAGMA table_list support")
+@pytest.mark.skipif(
+    not pragma_table_list_supported(), reason="Requires PRAGMA table_list support"
+)
 async def test_hidden_tables(app_client):
     ds = app_client.ds
     db = ds.add_database(Database(ds, is_memory=True, is_mutable=True))

--- a/tests/test_internals_database.py
+++ b/tests/test_internals_database.py
@@ -664,3 +664,45 @@ async def test_in_memory_databases_forbid_writes(app_client):
     # Using db.execute_write() should work:
     await db.execute_write("create table foo (t text)")
     assert await db.table_names() == ["foo"]
+
+
+@pytest.mark.asyncio
+async def test_hidden_tables(app_client):
+    ds = app_client.ds
+    db = ds.add_database(Database(ds, is_memory=True, is_mutable=True))
+    assert await db.hidden_table_names() == []
+    await db.execute("create virtual table f using fts5(a)")
+    assert await db.hidden_table_names() == [
+       'f_config',
+       'f_content',
+       'f_data',
+       'f_docsize',
+       'f_idx',
+   ]
+
+    await db.execute("create virtual table r using rtree(id, amin, amax)")
+    assert await db.hidden_table_names() == [
+       'f_config',
+       'f_content',
+       'f_data',
+       'f_docsize',
+       'f_idx',
+       'r_node',
+       'r_parent',
+       'r_rowid'
+   ]
+
+    await db.execute("create table _hideme(_)")
+    assert await db.hidden_table_names() == [
+        '_hideme',
+       'f_config',
+       'f_content',
+       'f_data',
+       'f_docsize',
+       'f_idx',
+       'r_node',
+       'r_parent',
+       'r_rowid'
+   ]
+
+

--- a/tests/test_internals_database.py
+++ b/tests/test_internals_database.py
@@ -673,36 +673,34 @@ async def test_hidden_tables(app_client):
     assert await db.hidden_table_names() == []
     await db.execute("create virtual table f using fts5(a)")
     assert await db.hidden_table_names() == [
-       'f_config',
-       'f_content',
-       'f_data',
-       'f_docsize',
-       'f_idx',
-   ]
+        "f_config",
+        "f_content",
+        "f_data",
+        "f_docsize",
+        "f_idx",
+    ]
 
     await db.execute("create virtual table r using rtree(id, amin, amax)")
     assert await db.hidden_table_names() == [
-       'f_config',
-       'f_content',
-       'f_data',
-       'f_docsize',
-       'f_idx',
-       'r_node',
-       'r_parent',
-       'r_rowid'
-   ]
+        "f_config",
+        "f_content",
+        "f_data",
+        "f_docsize",
+        "f_idx",
+        "r_node",
+        "r_parent",
+        "r_rowid",
+    ]
 
     await db.execute("create table _hideme(_)")
     assert await db.hidden_table_names() == [
-        '_hideme',
-       'f_config',
-       'f_content',
-       'f_data',
-       'f_docsize',
-       'f_idx',
-       'r_node',
-       'r_parent',
-       'r_rowid'
-   ]
-
-
+        "_hideme",
+        "f_config",
+        "f_content",
+        "f_data",
+        "f_docsize",
+        "f_idx",
+        "r_node",
+        "r_parent",
+        "r_rowid",
+    ]

--- a/tests/test_internals_database.py
+++ b/tests/test_internals_database.py
@@ -4,7 +4,7 @@ Tests for the datasette.database.Database class
 
 from datasette.app import Datasette
 from datasette.database import Database, Results, MultipleValues
-from datasette.utils.sqlite import sqlite3
+from datasette.utils.sqlite import sqlite3, sqlite_version
 from datasette.utils import Column
 from .fixtures import app_client, app_client_two_attached_databases_crossdb_enabled
 import pytest
@@ -666,7 +666,12 @@ async def test_in_memory_databases_forbid_writes(app_client):
     assert await db.table_names() == ["foo"]
 
 
+def pragma_table_list_supported():
+    return sqlite_version()[1] >= 37
+
+
 @pytest.mark.asyncio
+@pytest.mark.skipif(not pragma_table_list_supported(), reason="Requires PRAGMA table_list support")
 async def test_hidden_tables(app_client):
     ds = app_client.ds
     db = ds.add_database(Database(ds, is_memory=True, is_mutable=True))


### PR DESCRIPTION
Closes #2296 

- Hide shadow tables by default
- Do NOT hide FTS5 virtual tables (but hide their shadow tables)


This will likely fail the SQLite 3.25 test

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2391.org.readthedocs.build/en/2391/

<!-- readthedocs-preview datasette end -->