### PR TITLE
feat: improve the github actions run and cancel in progress job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Test
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
This will allow the jobs to be canceled in case a new commit is made on a same branch where the jobs are already running. This is a good optimization to make the tests run on the latest commit, rather than running many jobs for every commit and push.



Authored-by: Vinit Kumar <mail@vinitkumar.me>

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2585.org.readthedocs.build/en/2585/

<!-- readthedocs-preview datasette end -->