### PR TITLE
Fix mobile column actions not showing items for SQL views

### DIFF
--- a/datasette/static/mobile-column-actions.js
+++ b/datasette/static/mobile-column-actions.js
@@ -5,9 +5,7 @@ var MOBILE_COLUMN_DIALOG_TITLE_ID = "mobile-column-actions-title";
 function mobileColumnHeaders(manager) {
   return Array.from(
     document.querySelectorAll(manager.selectors.tableHeaders),
-  ).filter(
-    (th) => th.dataset.column && th.dataset.isLinkColumn !== "1",
-  );
+  ).filter((th) => th.dataset.column && th.dataset.isLinkColumn !== "1");
 }
 
 function mobileColumnMetaText(th) {

--- a/datasette/static/mobile-column-actions.js
+++ b/datasette/static/mobile-column-actions.js
@@ -6,7 +6,7 @@ function mobileColumnHeaders(manager) {
   return Array.from(
     document.querySelectorAll(manager.selectors.tableHeaders),
   ).filter(
-    (th) => th.dataset.column && th.querySelector(".dropdown-menu-icon"),
+    (th) => th.dataset.column && th.dataset.isLinkColumn !== "1",
   );
 }
 

--- a/datasette/templates/_table.html
+++ b/datasette/templates/_table.html
@@ -6,7 +6,7 @@
         <thead>
             <tr>
                 {% for column in display_columns %}
-                    <th {% if column.description %}data-column-description="{{ column.description }}" {% endif %}class="col-{{ column.name|to_css_class }}" scope="col" data-column="{{ column.name }}" data-column-type="{{ column.type.lower() }}" data-column-not-null="{{ column.notnull }}" data-is-pk="{% if column.is_pk %}1{% else %}0{% endif %}">
+                    <th {% if column.description %}data-column-description="{{ column.description }}" {% endif %}class="col-{{ column.name|to_css_class }}" scope="col" data-column="{{ column.name }}" data-column-type="{{ column.type.lower() }}" data-column-not-null="{{ column.notnull }}" data-is-pk="{% if column.is_pk %}1{% else %}0{% endif %}"{% if column.is_special_link_column %} data-is-link-column="1"{% endif %}>
                         {% if not column.sortable %}
                             {{ column.name }}
                         {% else %}

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -369,6 +369,7 @@ async def display_columns_and_rows(
                 "is_pk": False,
                 "type": "",
                 "notnull": 0,
+                "is_special_link_column": True,
             }
         columns = [first_column] + columns
     return columns, cell_rows

--- a/tests/test_table_html.py
+++ b/tests/test_table_html.py
@@ -248,6 +248,7 @@ async def test_sort_links(ds_client):
                 "data-column-type": "",
                 "data-column-not-null": "0",
                 "data-is-pk": "0",
+                "data-is-link-column": "1",
             },
             "a_href": None,
         },


### PR DESCRIPTION
The previous fix to exclude the Link column from mobile column actions
(d02072b) used .dropdown-menu-icon presence as a proxy, but dropdown
icons are only added to sortable columns (those with <a> tags). This
caused all non-sortable columns to be excluded too.

Instead, explicitly mark the Link column with a data-is-link-column
attribute and filter by that in mobileColumnHeaders, so non-sortable
columns on views and tables still appear in the mobile column actions.

https://claude.ai/code/session_01CG545gLcZxet7dS5nMzfCd

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2670.org.readthedocs.build/en/2670/

<!-- readthedocs-preview datasette end -->