### PR TITLE
Respect metadata-defined facet ordering in sorted_facet_results

### DIFF
--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -1589,9 +1589,7 @@ async def table_view_data(
                     metadata_facet_names.append(fc)
                 elif isinstance(fc, dict):
                     metadata_facet_names.append(list(fc.values())[0])
-            metadata_order = {
-                name: i for i, name in enumerate(metadata_facet_names)
-            }
+            metadata_order = {name: i for i, name in enumerate(metadata_facet_names)}
             metadata_facets = []
             request_facets = []
             for f in extra_facet_results["results"].values():

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -1580,11 +1580,37 @@ async def table_view_data(
         ]
 
     async def extra_sorted_facet_results(extra_facet_results):
-        return sorted(
-            extra_facet_results["results"].values(),
-            key=lambda f: (len(f["results"]), f["name"]),
-            reverse=True,
-        )
+        facet_configs = table_metadata.get("facets", [])
+        if facet_configs:
+            # Build ordered list of facet names from metadata config
+            metadata_facet_names = []
+            for fc in facet_configs:
+                if isinstance(fc, str):
+                    metadata_facet_names.append(fc)
+                elif isinstance(fc, dict):
+                    metadata_facet_names.append(list(fc.values())[0])
+            metadata_order = {
+                name: i for i, name in enumerate(metadata_facet_names)
+            }
+            metadata_facets = []
+            request_facets = []
+            for f in extra_facet_results["results"].values():
+                if f["name"] in metadata_order:
+                    metadata_facets.append(f)
+                else:
+                    request_facets.append(f)
+            metadata_facets.sort(key=lambda f: metadata_order[f["name"]])
+            request_facets.sort(
+                key=lambda f: (len(f["results"]), f["name"]),
+                reverse=True,
+            )
+            return metadata_facets + request_facets
+        else:
+            return sorted(
+                extra_facet_results["results"].values(),
+                key=lambda f: (len(f["results"]), f["name"]),
+                reverse=True,
+            )
 
     async def extra_table_definition():
         return await db.get_table_definition(table_name)

--- a/docs/facets.rst
+++ b/docs/facets.rst
@@ -153,6 +153,8 @@ Here's an example that turns on faceting by default for the ``qLegalStatus`` col
 
 Facets defined in this way will always be shown in the interface and returned in the API, regardless of the ``_facet`` arguments passed to the view.
 
+Facets defined in metadata will be displayed in the order they are listed in the configuration. Any additional facets added via query string parameters (e.g. ``?_facet=column_name``) will appear after the metadata-defined facets, sorted by the number of unique values.
+
 You can specify :ref:`array <facet_by_json_array>` or :ref:`date <facet_by_date>` facets in metadata using JSON objects with a single key of ``array`` or ``date`` and a value specifying the column, like this:
 
 .. [[[cog

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -632,9 +632,9 @@ def test_other_types_of_facet_in_metadata():
             assert fragment in response.text
         # Verify they appear in the metadata-defined order
         positions = [response.text.index(f) for f in fragments]
-        assert positions == sorted(positions), (
-            "Facets should appear in metadata-defined order"
-        )
+        assert positions == sorted(
+            positions
+        ), "Facets should appear in metadata-defined order"
 
 
 def test_metadata_facet_ordering():
@@ -652,9 +652,7 @@ def test_metadata_facet_ordering():
         }
     ) as client:
         # JSON response should have facets in the metadata-defined order
-        response = client.get(
-            "/fixtures/facetable.json?_extra=sorted_facet_results"
-        )
+        response = client.get("/fixtures/facetable.json?_extra=sorted_facet_results")
         data = response.json
         facet_names = [f["name"] for f in data["sorted_facet_results"]]
         assert facet_names == ["state", "tags", "created"]

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -623,12 +623,50 @@ def test_other_types_of_facet_in_metadata():
         }
     ) as client:
         response = client.get("/fixtures/facetable")
-        for fragment in (
-            "<strong>created (date)\n",
-            "<strong>tags (array)\n",
+        fragments = (
             "<strong>state\n",
-        ):
+            "<strong>tags (array)\n",
+            "<strong>created (date)\n",
+        )
+        for fragment in fragments:
             assert fragment in response.text
+        # Verify they appear in the metadata-defined order
+        positions = [response.text.index(f) for f in fragments]
+        assert positions == sorted(positions), (
+            "Facets should appear in metadata-defined order"
+        )
+
+
+def test_metadata_facet_ordering():
+    with make_app_client(
+        metadata={
+            "databases": {
+                "fixtures": {
+                    "tables": {
+                        "facetable": {
+                            "facets": ["state", {"array": "tags"}, {"date": "created"}]
+                        }
+                    }
+                }
+            }
+        }
+    ) as client:
+        # JSON response should have facets in the metadata-defined order
+        response = client.get(
+            "/fixtures/facetable.json?_extra=sorted_facet_results"
+        )
+        data = response.json
+        facet_names = [f["name"] for f in data["sorted_facet_results"]]
+        assert facet_names == ["state", "tags", "created"]
+
+        # With an additional request-based facet, metadata facets come first
+        # in their defined order, followed by request-based facets
+        response2 = client.get(
+            "/fixtures/facetable.json?_extra=sorted_facet_results&_facet=_city_id"
+        )
+        data2 = response2.json
+        facet_names2 = [f["name"] for f in data2["sorted_facet_results"]]
+        assert facet_names2 == ["state", "tags", "created", "_city_id"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
> Suggestion [[from Discord](https://discord.com/channels/823971286308356157/823971286941302908/1474455540204834917)](https://discord.com/channels/823971286308356157/823971286941302908/1474455540204834917):
> ```yaml
> dbname:
>   tables:
>     table_name:
>       facets:
>       - region
>       - provider
>       - capability_1_score
>       - capability_2_score
> ```
> Facets on the table page are currently ordered by the ones with the most results. We should change it so they use the defined `facets` order if one was defined, otherwise using the current behavior.

(I pasted in the issue body text from #2647)

## Summary
This change ensures that facets defined in table metadata are returned in their configured order, rather than being sorted by result count and name. Request-based facets (added via `_facet` parameter) are still sorted by result count and appear after metadata-defined facets.

## Key Changes
- Modified `extra_sorted_facet_results()` in `datasette/views/table.py` to parse facet configurations from table metadata and maintain their defined order
- Metadata-defined facets are now sorted according to their order in the config, while request-based facets fall back to the original sorting behavior (by result count, then name)
- Added comprehensive test coverage in `tests/test_facets.py`:
  - Enhanced existing `test_other_types_of_facet_in_metadata()` to verify facets appear in metadata-defined order in HTML responses
  - Added new `test_metadata_facet_ordering()` to verify JSON response ordering for both metadata-only and mixed metadata/request-based facets

## Implementation Details
- The facet config parser handles both string format (`"state"`) and dict format (`{"date": "created"}`) for facet definitions
- Facets are split into two groups: those defined in metadata (sorted by config order) and those added via request parameters (sorted by result count)
- When no metadata facets are defined, the original sorting behavior is preserved for backward compatibility

https://claude.ai/code/session_01PbSHtjsUpNk3Fx7xjvVqDb