### PR TITLE
docs: add example of checking a registered action permission

### DIFF
--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -957,6 +957,25 @@ The fields of the ``Action`` dataclass are as follows:
     - Implement a ``resources_sql()`` classmethod that returns SQL returning all resources as ``(parent, child)`` columns
     - Have an ``__init__`` method that accepts appropriate parameters and calls ``super().__init__(parent=..., child=...)``
 
+Checking a registered action
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To check one of these actions in your plugin code, call
+``datasette.allowed()`` with both the action name and a resource instance.
+For example, this checks if the current actor can view a specific
+``DocumentResource``:
+
+.. code-block:: python
+
+    async def can_view_document(
+        datasette, actor, collection, document_id
+    ):
+        return await datasette.allowed(
+            actor,
+            "view-document",
+            resource=DocumentResource(collection, document_id),
+        )
+
 The ``resources_sql()`` method
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary
Adds a concrete example showing how to check an action registered with `register_actions()` using `datasette.allowed()` and a resource instance.

## Changes
- Added a new **Checking a registered action** subsection to `docs/plugin_hooks.rst`
- Included a short async example that checks `"view-document"` against `DocumentResource(collection, document_id)`

## Testing
- `uv run blacken-docs -l 60 docs/plugin_hooks.rst`
- `uv run cog --check docs/plugin_hooks.rst`
- `uv run pytest tests/test_docs.py -q`

Fixes simonw/datasette#2469

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2659.org.readthedocs.build/en/2659/

<!-- readthedocs-preview datasette end -->