### PR TITLE
Fix filter-input and search-input zoom on iOS Safari  Fixes#2346

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ node_modules
 tests/*.dylib
 tests/*.so
 tests/*.dll
+
+.idea

--- a/datasette/static/app.css
+++ b/datasette/static/app.css
@@ -647,8 +647,12 @@ button.core[type=button] {
     border-radius: 3px;
     -webkit-appearance: none;
     padding: 9px 4px;
-    font-size: 1em;
+    font-size: 16px;
     font-family: Helvetica, sans-serif;
+}
+
+#_search {
+    font-size: 16px;
 }
 
 


### PR DESCRIPTION
Fixed auto zoom in Safari by changing font-size from 1em to 16px for input.filter-value and by styling #_search as well

lines 645 to 656 in static/app.css
.filters input.filter-value {
    width: 200px;
    border-radius: 3px;
    -webkit-appearance: none;
    padding: 9px 4px;
    font-size: 16px;
    font-family: Helvetica, sans-serif;
}

#_search {
    font-size: 16px;
}


<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2631.org.readthedocs.build/en/2631/

<!-- readthedocs-preview datasette end -->