### PR TITLE
Print correct URL for datasette -p 0 --root by pre-binding the socket

### DIFF
--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import socket
 import uvicorn
 import click
 from click import formatting
@@ -705,6 +706,18 @@ def serve(
         return
 
     # Start the server
+    # If port is 0 and we need to print/open a URL before the server starts
+    # (because of --root or --open), pre-bind a TCP socket so we know the
+    # OS-assigned port. See https://github.com/simonw/datasette/issues/873
+    pre_bound_socket = None
+    if port == 0 and not uds and (root or open_browser):
+        family = socket.AF_INET6 if host and ":" in host else socket.AF_INET
+        pre_bound_socket = socket.socket(family=family, type=socket.SOCK_STREAM)
+        pre_bound_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        pre_bound_socket.bind((host, 0))
+        pre_bound_socket.set_inheritable(True)
+        port = pre_bound_socket.getsockname()[1]
+
     url = None
     if root:
         ds.root_enabled = True
@@ -718,6 +731,19 @@ def serve(
             path = run_sync(lambda: initial_path_for_datasette(ds))
             url = f"http://{host}:{port}{path}"
         webbrowser.open(url)
+    if pre_bound_socket is not None:
+        # Hand the pre-bound socket to uvicorn via Server.run(sockets=[...])
+        # since uvicorn.run()'s `fd=` parameter assumes AF_UNIX.
+        config_kwargs = dict(
+            host=host, port=port, log_level="info", lifespan="on", workers=1
+        )
+        if ssl_keyfile:
+            config_kwargs["ssl_keyfile"] = ssl_keyfile
+        if ssl_certfile:
+            config_kwargs["ssl_certfile"] = ssl_certfile
+        config = uvicorn.Config(ds.app(), **config_kwargs)
+        uvicorn.Server(config).run(sockets=[pre_bound_socket])
+        return
     uvicorn_kwargs = dict(
         host=host, port=port, log_level="info", lifespan="on", workers=1
     )

--- a/tests/test_cli_serve_server.py
+++ b/tests/test_cli_serve_server.py
@@ -1,6 +1,11 @@
 import httpx
 import pytest
+import re
 import socket
+import subprocess
+import sys
+import tempfile
+import time
 
 
 @pytest.mark.serial
@@ -27,3 +32,59 @@ def test_serve_unix_domain_socket(ds_unix_domain_socket_server):
         "path": "/_memory",
         "tables": [],
     }.items() <= response.json().items()
+
+
+@pytest.mark.serial
+def test_serve_root_url_uses_actual_port_when_port_is_zero():
+    # Regression test for https://github.com/simonw/datasette/issues/873
+    # `datasette -p 0 --root` printed http://127.0.0.1:0/... instead of
+    # the OS-assigned port.
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "datasette", "--memory", "-p", "0", "--root"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=tempfile.gettempdir(),
+        text=True,
+    )
+    try:
+        # Read lines until we see the auth-token URL or time out
+        url_line = None
+        deadline = time.time() + 10.0
+        while time.time() < deadline:
+            line = proc.stdout.readline()
+            if not line:
+                if proc.poll() is not None:
+                    break
+                continue
+            if "/-/auth-token?token=" in line:
+                url_line = line.strip()
+                break
+        assert url_line, "Did not see auth-token URL in datasette output"
+        match = re.match(r"http://127\.0\.0\.1:(\d+)/-/auth-token\?token=", url_line)
+        assert match, f"Unexpected auth-token URL format: {url_line!r}"
+        printed_port = int(match.group(1))
+        assert printed_port != 0, (
+            "datasette -p 0 --root should print the OS-assigned port, "
+            "not the placeholder 0"
+        )
+        # Confirm a server is actually listening on that printed port
+        deadline2 = time.time() + 5.0
+        last_err = None
+        while time.time() < deadline2:
+            try:
+                response = httpx.get(f"http://127.0.0.1:{printed_port}/_memory.json")
+                assert response.status_code == 200
+                break
+            except httpx.ConnectError as exc:
+                last_err = exc
+                time.sleep(0.1)
+        else:
+            raise AssertionError(
+                f"Could not connect to printed port {printed_port}: {last_err}"
+            )
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
## Summary

Fixes #873 (open since 2018). `datasette/cli.py::serve` printed the `--root` auth-token URL (and built the `--open` URL) using the user-supplied `port` value before handing off to `uvicorn.run()`. With `-p 0`, uvicorn would assign a real port internally, but Datasette had already echoed `http://127.0.0.1:0/...`.

## Fix

When `port == 0` AND we need the URL upfront (`--root` or `--open`) AND not using `--uds`, pre-bind a TCP socket on `(host, 0)`, read the assigned port via `getsockname()`, then pass the bound socket to uvicorn via `uvicorn.Server(config).run(sockets=[sock])`. (`uvicorn.run()`'s `fd=` shortcut assumes AF_UNIX, so we use the lower-level Config/Server API on this single branch; the default `uvicorn.run()` path is untouched for everyone else.) Handles IPv6 hosts. SSL flags preserved.

26 LOC of production change.

## Test

`tests/test_cli_serve_server.py::test_serve_root_url_uses_actual_port_when_port_is_zero` — spawns `python -m datasette --memory -p 0 --root` as a subprocess, parses the printed `auth-token` URL with regex, asserts the port is non-zero, then issues an HTTPX request to that port and asserts 200 on `/_memory.json`.

`pytest tests/test_cli.py tests/test_cli_serve_server.py tests/test_cli_serve_get.py tests/test_internals_datasette_client.py` → 93 passed. Manual e2e: `datasette --memory -p 0 --root` now prints `http://127.0.0.1:50940/...` and `lsof` confirms the process is listening on the same port.

`ruff` + `black --check` clean.

## Risk notes

- `SO_REUSEADDR` matches uvicorn's own `Config.bind_socket`. `--uds` path explicitly excluded. Behaviour for the common case (`port != 0` or no `--root` / `--open`) is byte-identical.
- Cosmetic: when we pre-bind, uvicorn logs `Uvicorn running on socket ('127.0.0.1', <port>)` instead of the `http://...` line. The URL printed to stdout is correct, which is what the issue is about.

Refs #873

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2703.org.readthedocs.build/en/2703/

<!-- readthedocs-preview datasette end -->