### PR TITLE
Add CORS headers to /db?sql= query redirect

### DIFF
--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -61,8 +61,10 @@ class DatabaseView(View):
             if request.url_vars.get("format"):
                 redirect_url += "." + request.url_vars.get("format")
             redirect_url += "?" + request.query_string
-            return Response.redirect(redirect_url)
-            return await QueryView()(request, datasette)
+            response = Response.redirect(redirect_url)
+            if datasette.cors:
+                add_cors_headers(response.headers)
+            return response
 
         if format_ not in ("html", "json"):
             raise NotFound("Invalid format: {}".format(format_))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -717,6 +717,17 @@ def test_cors(
     assert "Access-Control-Max-Age" not in response.headers
 
 
+def test_cors_query_redirect(app_client_with_cors):
+    # /db?sql= redirects to /db/-/query - the redirect itself needs CORS
+    # headers, otherwise browsers refuse to follow it cross-origin
+    response = app_client_with_cors.get(
+        "/fixtures?sql=select+1", follow_redirects=False
+    )
+    assert response.status == 302
+    assert response.headers["Location"] == "/fixtures/-/query?sql=select+1"
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+
 @pytest.mark.parametrize(
     "path",
     (


### PR DESCRIPTION
Fixes #2728

## The bug

`/{database}?sql=...` 302-redirects to `/{database}/-/query` (since #2363). When `--cors` is enabled every other response gets the `Access-Control-Allow-Origin: *` header, but this redirect response does not.

Browsers will not follow a cross-origin redirect unless the redirect response itself carries CORS headers, so a cross-origin client that hits the old `?sql=` URL silently fails instead of being forwarded to `/-/query`.

## Reproduction

```python
from datasette.app import Datasette
ds = Datasette([...], cors=True)
# GET /db?sql=select+1
#   -> 302 Location: /db/-/query?sql=select+1
#   -> no Access-Control-Allow-Origin header
```

## The fix

Add `add_cors_headers()` to the redirect response when `datasette.cors` is set, matching the pattern already used elsewhere in `database.py` (and in `base.py`, `special.py`, `table.py`). Also dropped the unreachable line directly below the old `return`.

I left the status code as 302. The issue mentions it could be a 301, but that is a separate behavioural change (301s are cached aggressively by browsers) and the existing redirect tests assert 302, so I kept this PR scoped to the CORS bug.

## Testing

New test `tests/test_api.py::test_cors_query_redirect` asserts the redirect response is a 302 with the correct `Location` and an `Access-Control-Allow-Origin: *` header. It fails on `main` and passes with this change.

```
pytest tests/test_api.py -k cors tests/test_csv.py::test_table_csv_cors_headers
```