### PR TITLE
fix: preserve base_url in database query redirects

### DIFF
--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -57,7 +57,7 @@ class DatabaseView(View):
 
         sql = (request.args.get("sql") or "").strip()
         if sql:
-            redirect_url = "/" + request.url_vars.get("database") + "/-/query"
+            redirect_url = datasette.urls.database(database) + "/-/query"
             if request.url_vars.get("format"):
                 redirect_url += "." + request.url_vars.get("format")
             redirect_url += "?" + request.query_string

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -929,6 +929,12 @@ def test_base_url_affects_filter_redirects(app_client_base_url_prefix):
     )
 
 
+def test_base_url_affects_database_query_redirects(app_client_base_url_prefix):
+    response = app_client_base_url_prefix.get("/fixtures?sql=select+1")
+    assert response.status_code == 302
+    assert response.headers["location"] == "/prefix/fixtures/-/query?sql=select+1"
+
+
 def test_base_url_affects_metadata_extra_css_urls(app_client_base_url_prefix):
     html = app_client_base_url_prefix.get("/").text
     assert '<link rel="stylesheet" href="/prefix/static/extra-css-urls.css">' in html


### PR DESCRIPTION
## Summary
- preserve `base_url` when redirecting `/{database}?sql=...` to `/-/query`
- add a regression test covering prefixed deployments

## Testing
- `PYTHONPATH=. pytest tests/test_html.py -k "base_url_affects_filter_redirects or base_url_affects_database_query_redirects or base_url_config" -q`
- `PYTHONPATH=. python -m py_compile datasette/views/database.py tests/test_html.py`
- verified manually with `make_app_client(settings={"base_url": "/prefix/"})`: redirect location is `/prefix/fixtures/-/query?sql=select+1`

Fixes #2487