### PR TITLE
fix: return exact row counts from inspect

### DIFF
--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -154,6 +154,7 @@ async def inspect_(files, sqlite_extensions):
     app = Datasette([], immutables=files, sqlite_extensions=sqlite_extensions)
     data = {}
     for name, database in app.databases.items():
+        database.count_limit = 10**10
         counts = await database.table_counts(limit=3600 * 1000)
         data[name] = {
             "hash": database.hash,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,21 @@ def test_inspect_cli_writes_to_file(app_client):
     assert ["fixtures"] == list(data.keys())
 
 
+def test_inspect_cli_returns_exact_counts_for_large_tables(tmp_path):
+    db_path = tmp_path / "large.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("create table t(id integer primary key)")
+    conn.executemany("insert into t(id) values (?)", [(i,) for i in range(10002)])
+    conn.commit()
+    conn.close()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["inspect", str(db_path)])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["large"]["tables"]["t"]["count"] == 10002
+
+
 def test_serve_with_inspect_file_prepopulates_table_counts_cache():
     inspect_data = {"fixtures": {"tables": {"hithere": {"count": 44}}}}
     with make_app_client(inspect_data=inspect_data, is_immutable=True) as client:


### PR DESCRIPTION
## Summary
- make `datasette inspect` bypass the 10,001-row display count limit when collecting table counts
- add a regression test covering a table with 10,002 rows

## Testing
- `PYTHONPATH=. pytest tests/test_cli.py -k inspect_cli -q`
- `PYTHONPATH=. python -m py_compile datasette/cli.py tests/test_cli.py`
- manual reproduction with a temporary SQLite database confirms `datasette inspect` now returns `10002` instead of `10001`

Fixes #2485

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2700.org.readthedocs.build/en/2700/

<!-- readthedocs-preview datasette end -->