### PR TITLE
inspect: skip the table-count cap so on-disk numbers are exact

### DIFF
--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -154,7 +154,7 @@ async def inspect_(files, sqlite_extensions):
     app = Datasette([], immutables=files, sqlite_extensions=sqlite_extensions)
     data = {}
     for name, database in app.databases.items():
-        counts = await database.table_counts(limit=3600 * 1000)
+        counts = await database.table_counts(limit=3600 * 1000, exact=True)
         data[name] = {
             "hash": database.hash,
             "size": database.size,

--- a/datasette/database.py
+++ b/datasette/database.py
@@ -561,25 +561,26 @@ class Database:
             self.cached_size = Path(self.path).stat().st_size
             return self.cached_size
 
-    async def table_counts(self, limit=10):
+    async def table_counts(self, limit=10, exact=False):
         if not self.is_mutable and self.cached_table_counts is not None:
             return self.cached_table_counts
         # Try to get counts for each table, $limit timeout for each count
         counts = {}
         for table in await self.table_names():
             try:
+                if exact:
+                    sql = f"select count(*) from [{table}]"
+                else:
+                    sql = f"select count(*) from (select * from [{table}] limit {self.count_limit + 1})"
                 table_count = (
-                    await self.execute(
-                        f"select count(*) from (select * from [{table}] limit {self.count_limit + 1})",
-                        custom_time_limit=limit,
-                    )
+                    await self.execute(sql, custom_time_limit=limit)
                 ).rows[0][0]
                 counts[table] = table_count
             # In some cases I saw "SQL Logic Error" here in addition to
             # QueryInterrupted - so we catch that too:
             except (QueryInterrupted, sqlite3.OperationalError, sqlite3.DatabaseError):
                 counts[table] = None
-        if not self.is_mutable:
+        if not self.is_mutable and not exact:
             self._cached_table_counts = counts
         return counts
 


### PR DESCRIPTION
Closes #2712.

`Database.table_counts` has a `count_limit=10000` cap so the runtime UI doesn't sit on huge tables. The `datasette inspect` CLI shares that path, so the JSON it persists capped every row count at 10001.

This adds an `exact=True` path that issues a plain `SELECT COUNT(*)` (the same query `inspect_tables` in `inspect.py` already uses) and points the CLI at it. The exact path also skips caching the result on the `Database`, since a precomputed count is wrong if the file changes after inspect runs.