### PR TITLE
fix: add ultra-quickstart guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Datasette is aimed at data journalists, museum curators, archivists, local gover
 
 Want to stay up-to-date with the project? Subscribe to the [Datasette newsletter](https://datasette.substack.com/) for tips, tricks and news on what's new in the Datasette ecosystem.
 
+## Ultra-quickstart
+
+If you already have a SQLite database and want to run Datasette as quickly as possible:
+
+    uv tool install datasette
+    datasette my_database.db
+
+Then visit http://localhost:8001/
+
 ## Installation
 
 If you are on a Mac, [Homebrew](https://brew.sh/) is the easiest way to install Datasette:


### PR DESCRIPTION
## Summary
- Adds an **Ultra-quickstart** section near the top of `README.md`
- Highlights the two-command flow requested in the issue:
  - `uv tool install datasette`
  - `datasette my_database.db`
- Keeps existing installation and usage docs intact

Fixes #2625

## Testing
- `python -m pytest tests/test_docs.py -q` *(failed: `python` not found in this environment)*
- `python3 -m pytest tests/test_docs.py -q` *(failed: `pytest` module not installed in this environment)*

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2655.org.readthedocs.build/en/2655/

<!-- readthedocs-preview datasette end -->