### PR TITLE
Fix SQL injection via bracket escape bypass in escape_sqlite()

### DIFF
--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -405,7 +405,7 @@ def escape_sqlite(s):
     if _boring_keyword_re.match(s) and (s.lower() not in reserved_words):
         return s
     else:
-        return f"[{s}]"
+        return "[{}]".format(s.replace("]", "]]"))
 
 
 def make_dockerfile(


### PR DESCRIPTION
## Problem

`escape_sqlite()` wraps identifiers in `[brackets]` but does not escape existing `]` characters in the input. This allows bracket escape bypass.

Example:
```python
escape_sqlite("foo]bar")  # → "[foo]bar]" — broken/unsafe
```

## Solution

Escape `]` as `]]` per SQLite bracket-escaping rules:
```python
return "[{}]".format(s.replace("]", "]]"))
```

Now produces `[foo]]bar]` which is correct.

Fixes #2677

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2686.org.readthedocs.build/en/2686/

<!-- readthedocs-preview datasette end -->