### PR TITLE
Fix --default-deny index page 500 when no config file

### DIFF
--- a/datasette/utils/actions_sql.py
+++ b/datasette/utils/actions_sql.py
@@ -232,13 +232,20 @@ async def _build_single_action_sql(
 
         if anon_sqls_rewritten:
             anon_rules_union = " UNION ALL ".join(anon_sqls_rewritten)
-            query_parts.extend(
-                [
-                    "anon_rules AS (",
-                    f"  {anon_rules_union}",
-                    "),",
-                ]
+        else:
+            # Ensure anon_rules CTE always exists, even when there are no
+            # anonymous permission rules (e.g. --default-deny with no config).
+            anon_rules_union = (
+                "SELECT NULL AS parent, NULL AS child, NULL AS allow, NULL AS reason WHERE 0"
             )
+
+        query_parts.extend(
+            [
+                "anon_rules AS (",
+                f"  {anon_rules_union}",
+                "),",
+            ]
+        )
 
     # Continue with the cascading logic
     query_parts.extend(

--- a/datasette/utils/actions_sql.py
+++ b/datasette/utils/actions_sql.py
@@ -235,9 +235,7 @@ async def _build_single_action_sql(
         else:
             # Ensure anon_rules CTE always exists, even when there are no
             # anonymous permission rules (e.g. --default-deny with no config).
-            anon_rules_union = (
-                "SELECT NULL AS parent, NULL AS child, NULL AS allow, NULL AS reason WHERE 0"
-            )
+            anon_rules_union = "SELECT NULL AS parent, NULL AS child, NULL AS allow, NULL AS reason WHERE 0"
 
         query_parts.extend(
             [

--- a/tests/test_default_deny.py
+++ b/tests/test_default_deny.py
@@ -46,6 +46,29 @@ async def test_default_deny_denies_default_permissions():
 
 
 @pytest.mark.asyncio
+async def test_default_deny_root_user_index_pages_do_not_500_without_config():
+    """Regression test for issue #2644."""
+    ds = Datasette(default_deny=True)
+    ds.root_enabled = True
+    await ds.invoke_startup()
+
+    db = ds.add_memory_database("test_db")
+    await db.execute_write("create table test_table (id integer primary key)")
+    await ds._refresh_schemas()
+
+    # Authenticate as root using the one-time token
+    auth_response = await ds.client.get(f"/-/auth-token?token={ds._root_token}")
+    assert auth_response.status_code == 302
+    root_cookie = auth_response.cookies["ds_actor"]
+
+    response = await ds.client.get("/", cookies={"ds_actor": root_cookie})
+    assert response.status_code == 200
+
+    response = await ds.client.get("/test_db", cookies={"ds_actor": root_cookie})
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_default_deny_with_root_user():
     """Test that root user still has access when default_deny=True"""
     ds = Datasette(default_deny=True)


### PR DESCRIPTION
## Summary
Fixes a regression where `--default-deny --root` could return a 500 on index/database pages when no config file is present.

## What changed
- Always define the `anon_rules` CTE in `build_allowed_resources_sql()` when `include_is_private=True`
- Use an empty fallback CTE when there are no anonymous permission SQL rules
- Added a regression test that authenticates as root and verifies `/` and `/test_db` return 200 (not 500) in `default_deny=True` mode without config

## Testing
- `uv run pytest tests/test_default_deny.py -q`

Fixes #2644