### PR TITLE
Fix --reload treating 'serve' command as a file argument

### DIFF
--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -547,7 +547,7 @@ def serve(
     if reload:
         import hupper
 
-        reloader = hupper.start_reloader("datasette.cli.serve")
+        reloader = hupper.start_reloader("datasette.cli.cli")
         if immutable:
             reloader.watch_files(immutable)
         if config:


### PR DESCRIPTION
Closes #2123

When using `datasette serve --reload test_db`, the reloader treated `serve` as a file argument instead of a subcommand, producing:

```
Error: Invalid value for '[FILES]...': Path 'serve' does not exist.
```

**Root cause:** `hupper.start_reloader("datasette.cli.serve")` calls the `serve` Click command directly on restart. Click then parses `sys.argv[1:]` which starts with `serve` — but since `serve` isn't being routed through the CLI group, Click consumes it as a positional file argument.

**Fix:** Changed the reloader entry point from `datasette.cli.serve` to `datasette.cli.cli` so that hupper restarts through the full CLI group, which correctly recognizes `serve` as a subcommand.

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2645.org.readthedocs.build/en/2645/

<!-- readthedocs-preview datasette end -->