### PR TITLE
Use single-quotes in SQL string in `detect_spatialite()`, Fixes #2473

### DIFF
--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -586,7 +586,7 @@ def get_all_foreign_keys(conn):
 
 def detect_spatialite(conn):
     rows = conn.execute(
-        'select 1 from sqlite_master where tbl_name = "geometry_columns"'
+        "select 1 from sqlite_master where tbl_name = 'geometry_columns'"
     ).fetchall()
     return len(rows) > 0
 


### PR DESCRIPTION
Newer version of SQLite may reject strings that use double quotes, as seen in #2473 

Should also check other SQL in this codebase, but this solves the immediate issue

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2474.org.readthedocs.build/en/2474/

<!-- readthedocs-preview datasette end -->