### PR TITLE
Block open redirect via backslash in redirect Location

### DIFF
--- a/datasette/utils/asgi.py
+++ b/datasette/utils/asgi.py
@@ -330,9 +330,11 @@ async def asgi_send_html(send, html, status=200, headers=None):
 
 
 async def asgi_send_redirect(send, location, status=302):
-    # Prevent open redirect vulnerability: strip multiple leading slashes
-    # //example.com would be interpreted as a protocol-relative URL (e.g., https://example.com/)
-    location = re.sub(r"^/+", "/", location)
+    # Prevent open redirect vulnerability: collapse leading slashes and
+    # backslashes into a single slash. Browsers treat a backslash as a slash,
+    # so //example.com, /\example.com and /\/example.com would all otherwise be
+    # interpreted as a protocol-relative URL (e.g. https://example.com/).
+    location = re.sub(r"^[/\\]+", "/", location)
     await asgi_send(
         send,
         "",

--- a/tests/test_custom_pages.py
+++ b/tests/test_custom_pages.py
@@ -99,8 +99,18 @@ def test_custom_route_pattern_404(custom_pages_client):
     assert ">Oh no</" in response.text
 
 
-def test_custom_route_pattern_with_slash_slash_302(custom_pages_client):
-    # https://github.com/simonw/datasette/issues/2429
-    response = custom_pages_client.get("//example.com/")
+@pytest.mark.parametrize(
+    "path",
+    (
+        # https://github.com/simonw/datasette/issues/2429
+        "//example.com/",
+        # https://github.com/simonw/datasette/issues/2680
+        # Browsers treat backslashes as slashes, so these are also open redirects
+        "/\\example.com/",
+        "/\\/example.com/",
+    ),
+)
+def test_custom_route_pattern_open_redirect_302(custom_pages_client, path):
+    response = custom_pages_client.get(path)
     assert response.status == 302
     assert response.headers["location"] == "/example.com"


### PR DESCRIPTION
Fixes #2680

## The bug

The open-redirect protection added for #2429 collapses leading slashes in the redirect `Location` header so that `//example.com/` becomes `/example.com`. It only strips forward slashes though:

```python
location = re.sub(r"^/+", "/", location)
```

A request to `/\example.com/` (or its `%5C`-encoded form, which proxies/servers may decode to a literal backslash before it reaches Datasette) therefore redirects to `Location: /\example.com`. Browsers treat a backslash the same as a forward slash, so the browser reads that as `//example.com` and follows it to `https://example.com` — the open redirect is back.

`/\/example.com/` works the same way.

## Reproduction

Against `main`:

```
/\example.com/    -> 302 Location: /\example.com    (browser -> https://example.com)
/\/example.com/   -> 302 Location: /\/example.com   (browser -> https://example.com)
//example.com/    -> 302 Location: /example.com     (already fixed by #2429)
```

## The fix

Collapse leading backslashes as well as slashes in `asgi_send_redirect`:

```python
location = re.sub(r"^[/\\]+", "/", location)
```

Now all three cases redirect to the same-origin path `/example.com`. Inner slashes/backslashes are left untouched, so normal paths are unaffected.

## Testing

Extended the existing `//example.com/` test (renamed to `test_custom_route_pattern_open_redirect_302`) to cover `/\example.com/` and `/\/example.com/`. The two new cases fail before this change and pass after. `pytest tests/test_custom_pages.py` and the redirect/404 tests across the suite are green, and `black` reports no changes.