### PR TITLE
Use 2-space indent for JSON on HTML versions of /-/ pages

### DIFF
--- a/datasette/views/special.py
+++ b/datasette/views/special.py
@@ -67,7 +67,7 @@ class JsonDataView(BaseView):
             context = {
                 "filename": self.filename,
                 "data": data,
-                "data_json": json.dumps(data, indent=4, default=repr),
+                "data_json": json.dumps(data, indent=2, default=repr),
             }
             # Add has_debug_permission if this view requires permissions-debug
             if self.permission == "permissions-debug":


### PR DESCRIPTION
> Make it so https://latest.datasette.io/-/config and other special pages use 2 spaced indents for json on their html version, not 4 spaces

The /-/config, /-/settings, /-/versions and similar pages now render
JSON in their HTML view using 2-space indentation instead of 4.

https://claude.ai/code/session_01JxwDEjW2sCzvrZXUMhq9N5

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2739.org.readthedocs.build/en/2739/

<!-- readthedocs-preview datasette end -->