### PR TITLE
Database(is_temp_disk=True) option, used for internal database

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -381,7 +381,7 @@ class Datasette:
 
         self.internal_db_created = False
         if internal is None:
-            self._internal_database = Database(self, memory_name=secrets.token_hex())
+            self._internal_database = Database(self, is_temp_disk=True)
         else:
             self._internal_database = Database(self, path=internal, mode="rwc")
         self._internal_database.name = INTERNAL_DB_NAME

--- a/datasette/database.py
+++ b/datasette/database.py
@@ -1,10 +1,13 @@
 import asyncio
+import atexit
 from collections import namedtuple
+import os
 from pathlib import Path
 import janus
 import queue
 import sqlite_utils
 import sys
+import tempfile
 import threading
 import uuid
 
@@ -43,6 +46,7 @@ class Database:
         is_memory=False,
         memory_name=None,
         mode=None,
+        is_temp_disk=False,
     ):
         self.name = None
         self._thread_local_id = f"x{self._thread_local_id_counter}"
@@ -53,8 +57,19 @@ class Database:
         self.is_mutable = is_mutable
         self.is_memory = is_memory
         self.memory_name = memory_name
+        self._is_temp_disk = is_temp_disk
         if memory_name is not None:
             self.is_memory = True
+        if is_temp_disk:
+            fd, temp_path = tempfile.mkstemp(suffix=".db", prefix="datasette_temp_")
+            os.close(fd)
+            self.path = temp_path
+            self.is_mutable = True
+            self.mode = "rwc"
+            self._wal_enabled = False
+            atexit.register(self._cleanup_temp_file)
+        else:
+            self._wal_enabled = False
         self.cached_hash = None
         self.cached_size = None
         self._cached_table_counts = None
@@ -65,7 +80,8 @@ class Database:
         self._write_connection = None
         # This is used to track all file connections so they can be closed
         self._all_file_connections = []
-        self.mode = mode
+        if not is_temp_disk:
+            self.mode = mode
 
     @property
     def cached_table_counts(self):
@@ -86,6 +102,8 @@ class Database:
         return md5_not_usedforsecurity(self.name)[:6]
 
     def suggest_name(self):
+        if self._is_temp_disk:
+            return "_temp_disk"
         if self.path:
             return Path(self.path).stem
         elif self.memory_name:
@@ -124,12 +142,25 @@ class Database:
             f"file:{self.path}{qs}", uri=True, check_same_thread=False, **extra_kwargs
         )
         self._all_file_connections.append(conn)
+        if self._is_temp_disk and not self._wal_enabled:
+            conn.execute("PRAGMA journal_mode=WAL")
+            self._wal_enabled = True
         return conn
 
     def close(self):
         # Close all connections - useful to avoid running out of file handles in tests
         for connection in self._all_file_connections:
             connection.close()
+        if self._is_temp_disk:
+            self._cleanup_temp_file()
+
+    def _cleanup_temp_file(self):
+        if self._is_temp_disk and self.path:
+            for suffix in ("", "-wal", "-shm"):
+                try:
+                    os.unlink(self.path + suffix)
+                except OSError:
+                    pass
 
     async def execute_write(self, sql, params=None, block=True, request=None):
         def _inner(conn):
@@ -405,7 +436,7 @@ class Database:
     def hash(self):
         if self.cached_hash is not None:
             return self.cached_hash
-        elif self.is_mutable or self.is_memory:
+        elif self.is_mutable or self.is_memory or self._is_temp_disk:
             return None
         elif self.ds.inspect_data and self.ds.inspect_data.get(self.name):
             self.cached_hash = self.ds.inspect_data[self.name]["hash"]
@@ -419,7 +450,7 @@ class Database:
     def size(self):
         if self.cached_size is not None:
             return self.cached_size
-        elif self.is_memory:
+        elif self.is_memory or self._is_temp_disk:
             return 0
         elif self.is_mutable:
             return Path(self.path).stat().st_size
@@ -454,7 +485,7 @@ class Database:
 
     @property
     def mtime_ns(self):
-        if self.is_memory:
+        if self.is_memory or self._is_temp_disk:
             return None
         return Path(self.path).stat().st_mtime_ns
 
@@ -704,6 +735,8 @@ class Database:
             tags.append("mutable")
         if self.is_memory:
             tags.append("memory")
+        if self._is_temp_disk:
+            tags.append("temp_disk")
         if self.hash:
             tags.append(f"hash={self.hash}")
         if self.size is not None:

--- a/datasette/database.py
+++ b/datasette/database.py
@@ -57,7 +57,7 @@ class Database:
         self.is_mutable = is_mutable
         self.is_memory = is_memory
         self.memory_name = memory_name
-        self._is_temp_disk = is_temp_disk
+        self.is_temp_disk = is_temp_disk
         if memory_name is not None:
             self.is_memory = True
         if is_temp_disk:
@@ -102,7 +102,7 @@ class Database:
         return md5_not_usedforsecurity(self.name)[:6]
 
     def suggest_name(self):
-        if self._is_temp_disk:
+        if self.is_temp_disk:
             return "_temp_disk"
         if self.path:
             return Path(self.path).stem
@@ -142,7 +142,7 @@ class Database:
             f"file:{self.path}{qs}", uri=True, check_same_thread=False, **extra_kwargs
         )
         self._all_file_connections.append(conn)
-        if self._is_temp_disk and not self._wal_enabled:
+        if self.is_temp_disk and not self._wal_enabled:
             conn.execute("PRAGMA journal_mode=WAL")
             self._wal_enabled = True
         return conn
@@ -151,11 +151,11 @@ class Database:
         # Close all connections - useful to avoid running out of file handles in tests
         for connection in self._all_file_connections:
             connection.close()
-        if self._is_temp_disk:
+        if self.is_temp_disk:
             self._cleanup_temp_file()
 
     def _cleanup_temp_file(self):
-        if self._is_temp_disk and self.path:
+        if self.is_temp_disk and self.path:
             for suffix in ("", "-wal", "-shm"):
                 try:
                     os.unlink(self.path + suffix)
@@ -436,7 +436,7 @@ class Database:
     def hash(self):
         if self.cached_hash is not None:
             return self.cached_hash
-        elif self.is_mutable or self.is_memory or self._is_temp_disk:
+        elif self.is_mutable or self.is_memory or self.is_temp_disk:
             return None
         elif self.ds.inspect_data and self.ds.inspect_data.get(self.name):
             self.cached_hash = self.ds.inspect_data[self.name]["hash"]
@@ -450,7 +450,7 @@ class Database:
     def size(self):
         if self.cached_size is not None:
             return self.cached_size
-        elif self.is_memory or self._is_temp_disk:
+        elif self.is_memory or self.is_temp_disk:
             return 0
         elif self.is_mutable:
             return Path(self.path).stat().st_size
@@ -485,7 +485,7 @@ class Database:
 
     @property
     def mtime_ns(self):
-        if self.is_memory or self._is_temp_disk:
+        if self.is_memory or self.is_temp_disk:
             return None
         return Path(self.path).stat().st_mtime_ns
 
@@ -735,7 +735,7 @@ class Database:
             tags.append("mutable")
         if self.is_memory:
             tags.append("memory")
-        if self._is_temp_disk:
+        if self.is_temp_disk:
             tags.append("temp_disk")
         if self.hash:
             tags.append(f"hash={self.hash}")

--- a/datasette/database.py
+++ b/datasette/database.py
@@ -450,7 +450,7 @@ class Database:
     def size(self):
         if self.cached_size is not None:
             return self.cached_size
-        elif self.is_memory or self.is_temp_disk:
+        elif self.is_memory:
             return 0
         elif self.is_mutable:
             return Path(self.path).stat().st_size
@@ -485,7 +485,7 @@ class Database:
 
     @property
     def mtime_ns(self):
-        if self.is_memory or self.is_temp_disk:
+        if self.is_memory:
             return None
         return Path(self.path).stat().st_mtime_ns
 

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1552,8 +1552,8 @@ Instances of the ``Database`` class can be used to execute queries against attac
 
 .. _database_constructor:
 
-Database(ds, path=None, is_mutable=True, is_memory=False, memory_name=None)
----------------------------------------------------------------------------
+Database(ds, path=None, is_mutable=True, is_memory=False, memory_name=None, is_temp_disk=False)
+-----------------------------------------------------------------------------------------------
 
 The ``Database()`` constructor can be used by plugins, in conjunction with :ref:`datasette_add_database`, to create and register new databases.
 
@@ -1573,6 +1573,13 @@ The arguments are as follows:
 
 ``memory_name`` - string or ``None``
     Use this to create a named in-memory database. Unlike regular memory databases these can be accessed by multiple threads and will persist an changes made to them for the lifetime of the Datasette server process.
+
+``is_temp_disk`` - boolean
+    Set this to ``True`` to create a temporary file-backed database. This creates a SQLite database in a temporary file on disk (using Python's ``tempfile.mkstemp()``) with WAL mode enabled for better concurrent read/write performance. The temporary file is automatically cleaned up when the database is closed or when the process exits.
+
+    Unlike named in-memory databases (``memory_name``), temporary disk databases support concurrent readers and writers without locking errors, because WAL mode allows readers and writers to operate simultaneously. This makes them suitable for use cases like the internal database where concurrent access is common.
+
+    When ``is_temp_disk=True``, the ``path``, ``is_mutable``, and ``mode`` parameters are set automatically and should not be provided.
 
 The first argument is the ``datasette`` instance you are attaching to, the second is a ``path=``, then ``is_mutable`` and ``is_memory`` are both optional arguments.
 
@@ -1814,16 +1821,19 @@ The ``Database`` class also provides properties and methods for introspecting th
     The name of the database - usually the filename without the ``.db`` prefix.
 
 ``db.size`` - integer
-    The size of the database file in bytes. 0 for ``:memory:`` databases.
+    The size of the database file in bytes. 0 for ``:memory:`` and temporary disk databases.
 
 ``db.mtime_ns`` - integer or None
-    The last modification time of the database file in nanoseconds since the epoch. ``None`` for ``:memory:`` databases.
+    The last modification time of the database file in nanoseconds since the epoch. ``None`` for ``:memory:`` and temporary disk databases.
 
 ``db.is_mutable`` - boolean
     Is this database mutable, and allowed to accept writes?
 
 ``db.is_memory`` - boolean
     Is this database an in-memory database?
+
+``db.is_temp_disk`` - boolean
+    Is this database a temporary file-backed database? See :ref:`database_constructor` for details. Temporary disk databases report ``size`` as 0, ``hash`` as ``None``, and ``mtime_ns`` as ``None``.
 
 ``await db.attached_databases()`` - list of named tuples
     Returns a list of additional databases that have been connected to this database using the SQLite ATTACH command. Each named tuple has fields ``seq``, ``name`` and ``file``.

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1821,10 +1821,10 @@ The ``Database`` class also provides properties and methods for introspecting th
     The name of the database - usually the filename without the ``.db`` prefix.
 
 ``db.size`` - integer
-    The size of the database file in bytes. 0 for ``:memory:`` and temporary disk databases.
+    The size of the database file in bytes. 0 for ``:memory:`` databases.
 
 ``db.mtime_ns`` - integer or None
-    The last modification time of the database file in nanoseconds since the epoch. ``None`` for ``:memory:`` and temporary disk databases.
+    The last modification time of the database file in nanoseconds since the epoch. ``None`` for ``:memory:`` databases.
 
 ``db.is_mutable`` - boolean
     Is this database mutable, and allowed to accept writes?
@@ -1833,7 +1833,7 @@ The ``Database`` class also provides properties and methods for introspecting th
     Is this database an in-memory database?
 
 ``db.is_temp_disk`` - boolean
-    Is this database a temporary file-backed database? See :ref:`database_constructor` for details. Temporary disk databases report ``size`` as 0, ``hash`` as ``None``, and ``mtime_ns`` as ``None``.
+    Is this database a temporary file-backed database? See :ref:`database_constructor` for details. Temporary disk databases report ``hash`` as ``None`` but have real values for ``size`` and ``mtime_ns`` since they are backed by a file on disk.
 
 ``await db.attached_databases()`` - list of named tuples
     Returns a list of additional databases that have been connected to this database using the SQLite ATTACH command. Each named tuple has fields ``seq``, ``name`` and ``file``.

--- a/tests/test_internals_database.py
+++ b/tests/test_internals_database.py
@@ -774,7 +774,10 @@ async def test_replace_database(tmpdir):
     [
         ({"is_memory": True}, "<Database: test_db (mutable, memory, size=0)>"),
         ({"memory_name": "my_mem"}, "<Database: test_db (mutable, memory, size=0)>"),
-        ({"is_memory": True, "is_mutable": False}, "<Database: test_db (memory, size=0)>"),
+        (
+            {"is_memory": True, "is_mutable": False},
+            "<Database: test_db (memory, size=0)>",
+        ),
     ],
     ids=["memory", "named_memory", "immutable_memory"],
 )

--- a/tests/test_internals_database.py
+++ b/tests/test_internals_database.py
@@ -767,3 +767,50 @@ async def test_replace_database(tmpdir):
     db2 = datasette.get_database("data1")
     count = (await db2.execute("select count(*) from t")).first()[0]
     assert count == 1
+
+
+def test_repr_mutable_file_database(app_client):
+    db = app_client.ds.get_database("fixtures")
+    r = repr(db)
+    assert r.startswith("<Database: fixtures (mutable, size=")
+    assert r.endswith(")>")
+
+
+def test_repr_immutable_file_database(tmp_path):
+    path = str(tmp_path / "imm.db")
+    sqlite3.connect(path).execute("create table t (id integer primary key)")
+    ds = Datasette(files=[path], immutables=[path])
+    db = ds.get_database("imm")
+    r = repr(db)
+    assert "mutable" not in r
+    assert "hash=" in r
+    assert "size=" in r
+
+
+def test_repr_memory_database(app_client):
+    db = Database(app_client.ds, is_memory=True)
+    db.name = "test_mem"
+    r = repr(db)
+    assert r == "<Database: test_mem (mutable, memory, size=0)>"
+
+
+def test_repr_named_memory_database(app_client):
+    db = Database(app_client.ds, memory_name="my_mem")
+    db.name = "my_mem"
+    r = repr(db)
+    assert r == "<Database: my_mem (mutable, memory, size=0)>"
+
+
+def test_repr_temp_disk_database(app_client):
+    db = Database(app_client.ds, is_temp_disk=True)
+    db.name = "temp_test"
+    r = repr(db)
+    assert r == "<Database: temp_test (mutable, temp_disk, size=0)>"
+    db.close()
+
+
+def test_repr_immutable_memory_database(app_client):
+    db = Database(app_client.ds, is_memory=True, is_mutable=False)
+    db.name = "immut_mem"
+    r = repr(db)
+    assert r == "<Database: immut_mem (memory, size=0)>"

--- a/tests/test_internals_database.py
+++ b/tests/test_internals_database.py
@@ -770,18 +770,18 @@ async def test_replace_database(tmpdir):
 
 
 @pytest.mark.parametrize(
-    "kwargs,expected_tags",
+    "kwargs,expected_repr",
     [
-        ({"is_memory": True}, ["mutable", "memory", "size=0"]),
-        ({"memory_name": "my_mem"}, ["mutable", "memory", "size=0"]),
-        ({"is_temp_disk": True}, ["mutable", "temp_disk", "size=0"]),
-        ({"is_memory": True, "is_mutable": False}, ["memory", "size=0"]),
+        ({"is_memory": True}, "<Database: test_db (mutable, memory, size=0)>"),
+        ({"memory_name": "my_mem"}, "<Database: test_db (mutable, memory, size=0)>"),
+        ({"is_temp_disk": True}, "<Database: test_db (mutable, temp_disk, size=0)>"),
+        ({"is_memory": True, "is_mutable": False}, "<Database: test_db (memory, size=0)>"),
     ],
     ids=["memory", "named_memory", "temp_disk", "immutable_memory"],
 )
-def test_repr(app_client, kwargs, expected_tags):
+def test_repr(app_client, kwargs, expected_repr):
     db = Database(app_client.ds, **kwargs)
     db.name = "test_db"
-    assert repr(db) == "<Database: test_db ({})>".format(", ".join(expected_tags))
+    assert repr(db) == expected_repr
     if kwargs.get("is_temp_disk"):
         db.close()

--- a/tests/test_internals_database.py
+++ b/tests/test_internals_database.py
@@ -774,14 +774,22 @@ async def test_replace_database(tmpdir):
     [
         ({"is_memory": True}, "<Database: test_db (mutable, memory, size=0)>"),
         ({"memory_name": "my_mem"}, "<Database: test_db (mutable, memory, size=0)>"),
-        ({"is_temp_disk": True}, "<Database: test_db (mutable, temp_disk, size=0)>"),
         ({"is_memory": True, "is_mutable": False}, "<Database: test_db (memory, size=0)>"),
     ],
-    ids=["memory", "named_memory", "temp_disk", "immutable_memory"],
+    ids=["memory", "named_memory", "immutable_memory"],
 )
 def test_repr(app_client, kwargs, expected_repr):
     db = Database(app_client.ds, **kwargs)
     db.name = "test_db"
     assert repr(db) == expected_repr
-    if kwargs.get("is_temp_disk"):
-        db.close()
+
+
+def test_repr_temp_disk(app_client):
+    db = Database(app_client.ds, is_temp_disk=True)
+    db.name = "test_db"
+    r = repr(db)
+    assert r.startswith("<Database: test_db (mutable, temp_disk, size=")
+    assert r.endswith(")>")
+    assert isinstance(db.size, int)
+    assert isinstance(db.mtime_ns, int)
+    db.close()

--- a/tests/test_internals_database.py
+++ b/tests/test_internals_database.py
@@ -769,48 +769,19 @@ async def test_replace_database(tmpdir):
     assert count == 1
 
 
-def test_repr_mutable_file_database(app_client):
-    db = app_client.ds.get_database("fixtures")
-    r = repr(db)
-    assert r.startswith("<Database: fixtures (mutable, size=")
-    assert r.endswith(")>")
-
-
-def test_repr_immutable_file_database(tmp_path):
-    path = str(tmp_path / "imm.db")
-    sqlite3.connect(path).execute("create table t (id integer primary key)")
-    ds = Datasette(files=[path], immutables=[path])
-    db = ds.get_database("imm")
-    r = repr(db)
-    assert "mutable" not in r
-    assert "hash=" in r
-    assert "size=" in r
-
-
-def test_repr_memory_database(app_client):
-    db = Database(app_client.ds, is_memory=True)
-    db.name = "test_mem"
-    r = repr(db)
-    assert r == "<Database: test_mem (mutable, memory, size=0)>"
-
-
-def test_repr_named_memory_database(app_client):
-    db = Database(app_client.ds, memory_name="my_mem")
-    db.name = "my_mem"
-    r = repr(db)
-    assert r == "<Database: my_mem (mutable, memory, size=0)>"
-
-
-def test_repr_temp_disk_database(app_client):
-    db = Database(app_client.ds, is_temp_disk=True)
-    db.name = "temp_test"
-    r = repr(db)
-    assert r == "<Database: temp_test (mutable, temp_disk, size=0)>"
-    db.close()
-
-
-def test_repr_immutable_memory_database(app_client):
-    db = Database(app_client.ds, is_memory=True, is_mutable=False)
-    db.name = "immut_mem"
-    r = repr(db)
-    assert r == "<Database: immut_mem (memory, size=0)>"
+@pytest.mark.parametrize(
+    "kwargs,expected_tags",
+    [
+        ({"is_memory": True}, ["mutable", "memory", "size=0"]),
+        ({"memory_name": "my_mem"}, ["mutable", "memory", "size=0"]),
+        ({"is_temp_disk": True}, ["mutable", "temp_disk", "size=0"]),
+        ({"is_memory": True, "is_mutable": False}, ["memory", "size=0"]),
+    ],
+    ids=["memory", "named_memory", "temp_disk", "immutable_memory"],
+)
+def test_repr(app_client, kwargs, expected_tags):
+    db = Database(app_client.ds, **kwargs)
+    db.name = "test_db"
+    assert repr(db) == "<Database: test_db ({})>".format(", ".join(expected_tags))
+    if kwargs.get("is_temp_disk"):
+        db.close()


### PR DESCRIPTION
Refs:
- #2683 

Replace the default in-memory internal database with a temporary
file-backed database using WAL mode. This fixes concurrent read/write
locking errors that occur with named in-memory SQLite databases.

The new is_temp_disk parameter on Database creates a temp file via
tempfile.mkstemp, connects to it as a regular file-based database
with WAL mode enabled, and cleans it up on close() and via atexit.

https://claude.ai/code/session_01TteLrUjpDcARjnP1GMRqz2