### PR TITLE
Add pks parameter to render_cell() plugin hook

### DIFF
--- a/datasette/hookspecs.py
+++ b/datasette/hookspecs.py
@@ -55,7 +55,7 @@ def publish_subcommand(publish):
 
 
 @hookspec
-def render_cell(row, value, column, table, database, datasette, request):
+def render_cell(row, value, column, table, pks, database, datasette, request):
     """Customize rendering of HTML table cell values"""
 
 

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -1205,6 +1205,7 @@ async def display_rows(datasette, database, request, rows, columns):
                 value=value,
                 column=column,
                 table=None,
+                pks=[],
                 database=database,
                 datasette=datasette,
                 request=request,

--- a/datasette/views/row.py
+++ b/datasette/views/row.py
@@ -130,6 +130,7 @@ class RowView(DataView):
                         value=value,
                         column=column,
                         table=table,
+                        pks=resolved.pks,
                         database=database,
                         datasette=self.ds,
                         request=request,

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -235,6 +235,7 @@ async def display_columns_and_rows(
                 value=value,
                 column=column,
                 table=table_name,
+                pks=pks_for_display,
                 database=database_name,
                 datasette=datasette,
                 request=request,
@@ -1494,6 +1495,7 @@ async def table_view_data(
 
     async def extra_render_cell():
         "Rendered HTML for each cell using the render_cell plugin hook"
+        pks_for_display = pks if pks else (["rowid"] if not is_view else [])
         columns = [col[0] for col in results.description]
         rendered_rows = []
         for row in rows:
@@ -1506,6 +1508,7 @@ async def table_view_data(
                     value=value,
                     column=column,
                     table=table_name,
+                    pks=pks_for_display,
                     database=database_name,
                     datasette=datasette,
                     request=request,

--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -9,7 +9,7 @@ Each plugin can implement one or more hooks using the ``@hookimpl`` decorator ag
 
 When you implement a plugin hook you can accept any or all of the parameters that are documented as being passed to that hook.
 
-For example, you can implement the ``render_cell`` plugin hook like this even though the full documented hook signature is ``render_cell(row, value, column, table, database, datasette)``:
+For example, you can implement the ``render_cell`` plugin hook like this even though the full documented hook signature is ``render_cell(row, value, column, table, pks, database, datasette, request)``:
 
 .. code-block:: python
 
@@ -474,8 +474,8 @@ Examples: `datasette-publish-fly <https://datasette.io/plugins/datasette-publish
 
 .. _plugin_hook_render_cell:
 
-render_cell(row, value, column, table, database, datasette, request)
---------------------------------------------------------------------
+render_cell(row, value, column, table, pks, database, datasette, request)
+-------------------------------------------------------------------------
 
 Lets you customize the display of values within table cells in the HTML table view.
 
@@ -490,6 +490,9 @@ Lets you customize the display of values within table cells in the HTML table vi
 
 ``table`` - string or None
     The name of the table - or ``None`` if this is a custom SQL query
+
+``pks`` - list of strings
+    The primary key column names for the table being rendered. For tables without an explicitly defined primary key, this will be ``["rowid"]``. For custom SQL queries and views (where ``table`` is ``None``), this will be an empty list ``[]``.
 
 ``database`` - string
     The name of the database

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -428,6 +428,7 @@ CREATE TABLE compound_primary_key (
 
 INSERT INTO compound_primary_key VALUES ('a', 'b', 'c');
 INSERT INTO compound_primary_key VALUES ('a/b', '.c-d', 'c');
+INSERT INTO compound_primary_key VALUES ('d', 'e', 'RENDER_CELL_DEMO');
 
 CREATE TABLE compound_three_primary_keys (
   pk1 varchar(30),
@@ -700,6 +701,7 @@ CREATE VIEW searchable_view_configured_by_metadata AS
             for i in range(201)
         ]
     )
+    + '\nINSERT INTO no_primary_key VALUES ("RENDER_CELL_DEMO", "a202", "b202", "c202");\n'
     + "\n".join(
         [
             'INSERT INTO compound_three_primary_keys VALUES ("{a}", "{b}", "{c}", "{content}");'.format(

--- a/tests/plugins/my_plugin.py
+++ b/tests/plugins/my_plugin.py
@@ -104,7 +104,7 @@ def extra_body_script(
 
 
 @hookimpl
-def render_cell(row, value, column, table, database, datasette, request):
+def render_cell(row, value, column, table, pks, database, datasette, request):
     async def inner():
         # Render some debug output in cell with value RENDER_CELL_DEMO
         if value == "RENDER_CELL_DEMO":
@@ -113,6 +113,7 @@ def render_cell(row, value, column, table, database, datasette, request):
                 "column": column,
                 "table": table,
                 "database": database,
+                "pks": pks,
                 "config": datasette.plugin_config(
                     "name-of-plugin",
                     database=database,


### PR DESCRIPTION
The render_cell() hook now receives a pks parameter containing the list
of primary key column names for the table being rendered. This avoids
plugins needing to make redundant async calls to look up primary keys.

For tables without an explicit primary key, pks is ["rowid"]. For custom
SQL queries and views, pks is an empty list [].

https://claude.ai/code/session_01HFYfevAziq4fSYTNRD9ZCh

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2641.org.readthedocs.build/en/2641/

<!-- readthedocs-preview datasette end -->