### PR TITLE
Remove chunked header from database downloads

### DIFF
--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -406,7 +406,6 @@ async def database_download(request, datasette):
         if_none_match = request.headers.get("if-none-match")
         if if_none_match and if_none_match == etag:
             return Response("", status=304)
-    headers["Transfer-Encoding"] = "chunked"
     return AsgiFileDownload(
         filepath,
         filename=os.path.basename(filepath),

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -527,7 +527,7 @@ def test_database_download_for_immutable():
             download_response.headers["content-disposition"]
             == 'attachment; filename="fixtures.db"'
         )
-        assert download_response.headers["transfer-encoding"] == "chunked"
+        assert "transfer-encoding" not in download_response.headers
         # ETag header should be present and match db.hash
         assert "etag" in download_response.headers
         etag = download_response.headers["etag"]


### PR DESCRIPTION
## Summary

Fixes #2663.

`database_download()` currently adds `Transfer-Encoding: chunked` even though `AsgiFileDownload` already sets `Content-Length` for the file response. That causes downloads to send both headers, which prevents browsers from showing a progress bar.

This removes the extra `Transfer-Encoding` header and updates the existing immutable download test to assert that the response keeps `content-length` without `transfer-encoding`.

## Validation

- `uv run pytest tests/test_html.py -k 'database_download' -q`
- `uv run python` against `make_app_client(is_immutable=True)` to confirm `/fixtures.db` returns `content-length` and no `transfer-encoding`


<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2694.org.readthedocs.build/en/2694/

<!-- readthedocs-preview datasette end -->