### PR TITLE
Add ultra-quickstart section to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ Datasette is aimed at data journalists, museum curators, archivists, local gover
 
 [Explore a demo](https://datasette.io/global-power-plants/global-power-plants), watch [a video about the project](https://simonwillison.net/2021/Feb/7/video/) or try it out [on GitHub Codespaces](https://github.com/datasette/datasette-studio).
 
+## Ultra-quickstart
+
+The fastest way to get started with Datasette if you have Python installed:
+
+```bash
+# Install with uv (recommended) or pip
+uv tool install datasette
+# Or: pip install datasette
+
+# Serve a SQLite database
+datasette my_database.db
+
+# Or try it with a demo database
+datasette https://datasette.io/fixtures.db
+```
+
+Then visit http://localhost:8001 to explore your data. See [Getting started](https://docs.datasette.io/en/stable/getting_started.html) for more.
+
 * [datasette.io](https://datasette.io/) is the official project website
 * Latest [Datasette News](https://datasette.io/news)
 * Comprehensive documentation: https://docs.datasette.io/

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,6 +1,16 @@
 Getting started
 ===============
 
+Ultra-quickstart
+----------------
+
+Just want to get going? If you have Python installed::
+
+    uv tool install datasette  # or: pip install datasette
+    datasette my_database.db
+
+Then visit http://localhost:8001/ to explore your data.
+
 .. _getting_started_demo:
 
 Play with a live demo

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,6 +17,23 @@ If you want to start making contributions to the Datasette project by installing
 Basic installation
 ==================
 
+.. _installation_uv:
+
+Using uv (recommended)
+----------------------
+
+`uv <https://docs.astral.sh/uv/>`__ is a fast Python package installer and resolver. It's the quickest way to install Datasette::
+
+    uv tool install datasette
+
+You can then run Datasette with::
+
+    datasette --version
+
+To upgrade to the latest version::
+
+    uv tool upgrade datasette
+
 .. _installation_datasette_desktop:
 
 Datasette Desktop for Mac


### PR DESCRIPTION
This PR adds a prominent ultra-quickstart section as requested in #2625.

## Changes

- **README.md**: New 'Ultra-quickstart' section right after the intro description, showing the fastest way to get started
- **docs/getting_started.rst**: Quickstart section at the very top for immediate visibility  
- **docs/installation.rst**: Added 'uv' as the recommended installation method (it's becoming the standard for Python tooling)

## Example

Users can now see at a glance:

```bash
# Install with uv (recommended) or pip
uv tool install datasette
# Or: pip install datasette

# Serve a SQLite database
datasette my_database.db
```

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2635.org.readthedocs.build/en/2635/

<!-- readthedocs-preview datasette end -->