### PR TITLE
Add DATASETTE_SSL_KEYFILE and DATASETTE_SSL_CERTFILE envvars

### DIFF
--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -468,10 +468,12 @@ def uninstall(packages, yes):
 @click.option(
     "--ssl-keyfile",
     help="SSL key file",
+    envvar="DATASETTE_SSL_KEYFILE",
 )
 @click.option(
     "--ssl-certfile",
     help="SSL certificate file",
+    envvar="DATASETTE_SSL_CERTFILE",
 )
 @click.option(
     "--internal",


### PR DESCRIPTION
For the `--ssl-keyfile` and `--ssl-certfile` flags

Closes #2422 

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2423.org.readthedocs.build/en/2423/

<!-- readthedocs-preview datasette end -->