### PR TITLE
Return MultiParams from request.post_vars() to handle multi-valued keys

### DIFF
--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -1193,6 +1193,11 @@ class MultiParams:
         """Return full list"""
         return self._data.get(name) or []
 
+    def items(self):
+        """Yield (key, first_value) pairs, matching ``__getitem__`` semantics."""
+        for key, values in self._data.items():
+            yield key, values[0]
+
 
 class ConnectionProblem(Exception):
     pass

--- a/datasette/utils/asgi.py
+++ b/datasette/utils/asgi.py
@@ -3,7 +3,7 @@ import re
 from http.cookies import Morsel, SimpleCookie
 from mimetypes import guess_type
 from pathlib import Path
-from urllib.parse import parse_qs, parse_qsl, urlunparse
+from urllib.parse import parse_qs, urlunparse
 
 import aiofiles
 import aiofiles.os
@@ -194,7 +194,7 @@ class Request:
 
     async def post_vars(self):
         body = await self.post_body()
-        return dict(parse_qsl(body.decode("utf-8"), keep_blank_values=True))
+        return MultiParams(parse_qs(qs=body.decode("utf-8"), keep_blank_values=True))
 
     async def json(self):
         body = await self.post_body()

--- a/datasette/views/query_helpers.py
+++ b/datasette/views/query_helpers.py
@@ -281,9 +281,9 @@ def _execute_write_disabled_reason(sql, analysis_error, analysis_rows):
 
 
 def _coerce_execute_write_payload(data, is_json):
-    if not isinstance(data, dict):
-        raise QueryValidationError("JSON must be a dictionary")
     if is_json:
+        if not isinstance(data, dict):
+            raise QueryValidationError("JSON must be a dictionary")
         invalid_keys = set(data) - {"sql", "params"}
         if invalid_keys:
             raise QueryValidationError(

--- a/datasette/views/stored_queries.py
+++ b/datasette/views/stored_queries.py
@@ -370,14 +370,17 @@ class QueryStoreView(QueryCreateView):
         query_data = {}
         try:
             data, is_json = await _json_or_form_payload(request)
-            if not isinstance(data, dict):
-                raise QueryValidationError("JSON must be a dictionary")
-            query_data = data.get("query") if is_json else data
-            if not isinstance(query_data, dict):
-                raise QueryValidationError("JSON must contain a query dictionary")
+            if is_json:
+                if not isinstance(data, dict):
+                    raise QueryValidationError("JSON must be a dictionary")
+                query_data = data.get("query")
+                if not isinstance(query_data, dict):
+                    raise QueryValidationError("JSON must contain a query dictionary")
+            else:
+                query_data = data
             prepared = await _prepare_query_create(self.ds, request, db, query_data)
         except QueryValidationError as ex:
-            if not is_json and isinstance(query_data, dict):
+            if not is_json:
                 return await self._error_response(
                     request, db, query_data, ex.message, ex.status
                 )
@@ -388,7 +391,7 @@ class QueryStoreView(QueryCreateView):
         try:
             await self.ds.add_query(db.name, name, replace=False, **prepared)
         except sqlite3.IntegrityError as ex:
-            if not is_json and isinstance(query_data, dict):
+            if not is_json:
                 return await self._error_response(request, db, query_data, str(ex), 400)
             return Response.error([str(ex)], 400)
 
@@ -452,8 +455,8 @@ class QueryUpdateView(BaseView):
             )
 
         try:
-            data, _ = await _json_or_form_payload(request)
-            if not isinstance(data, dict):
+            data, is_json = await _json_or_form_payload(request)
+            if is_json and not isinstance(data, dict):
                 raise QueryValidationError("JSON must be a dictionary")
             invalid_keys = set(data) - {"update", "return"}
             if invalid_keys:
@@ -555,8 +558,8 @@ class QueryEditView(BaseView):
         if existing.is_trusted:
             return Response.error(["Trusted queries cannot be edited"], 403)
 
-        data, _ = await _json_or_form_payload(request)
-        if not isinstance(data, dict):
+        data, is_json = await _json_or_form_payload(request)
+        if is_json and not isinstance(data, dict):
             return Response.error(["Invalid form submission"], 400)
         sql = data.get("sql")
         sql = existing.sql if sql is None else sql.strip()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -210,6 +210,7 @@ Bug fixes
 
 - Fixed a bug where visiting ``/<database>/-/query`` without a ``?sql=`` parameter returned a 500 error. (:issue:`2743`)
 - The ``datasette inspect`` command now correctly records row counts for tables with more than 10,000 rows. (:issue:`2712`)
+- ``await request.post_vars()`` now returns a :ref:`MultiParams <internals_multiparams>` object instead of a ``dict``, so multiple values for the same form field are preserved. Use ``.getlist(key)`` to retrieve every value. Existing ``post_vars[key]`` access continues to work, but now returns the *first* submitted value rather than the *last* (matching ``request.args`` semantics). (:issue:`2425`)
 
 .. _v1_0_a30:
 

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -106,8 +106,8 @@ The object also has the following awaitable methods:
 
     Don't forget to read about :ref:`internals_csrf`!
 
-``await request.post_vars()`` - dictionary
-    Returns a dictionary of form variables that were submitted in the request body via ``POST`` using ``application/x-www-form-urlencoded`` encoding. For multipart forms or file uploads, use ``request.form()`` instead.
+``await request.post_vars()`` - MultiParams
+    Returns a :ref:`MultiParams <internals_multiparams>` object of form variables that were submitted in the request body via ``POST`` using ``application/x-www-form-urlencoded`` encoding. This has the same shape as ``request.args``, so use ``.getlist(key)`` to retrieve every value submitted for keys with multiple values (such as ``<select multiple>`` fields). For multipart forms or file uploads, use ``request.form()`` instead.
 
 ``await request.json()`` - Any
     Returns the parsed JSON body of a request submitted by ``POST``.

--- a/tests/plugins/my_plugin.py
+++ b/tests/plugins/my_plugin.py
@@ -237,7 +237,8 @@ def register_routes():
         if request.method == "GET":
             return Response.html(request.scope["csrftoken"]())
         else:
-            return Response.json(await request.post_vars())
+            # post_vars() returns a MultiParams; convert to a plain dict for JSON
+            return Response.json(dict(await request.post_vars()))
 
     async def csrftoken_form(request, datasette):
         return Response.html(

--- a/tests/test_internals_request.py
+++ b/tests/test_internals_request.py
@@ -35,28 +35,44 @@ def _receive_chunks(chunks):
     return receive
 
 
+def _form_request(body: bytes) -> Request:
+    return Request(
+        _post_scope(headers=[[b"content-type", b"application/x-www-form-urlencoded"]]),
+        _receive_chunks([body]),
+    )
+
+
 @pytest.mark.asyncio
 async def test_request_post_vars():
-    scope = {
-        "http_version": "1.1",
-        "method": "POST",
-        "path": "/",
-        "raw_path": b"/",
-        "query_string": b"",
-        "scheme": "http",
-        "type": "http",
-        "headers": [[b"content-type", b"application/x-www-form-urlencoded"]],
-    }
+    request = _form_request(b"foo=bar&baz=1&empty=")
+    post_vars = await request.post_vars()
+    assert post_vars["foo"] == "bar"
+    assert post_vars["baz"] == "1"
+    assert post_vars["empty"] == ""
+    assert post_vars.get("missing") is None
+    assert set(post_vars.keys()) == {"foo", "baz", "empty"}
+    assert dict(post_vars.items()) == {"foo": "bar", "baz": "1", "empty": ""}
 
-    async def receive():
-        return {
-            "type": "http.request",
-            "body": b"foo=bar&baz=1&empty=",
-            "more_body": False,
-        }
 
-    request = Request(scope, receive)
-    assert {"foo": "bar", "baz": "1", "empty": ""} == await request.post_vars()
+@pytest.mark.asyncio
+async def test_request_post_vars_multi():
+    # post_vars() returns a MultiParams so multiple values for the same key are
+    # preserved, matching the behaviour of request.args. See issue #2425.
+    request = _form_request(b"multi=1&multi=2&single=3")
+    post_vars = await request.post_vars()
+    assert post_vars.get("multi") == "1"
+    assert post_vars.get("single") == "3"
+    assert post_vars["multi"] == "1"
+    assert post_vars["single"] == "3"
+    assert post_vars.getlist("multi") == ["1", "2"]
+    assert post_vars.getlist("single") == ["3"]
+    assert post_vars.getlist("missing") == []
+    assert "multi" in post_vars
+    assert "missing" not in post_vars
+    assert list(post_vars.keys()) == ["multi", "single"]
+    assert len(post_vars) == 2
+    with pytest.raises(KeyError):
+        post_vars["missing"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #2425.

## Problem

``request.post_vars()`` is implemented as ``dict(parse_qsl(body, keep_blank_values=True))``, which silently collapses any duplicate keys to the last value. Forms that submit multiple values for the same field — e.g. ``<select multiple>``, multi-checkbox groups, ``?_facet=...&_facet=...`` style POSTs — lose data with no error. ``request.args`` already handles this correctly via ``MultiParams``.

## Fix

Return a ``MultiParams`` built from ``parse_qs(...)`` instead of a ``dict``, matching the shape of ``request.args``. ``MultiParams`` was already imported in ``asgi.py``, so no new imports.

Added an ``items()`` method to ``MultiParams`` that yields ``(key, first_value)`` pairs (matching ``__getitem__`` semantics), so ``MultiParams`` can be passed directly into ``dict()``, dict-comprehension patterns and similar.

The internal ``_json_or_form_payload`` helper feeds two callers — ``_coerce_execute_write_payload`` and the ``QueryStoreView`` / ``QueryUpdateView`` POST handlers — that both had ``isinstance(data, dict)`` guards intended to validate JSON shape. Those guards spuriously rejected the new ``MultiParams`` on the form path, so they have been gated on ``is_json``. The fall-through logic that re-renders the HTML form on validation errors uses ``.get()`` on ``query_data`` and works against either ``dict`` or ``MultiParams``.

## Behavioural notes

- ``post_vars[key]`` and ``post_vars.get(key)`` continue to work but now return the *first* submitted value rather than the *last*. This matches ``request.args`` semantics and is documented in the changelog.
- ``post_vars.getlist(key)`` now returns the full list of submitted values — the new capability the issue asked for.
- Plugins doing ``Response.json(await request.post_vars())`` should wrap in ``dict(...)`` because ``MultiParams`` is not directly JSON-serialisable. The bundled ``my_plugin`` test fixture has been updated to demonstrate this.

## Test plan

- Updated ``test_request_post_vars`` to assert ``MultiParams`` behaviour against the previously-existing single-value payload.
- New ``test_request_post_vars_multi`` mirrors ``test_request_args``, covering ``[]``, ``get``, ``getlist``, ``in``, ``keys``, ``len`` and ``KeyError`` for missing keys.
- Full test suite passes (``pytest --ignore=tests/test_multipart.py -n auto``: 1853 passed). ``tests/test_multipart.py`` has a pre-existing ``ModuleNotFoundError: multipart_form_data_conformance`` unrelated to this change.

## Files touched

- ``datasette/utils/asgi.py`` — ``post_vars()`` returns ``MultiParams``.
- ``datasette/utils/__init__.py`` — ``MultiParams.items()``.
- ``datasette/views/query_helpers.py`` — gate ``isinstance(data, dict)`` on ``is_json`` in ``_coerce_execute_write_payload``.
- ``datasette/views/stored_queries.py`` — gate ``isinstance`` guards on ``is_json`` in ``QueryStoreView.post`` and ``QueryUpdateView.post``; drop the now-redundant ``isinstance(query_data, dict)`` checks in the error fall-through branches.
- ``tests/test_internals_request.py`` — updated and added tests.
- ``tests/plugins/my_plugin.py`` — wrap ``post_vars()`` in ``dict()`` for JSON serialisation.
- ``docs/internals.rst`` and ``docs/changelog.rst`` — documentation updates.