### PR TITLE
Fix /-/check 500 error on query-scoped actions

### DIFF
--- a/datasette/views/special.py
+++ b/datasette/views/special.py
@@ -497,11 +497,13 @@ async def _check_permission_for_actor(ds, action, parent, child, actor):
     if action_obj.resource_class is None:
         resource_obj = None
     elif action_obj.takes_parent and action_obj.takes_child:
-        # Child-level resource (e.g., TableResource, QueryResource)
-        resource_obj = action_obj.resource_class(database=parent, table=child)
+        # Child-level resource (e.g., TableResource, QueryResource). Pass
+        # positional args so we work with subclasses whose second parameter
+        # is named `table`, `query`, or anything else.
+        resource_obj = action_obj.resource_class(parent, child)
     elif action_obj.takes_parent:
         # Parent-level resource (e.g., DatabaseResource)
-        resource_obj = action_obj.resource_class(database=parent)
+        resource_obj = action_obj.resource_class(parent)
     else:
         # This shouldn't happen given validation in Action.__post_init__
         return {"error": f"Invalid action configuration: {action}"}, 500

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1734,6 +1734,34 @@ async def test_permission_check_view_requires_debug_permission():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action,child",
+    [
+        ("view-query", "myquery"),
+        ("update-query", "myquery"),
+        ("delete-query", "myquery"),
+    ],
+)
+async def test_permission_check_view_query_scoped_action(action, child):
+    """Test that /-/check works for query-scoped actions (issue #2756)."""
+    ds = Datasette()
+    ds.root_enabled = True
+    root_token = await ds.create_token("root", handler="signed")
+    response = await ds.client.get(
+        f"/-/check.json?action={action}&parent=mydb&child={child}",
+        headers={"Authorization": f"Bearer {root_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["action"] == action
+    assert data["resource"] == {
+        "parent": "mydb",
+        "child": child,
+        "path": f"/mydb/{child}",
+    }
+
+
+@pytest.mark.asyncio
 async def test_root_allow_block_with_table_restricted_actor():
     """
     Test that root-level allow: blocks are processed for actors with


### PR DESCRIPTION
Closes #2756.

`_check_permission_for_actor` builds child-level resources with hardcoded `table=child`, which raises `TypeError` for `QueryResource` (it accepts `query=`, not `table=`). Visiting `/-/check?action=delete-query` (or `view-query`, `update-query`) returned a 500.

Switched the call to positional args so it works with every `Resource` subclass regardless of the second-parameter name.

Verification: with the fix reverted via `git stash`, the three new parametrized cases reproduce the original `TypeError`; restoring it makes them pass. Full `tests/test_permissions.py` and `tests/test_actions_sql.py` runs are green.