### PR TITLE
fix: tilde encode database name in expanded foreign key links

### DIFF
--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -273,7 +273,7 @@ async def display_columns_and_rows(
                 link_template = LINK_WITH_LABEL if (label != value) else LINK_WITH_VALUE
                 display_value = markupsafe.Markup(
                     link_template.format(
-                        database=database_name,
+                        database=tilde_encode(database_name),
                         base_url=base_url,
                         table=tilde_encode(other_table),
                         link_id=tilde_encode(str(value)),

--- a/tests/test_table_html.py
+++ b/tests/test_table_html.py
@@ -3,6 +3,7 @@ from bs4 import BeautifulSoup as Soup
 from .fixtures import (  # noqa
     app_client,
     make_app_client,
+    app_client_with_dot,
 )
 import pathlib
 import pytest
@@ -1291,3 +1292,9 @@ async def test_foreign_key_labels_obey_permissions(config):
         "rows": [{"id": 1, "name": "world", "a_id": 1}],
         "truncated": False,
     }
+
+
+def test_foreign_keys_special_character_in_database_name(app_client_with_dot):
+    # https://github.com/simonw/datasette/pull/2476
+    response = app_client_with_dot.get("/fixtures~2Edot/complex_foreign_keys")
+    assert '<a href="/fixtures~2Edot/simple_primary_key/2">world</a>' in response.text


### PR DESCRIPTION
Hey, thanks for making this awesome program.  I'm just starting out with it.

For entirely self-inflicted reasons I have a database with a special character in the name and it works decently well except for autogenerated foreign key links; the links do not perform tilde encoding and thus don't work.

I'm not sure I have the best dev environment set up right now - tests don't run right.  Hopefully there's CI on the PR.
(Windows, python3.13, `pip install '.[test]'`...)
<details>
<summary>failing tests...</summary>
<img src=https://github.com/user-attachments/assets/eb495225-413b-4b08-96d6-18f9cafc0585 />

```
ERROR tests/test_canned_queries.py::test_canned_query_form_csrf_hidden_field[canned_read-False] - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\...
ERROR tests/test_canned_queries.py::test_insert_error - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\...
ERROR tests/test_canned_queries.py::test_canned_query_form_csrf_hidden_field[add_name_specify_id-True] - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\...
ERROR tests/test_canned_queries.py::test_on_success_message_sql - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\...
ERROR tests/test_canned_queries.py::test_canned_query_form_csrf_hidden_field[add_name-True] - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\...
ERROR tests/test_canned_queries.py::test_error_in_on_success_message_sql - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\...
ERROR tests/test_utils_check_callable.py::test_check_callable[str-True-False] - ExceptionGroup: errors while tearing down <Session  exitstatus=<ExitCode.OK: 0> testsfailed=19 testscollected=1461>...
ERROR tests/test_utils.py::test_named_parameters[True-select 1 + :one + :two-expected2] - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\...
ERROR tests/test_table_html.py::test_binary_data_display_in_table - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\...
ERROR tests/test_canned_queries.py::test_custom_params - PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\...
```

</details>

## Before:
![image](https://github.com/user-attachments/assets/bf504c8a-f260-466e-b15d-fa5f9b4acd60)

![image](https://github.com/user-attachments/assets/d5b3049e-2e5a-4d9b-ad88-b7a33229d9c3)

<hr>

## After:
![image](https://github.com/user-attachments/assets/f3dd29e2-b358-4773-a561-4fbb051020cc)

![image](https://github.com/user-attachments/assets/b02ee3a6-9676-452b-8de7-025073f50d1a)



<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2476.org.readthedocs.build/en/2476/

<!-- readthedocs-preview datasette end -->