### PR TITLE
fix: support static files with spaces in their names

### DIFF
--- a/datasette/utils/asgi.py
+++ b/datasette/utils/asgi.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 from datasette.utils import MultiParams, calculate_etag
 from mimetypes import guess_type
-from urllib.parse import parse_qs, urlunparse, parse_qsl
+from urllib.parse import parse_qs, urlunparse, parse_qsl, unquote
 from pathlib import Path
 from http.cookies import SimpleCookie, Morsel
 import aiofiles
@@ -318,7 +318,7 @@ def asgi_static(root_path, chunk_size=4096, headers=None, content_type=None):
         path = request.scope["url_route"]["kwargs"]["path"]
         headers = static_headers.copy()
         try:
-            full_path = (root_path / path).resolve().absolute()
+            full_path = (root_path / unquote(path)).resolve().absolute()
         except FileNotFoundError:
             await asgi_send_html(send, "404: Directory not found", 404)
             return

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -116,6 +116,14 @@ def test_static_mounts():
     ) as client:
         response = client.get("/custom-static/test_html.py")
         assert response.status_code == 200
+        response = client.get(
+            "/custom-static/test_templates/pages/nested/filename with spaces"
+        )
+        assert response.status_code == 200
+        response = client.get(
+            "/custom-static/test_templates/pages/topic_{topic}/{slug}.html"
+        )
+        assert response.status_code == 200
         response = client.get("/custom-static/not_exists.py")
         assert response.status_code == 404
         response = client.get("/custom-static/../LICENSE")


### PR DESCRIPTION
Browser encodes all non-ASCII characters in URL into percent encoding format.

Static files are served from the filesystem, and can have unsafe characters in their names.

To support such files the request `path` should be decoded.

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2450.org.readthedocs.build/en/2450/

<!-- readthedocs-preview datasette end -->