### PR TITLE
Fixed hundreds of database connection closing warnings

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -1608,6 +1608,7 @@ class Datasette:
                     break
                 except importlib.metadata.PackageNotFoundError:
                     pass
+        conn.close()
         return info
 
     def _plugins(self, request=None, all=False):

--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -619,7 +619,9 @@ def serve(
     for file in file_paths:
         if not pathlib.Path(file).exists():
             if create:
-                sqlite3.connect(file).execute("vacuum")
+                conn = sqlite3.connect(file)
+                conn.execute("vacuum")
+                conn.close()
             else:
                 raise click.ClickException(
                     "Invalid value for '[FILES]...': Path '{}' does not exist.".format(

--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -671,13 +671,18 @@ def detect_fts_sql(table):
 
 
 def detect_json1(conn=None):
+    close_conn = False
     if conn is None:
         conn = sqlite3.connect(":memory:")
+        close_conn = True
     try:
         conn.execute("SELECT json('{}')")
         return True
     except Exception:
         return False
+    finally:
+        if close_conn:
+            conn.close()
 
 
 def table_columns(conn, table):

--- a/datasette/utils/sqlite.py
+++ b/datasette/utils/sqlite.py
@@ -20,15 +20,16 @@ def sqlite_version():
 
 
 def _sqlite_version():
-    return tuple(
-        map(
-            int,
-            sqlite3.connect(":memory:")
-            .execute("select sqlite_version()")
-            .fetchone()[0]
-            .split("."),
+    conn = sqlite3.connect(":memory:")
+    try:
+        return tuple(
+            map(
+                int,
+                conn.execute("select sqlite_version()").fetchone()[0].split("."),
+            )
         )
-    )
+    finally:
+        conn.close()
 
 
 def supports_table_xinfo():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,9 +90,10 @@ async def ds_client():
 
 
 def pytest_report_header(config):
-    return "SQLite: {}".format(
-        sqlite3.connect(":memory:").execute("select sqlite_version()").fetchone()[0]
-    )
+    conn = sqlite3.connect(":memory:")
+    version = conn.execute("select sqlite_version()").fetchone()[0]
+    conn.close()
+    return "SQLite: {}".format(version)
 
 
 def pytest_configure(config):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -188,6 +188,8 @@ def app_client():
 def app_client_no_files():
     ds = Datasette([])
     yield TestClient(ds)
+    for db in ds.databases.values():
+        db.close()
 
 
 @pytest.fixture(scope="session")
@@ -833,6 +835,7 @@ def cli(db_filename, config, metadata, plugins_path, recreate, extra_db_filename
     for sql, params in TABLE_PARAMETERIZED_SQL:
         with conn:
             conn.execute(sql, params)
+    conn.close()
     print(f"Test tables written to {db_filename}")
     if metadata:
         with open(metadata, "w") as fp:
@@ -861,6 +864,7 @@ def cli(db_filename, config, metadata, plugins_path, recreate, extra_db_filename
                 pathlib.Path(extra_db_filename).unlink()
         conn = sqlite3.connect(extra_db_filename)
         conn.executescript(EXTRA_DATABASE_SQL)
+        conn.close()
         print(f"Test tables written to {extra_db_filename}")
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -171,11 +171,15 @@ def make_app_client(
             crossdb=crossdb,
         )
         yield TestClient(ds)
-        # Close as many database connections as possible
-        # to try and avoid too many open files error
+        # Close all database connections first (while executor is still running)
+        # This allows db.close() to submit cleanup tasks to executor threads
         for db in ds.databases.values():
-            if not db.is_memory:
-                db.close()
+            db.close()
+        if hasattr(ds, "_internal_database"):
+            ds._internal_database.close()
+        # Then shut down executor
+        if ds.executor is not None:
+            ds.executor.shutdown(wait=True)
 
 
 @pytest.fixture(scope="session")
@@ -188,8 +192,14 @@ def app_client():
 def app_client_no_files():
     ds = Datasette([])
     yield TestClient(ds)
+    # Close databases first (while executor is still running)
     for db in ds.databases.values():
         db.close()
+    if hasattr(ds, "_internal_database"):
+        ds._internal_database.close()
+    # Then shut down executor
+    if ds.executor is not None:
+        ds.executor.shutdown(wait=True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -17,10 +17,11 @@ def ds_write(tmp_path_factory):
         db.execute(
             "create table docs (id integer primary key, title text, score float, age integer)"
         )
+    db1.close()
+    db2.close()
     ds = Datasette([db_path], immutables=[db_path_immutable])
     ds.root_enabled = True
     yield ds
-    db.close()
 
 
 def write_token(ds, actor_id="root", permissions=None):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -442,7 +442,9 @@ def test_serve_duplicate_database_names(tmpdir):
     nested.mkdir()
     db_2_path = str(tmpdir / "nested" / "db.db")
     for path in (db_1_path, db_2_path):
-        sqlite3.connect(path).execute("vacuum")
+        conn = sqlite3.connect(path)
+        conn.execute("vacuum")
+        conn.close()
     result = runner.invoke(cli, [db_1_path, db_2_path, "--get", "/-/databases.json"])
     assert result.exit_code == 0, result.output
     databases = json.loads(result.output)
@@ -456,7 +458,9 @@ def test_weird_database_names(tmpdir, filename):
     # https://github.com/simonw/datasette/issues/1181
     runner = CliRunner()
     db_path = str(tmpdir / filename)
-    sqlite3.connect(db_path).execute("vacuum")
+    conn = sqlite3.connect(db_path)
+    conn.execute("vacuum")
+    conn.close()
     result1 = runner.invoke(cli, [db_path, "--get", "/"])
     assert result1.exit_code == 0, result1.output
     filename_no_stem = filename.rsplit(".", 1)[0]
@@ -493,7 +497,9 @@ def test_duplicate_database_files_error(tmpdir):
     """Test that passing the same database file multiple times raises an error"""
     runner = CliRunner()
     db_path = str(tmpdir / "test.db")
-    sqlite3.connect(db_path).execute("vacuum")
+    conn = sqlite3.connect(db_path)
+    conn.execute("vacuum")
+    conn.close()
 
     # Test with exact duplicate
     result = runner.invoke(cli, ["serve", db_path, db_path, "--get", "/"])
@@ -512,7 +518,9 @@ def test_duplicate_database_files_error(tmpdir):
     config_dir = tmpdir / "config"
     config_dir.mkdir()
     config_db_path = str(config_dir / "data.db")
-    sqlite3.connect(config_db_path).execute("vacuum")
+    conn = sqlite3.connect(config_db_path)
+    conn.execute("vacuum")
+    conn.close()
 
     result3 = runner.invoke(
         cli, ["serve", config_db_path, str(config_dir), "--get", "/"]
@@ -523,7 +531,9 @@ def test_duplicate_database_files_error(tmpdir):
 
     # Test that mixing a file NOT in the directory with a directory works fine
     other_db_path = str(tmpdir / "other.db")
-    sqlite3.connect(other_db_path).execute("vacuum")
+    conn = sqlite3.connect(other_db_path)
+    conn.execute("vacuum")
+    conn.close()
 
     result4 = runner.invoke(
         cli, ["serve", other_db_path, str(config_dir), "--get", "/-/databases.json"]

--- a/tests/test_config_dir.py
+++ b/tests/test_config_dir.py
@@ -62,6 +62,7 @@ def config_dir(tmp_path_factory):
         ;
         """
         )
+        db.close()
 
     # Mark "immutable.db" as immutable
     (config_dir / "inspect-data.json").write_text(
@@ -97,6 +98,8 @@ def test_invalid_settings(config_dir):
 def config_dir_client(config_dir):
     ds = Datasette([], config_dir=config_dir)
     yield _TestClient(ds)
+    for db in ds.databases.values():
+        db.close()
 
 
 def test_settings(config_dir_client):

--- a/tests/test_config_dir.py
+++ b/tests/test_config_dir.py
@@ -100,6 +100,8 @@ def config_dir_client(config_dir):
     yield _TestClient(ds)
     for db in ds.databases.values():
         db.close()
+    if hasattr(ds, "_internal_database"):
+        ds._internal_database.close()
 
 
 def test_settings(config_dir_client):

--- a/tests/test_crossdb.py
+++ b/tests/test_crossdb.py
@@ -43,6 +43,7 @@ def test_crossdb_warning_if_too_many_databases(tmp_path_factory):
         path = str(db_dir / "db_{}.db".format(i))
         conn = sqlite3.connect(path)
         conn.execute("vacuum")
+        conn.close()
         dbs.append(path)
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_docs_plugins.py
+++ b/tests/test_docs_plugins.py
@@ -23,6 +23,14 @@ async def datasette_with_plugin():
         yield datasette
     finally:
         datasette.pm.unregister(name="undo")
+        # Close databases first (while executor is still running)
+        for db in datasette.databases.values():
+            db.close()
+        if hasattr(datasette, "_internal_database"):
+            datasette._internal_database.close()
+        # Then shut down executor
+        if datasette.executor is not None:
+            datasette.executor.shutdown(wait=True)
 # -- end datasette_with_plugin_fixture --
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -378,9 +378,9 @@ def test_plugins_async_template_function(restore_working_directory):
             .select("pre.extra_from_awaitable_function")[0]
             .text
         )
-        expected = (
-            sqlite3.connect(":memory:").execute("select sqlite_version()").fetchone()[0]
-        )
+        conn = sqlite3.connect(":memory:")
+        expected = conn.execute("select sqlite_version()").fetchone()[0]
+        conn.close()
         assert expected == extra_from_awaitable_function
 
 
@@ -424,6 +424,7 @@ def view_names_client(tmp_path_factory):
     db_path = str(tmpdir / "fixtures.db")
     conn = sqlite3.connect(db_path)
     conn.executescript(TABLES)
+    conn.close()
     return _TestClient(
         Datasette([db_path], template_dir=str(templates), plugins_dir=str(plugins))
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -210,6 +210,7 @@ def test_detect_fts(open_quote, close_quote):
     assert None is utils.detect_fts(conn, "Test_View")
     assert None is utils.detect_fts(conn, "r")
     assert "Street_Tree_List_fts" == utils.detect_fts(conn, "Street_Tree_List")
+    conn.close()
 
 
 @pytest.mark.parametrize("table", ("regular", "has'single quote"))
@@ -226,6 +227,7 @@ def test_detect_fts_different_table_names(table):
     conn = utils.sqlite3.connect(":memory:")
     conn.executescript(sql)
     assert "{table}_fts".format(table=table) == utils.detect_fts(conn, table)
+    conn.close()
 
 
 @pytest.mark.parametrize(
@@ -369,6 +371,7 @@ def test_table_columns():
     """
     )
     assert ["id", "name", "bob"] == utils.table_columns(conn, "places")
+    conn.close()
 
 
 @pytest.mark.parametrize(
@@ -443,11 +446,13 @@ def test_check_connection_spatialite_raises():
     conn = sqlite3.connect(path)
     with pytest.raises(utils.SpatialiteConnectionProblem):
         utils.check_connection(conn)
+    conn.close()
 
 
 def test_check_connection_passes():
     conn = sqlite3.connect(":memory:")
     utils.check_connection(conn)
+    conn.close()
 
 
 def test_call_with_supported_arguments():
@@ -574,10 +579,14 @@ def test_display_actor(actor, expected):
 async def test_initial_path_for_datasette(tmp_path_factory, dbs, expected_path):
     db_dir = tmp_path_factory.mktemp("dbs")
     one_table = str(db_dir / "one.db")
-    sqlite3.connect(one_table).execute("create table one (id integer primary key)")
+    conn1 = sqlite3.connect(one_table)
+    conn1.execute("create table one (id integer primary key)")
+    conn1.close()
     two_tables = str(db_dir / "two.db")
-    sqlite3.connect(two_tables).execute("create table two (id integer primary key)")
-    sqlite3.connect(two_tables).execute("create table three (id integer primary key)")
+    conn2 = sqlite3.connect(two_tables)
+    conn2.execute("create table two (id integer primary key)")
+    conn2.execute("create table three (id integer primary key)")
+    conn2.close()
     datasette = Datasette(
         [{"one_table": one_table, "two_tables": two_tables}[db] for db in dbs]
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,7 +34,9 @@ def inner_html(soup):
 
 def has_load_extension():
     conn = sqlite3.connect(":memory:")
-    return hasattr(conn, "enable_load_extension")
+    result = hasattr(conn, "enable_load_extension")
+    conn.close()
+    return result
 
 
 def cookie_was_deleted(response, cookie):


### PR DESCRIPTION
From 409 warnings down to 52 warnings.

Claude Code says: https://gistpreview.github.io/?69d2ce58f09fdd8463e384cc1ebee4cf

Fixed connection leaks in:
1. datasette/utils/sqlite.py - _sqlite_version() now closes connection
2. datasette/cli.py - --create flag now closes connection
3. datasette/app.py - _versions() now closes connection
4. datasette/utils/__init__.py - detect_json1() now closes connection when created internally
5. tests/conftest.py - pytest_report_header() now closes connection
6. tests/utils.py - has_load_extension() now closes connection
7. tests/fixtures.py - app_client_no_files and CLI fixtures now close connections
8. tests/test_api_write.py - ds_write fixture closes both connections
9. tests/test_cli.py - Multiple test functions now close connections
10. tests/test_config_dir.py - config_dir and config_dir_client fixtures now close connections
11. tests/test_crossdb.py - Loop connections now closed
12. tests/test_internals_database.py - Test setup connections now closed
13. tests/test_plugins.py - view_names_client fixture and test now close connections
14. tests/test_utils.py - Multiple test functions now close connections

Refs:
- #2614

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2615.org.readthedocs.build/en/2615/

<!-- readthedocs-preview datasette end -->