### PR TITLE
Hide sqlite_sequence table by default

### DIFF
--- a/datasette/database.py
+++ b/datasette/database.py
@@ -502,6 +502,19 @@ class Database:
                 t for t in db_config["tables"] if db_config["tables"][t].get("hidden")
             ]
 
+        # Hide internal tables
+        hidden_tables += [
+            x[0]
+            for x in await self.execute(
+                """
+                  SELECT name
+                  FROM sqlite_master
+                  WHERE name IN ('sqlite_sequence')
+                  AND type = 'table'
+                """
+            )
+        ]
+
         if sqlite_version()[1] >= 37:
             hidden_tables += [
                 x[0]
@@ -605,7 +618,6 @@ class Database:
                 "spatial_ref_sys",
                 "spatialite_history",
                 "sql_statements_log",
-                "sqlite_sequence",
                 "views_geometry_columns",
                 "virts_geometry_columns",
                 "data_licenses",

--- a/tests/test_internals_database.py
+++ b/tests/test_internals_database.py
@@ -688,8 +688,15 @@ async def test_hidden_tables(app_client):
     ds = app_client.ds
     db = ds.add_database(Database(ds, is_memory=True, is_mutable=True))
     assert await db.hidden_table_names() == []
+
+    await db.execute("create table t (id integer primary key autoincrement)")
+    assert await db.hidden_table_names() == [
+        "sqlite_sequence",
+    ]
+
     await db.execute("create virtual table f using fts5(a)")
     assert await db.hidden_table_names() == [
+        "sqlite_sequence",
         "f_config",
         "f_content",
         "f_data",
@@ -699,6 +706,7 @@ async def test_hidden_tables(app_client):
 
     await db.execute("create virtual table r using rtree(id, amin, amax)")
     assert await db.hidden_table_names() == [
+        "sqlite_sequence",
         "f_config",
         "f_content",
         "f_data",
@@ -711,6 +719,7 @@ async def test_hidden_tables(app_client):
 
     await db.execute("create table _hideme(_)")
     assert await db.hidden_table_names() == [
+        "sqlite_sequence",
         "_hideme",
         "f_config",
         "f_content",
@@ -725,6 +734,7 @@ async def test_hidden_tables(app_client):
     # A fts virtual table with a content table should be hidden too
     await db.execute("create virtual table f2_fts using fts5(a, content='f')")
     assert await db.hidden_table_names() == [
+        "sqlite_sequence",
         "_hideme",
         "f2_fts_config",
         "f2_fts_data",


### PR DESCRIPTION
Previously, the `sqlite_sequence` table created for `AUTOINCREMENT` columns was only hidden when SpatiaLite is installed. Now it is hidden by default.

Closes: #2448

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2494.org.readthedocs.build/en/2494/

<!-- readthedocs-preview datasette end -->