### PR TITLE
Add web UI to edit and delete stored queries

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -55,6 +55,7 @@ from .views.stored_queries import (
     QueryCreateAnalyzeView,
     QueryDeleteView,
     QueryDefinitionView,
+    QueryEditView,
     GlobalQueryListView,
     QueryListView,
     QueryParametersView,
@@ -2492,6 +2493,10 @@ class Datasette:
         add_route(
             QueryDefinitionView.as_view(self),
             r"/(?P<database>[^\/\.]+)/(?P<query>[^\/\.]+)/-/definition$",
+        )
+        add_route(
+            QueryEditView.as_view(self),
+            r"/(?P<database>[^\/\.]+)/(?P<query>[^\/\.]+)/-/edit$",
         )
         add_route(
             QueryUpdateView.as_view(self),

--- a/datasette/default_query_actions.py
+++ b/datasette/default_query_actions.py
@@ -1,0 +1,48 @@
+from datasette import hookimpl
+from datasette.resources import QueryResource
+
+
+@hookimpl
+def query_actions(datasette, actor, database, query_name, request):
+    # Only stored queries (with a name) can be edited or deleted
+    if not query_name:
+        return None
+
+    async def inner():
+        query = await datasette.get_query(database, query_name)
+        if query is None:
+            return []
+        # Config-defined and trusted queries are managed outside the UI
+        if query.source == "config" or query.is_trusted:
+            return []
+
+        links = []
+        if await datasette.allowed(
+            action="update-query",
+            resource=QueryResource(database, query_name),
+            actor=actor,
+        ):
+            links.append(
+                {
+                    "href": datasette.urls.table(database, query_name) + "/-/edit",
+                    "label": "Edit this query",
+                    "description": (
+                        "Change the title, description, SQL or visibility."
+                    ),
+                }
+            )
+        if await datasette.allowed(
+            action="delete-query",
+            resource=QueryResource(database, query_name),
+            actor=actor,
+        ):
+            links.append(
+                {
+                    "href": datasette.urls.table(database, query_name) + "/-/delete",
+                    "label": "Delete this query",
+                    "description": "Permanently remove this saved query.",
+                }
+            )
+        return links
+
+    return inner

--- a/datasette/plugins.py
+++ b/datasette/plugins.py
@@ -31,6 +31,7 @@ DEFAULT_PLUGINS = (
     "datasette.default_debug_menu",
     "datasette.default_jump_items",
     "datasette.default_database_actions",
+    "datasette.default_query_actions",
     "datasette.handle_exception",
     "datasette.forbidden",
     "datasette.events",

--- a/datasette/templates/_query_form_styles.html
+++ b/datasette/templates/_query_form_styles.html
@@ -1,0 +1,138 @@
+<style>
+.query-create-page {
+    max-width: 64rem;
+}
+.query-create-form {
+    --query-create-label-width: clamp(7rem, 18vw, 10rem);
+    --query-create-column-gap: 0.8rem;
+    --query-create-control-width: minmax(16rem, 1fr);
+}
+.query-create-fields {
+    margin: 0 0 0.85rem;
+    max-width: 52rem;
+}
+.query-create-field {
+    align-items: start;
+    column-gap: var(--query-create-column-gap);
+    display: grid;
+    grid-template-columns: var(--query-create-label-width) var(--query-create-control-width);
+    margin: 0 0 0.65rem;
+}
+.query-create-field label {
+    padding-top: 0.55rem;
+    width: auto;
+}
+.query-create-field input[type=text],
+.query-create-field textarea {
+    box-sizing: border-box;
+    width: 100%;
+}
+form.sql .query-create-field textarea {
+    width: 100%;
+}
+.query-create-url-control {
+    align-items: center;
+    box-sizing: border-box;
+    display: grid;
+    gap: 0.35rem;
+    grid-template-columns: max-content minmax(12rem, 1fr);
+    width: 100%;
+}
+.query-create-url-prefix {
+    color: #4f5b6d;
+    font-family: var(--font-monospace, monospace);
+    white-space: nowrap;
+}
+.query-create-url-control input[type=text] {
+    border: 1px solid #ccc;
+    border-radius: 3px;
+}
+.query-create-url-static {
+    color: #39445a;
+    font-family: var(--font-monospace, monospace);
+    word-break: break-all;
+}
+.query-create-field textarea {
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    display: block;
+    font-family: Helvetica, sans-serif;
+    font-size: 1em;
+    min-height: 5rem;
+    padding: 9px 4px;
+    resize: vertical;
+}
+form.sql .query-create-sql {
+    column-gap: var(--query-create-column-gap);
+    display: grid;
+    grid-template-columns: var(--query-create-label-width) var(--query-create-control-width);
+    margin: 0.9rem 0 0.75rem;
+    max-width: 52rem;
+}
+.query-create-sql .cm-editor,
+form.sql .query-create-sql textarea#sql-editor {
+    grid-column: 2;
+    width: 100%;
+}
+.query-create-options {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.8rem 1.4rem;
+    margin: 0 0 0.9rem calc(var(--query-create-label-width) + var(--query-create-column-gap));
+    max-width: calc(52rem - var(--query-create-label-width) - var(--query-create-column-gap));
+}
+.query-create-options label {
+    align-items: center;
+    display: inline-flex;
+    gap: 0.35rem;
+    width: auto;
+}
+.query-create-options input[type=checkbox] {
+    margin: 0;
+}
+.query-create-option-note,
+.query-create-analysis-note {
+    color: #4f5b6d;
+    flex-basis: 100%;
+    font-size: 0.82rem;
+}
+.query-create-option-note {
+    margin: -0.45rem 0 0;
+}
+.query-create-analysis-note {
+    margin: 0;
+}
+.query-create-analysis {
+    margin-top: 0.8rem;
+}
+.query-create-submit {
+    margin-left: calc(var(--query-create-label-width) + var(--query-create-column-gap));
+    margin-bottom: 0.9rem;
+    margin-top: 1rem;
+}
+@media (max-width: 560px) {
+    .query-create-form {
+        --query-create-label-width: 1fr;
+        --query-create-column-gap: 0;
+    }
+    .query-create-field {
+        grid-template-columns: 1fr;
+        row-gap: 0.25rem;
+    }
+    .query-create-field label {
+        padding-top: 0;
+    }
+    form.sql .query-create-sql {
+        grid-template-columns: 1fr;
+    }
+    .query-create-sql .cm-editor,
+    form.sql .query-create-sql textarea#sql-editor {
+        grid-column: 1;
+    }
+    .query-create-options,
+    .query-create-submit {
+        margin-left: 0;
+    }
+}
+</style>

--- a/datasette/templates/query_delete.html
+++ b/datasette/templates/query_delete.html
@@ -32,6 +32,16 @@
     display: flex;
     gap: 1rem;
 }
+.query-delete-form input[type=submit] {
+    background: linear-gradient(180deg, #d73a31 0%, #b42318 100%);
+    border-color: #b42318;
+    font-weight: 700;
+}
+.query-delete-form input[type=submit]:hover,
+.query-delete-form input[type=submit]:focus {
+    background: linear-gradient(180deg, #c3342b 0%, #971c14 100%);
+    border-color: #971c14;
+}
 </style>
 {% endblock %}
 
@@ -60,7 +70,7 @@
     <dd><pre>{{ query.sql }}</pre></dd>
 </dl>
 
-<form action="{{ query_url }}/-/delete" method="post">
+<form class="core query-delete-form" action="{{ query_url }}/-/delete" method="post">
     <p class="query-delete-actions">
         <input type="submit" value="Delete query">
         <a href="{{ query_url }}">Cancel</a>

--- a/datasette/templates/query_delete.html
+++ b/datasette/templates/query_delete.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+
+{% block title %}Delete query: {{ query.name }}{% endblock %}
+
+{% block extra_head %}
+{{- super() -}}
+<style>
+.query-delete-page {
+    max-width: 48rem;
+}
+.query-delete-summary {
+    background-color: #f7f7f9;
+    border: 1px solid #d7dde5;
+    border-radius: 4px;
+    margin: 0.75rem 0 1.25rem;
+    padding: 0.75rem 1rem;
+}
+.query-delete-summary dt {
+    color: #4f5b6d;
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+.query-delete-summary dd {
+    margin: 0 0 0.6rem;
+}
+.query-delete-summary dd pre {
+    margin: 0.2rem 0 0;
+    white-space: pre-wrap;
+}
+.query-delete-actions {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+}
+</style>
+{% endblock %}
+
+{% block body_class %}query-delete db-{{ database|to_css_class }}{% endblock %}
+
+{% block crumbs %}
+{{ crumbs.nav(request=request, database=database) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="query-delete-page">
+
+<h1 style="padding-left: 10px; border-left: 10px solid #{{ database_color }}">Delete query: {{ query.title or query.name }}</h1>
+
+<p>Are you sure you want to delete this saved query? This cannot be undone.</p>
+
+<dl class="query-delete-summary">
+    <dt>URL</dt>
+    <dd><a href="{{ query_url }}">{{ query_url }}</a></dd>
+    {% if query.description %}
+        <dt>Description</dt>
+        <dd>{{ query.description }}</dd>
+    {% endif %}
+    <dt>SQL</dt>
+    <dd><pre>{{ query.sql }}</pre></dd>
+</dl>
+
+<form action="{{ query_url }}/-/delete" method="post">
+    <p class="query-delete-actions">
+        <input type="submit" value="Delete query">
+        <a href="{{ query_url }}">Cancel</a>
+    </p>
+</form>
+
+</div>
+
+{% endblock %}

--- a/datasette/templates/query_edit.html
+++ b/datasette/templates/query_edit.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Create query{% endblock %}
+{% block title %}Edit query: {{ name }}{% endblock %}
 
 {% block extra_head %}
 {{- super() -}}
@@ -9,7 +9,7 @@
 {% include "_query_form_styles.html" %}
 {% endblock %}
 
-{% block body_class %}query-create db-{{ database|to_css_class }}{% endblock %}
+{% block body_class %}query-edit db-{{ database|to_css_class }}{% endblock %}
 
 {% block crumbs %}
 {{ crumbs.nav(request=request, database=database) }}
@@ -19,12 +19,12 @@
 
 <div class="query-create-page">
 
-<h1 style="padding-left: 10px; border-left: 10px solid #{{ database_color }}">Create query</h1>
+<h1 style="padding-left: 10px; border-left: 10px solid #{{ database_color }}">Edit query: {{ title or name }}</h1>
 
-<form class="sql core query-create-form" action="{{ urls.database(database) }}/-/queries/store" method="post" data-analyze-url="{{ urls.database(database) }}/-/queries/analyze">
+<form class="sql core query-create-form" action="{{ query_url }}/-/edit" method="post" data-analyze-url="{{ urls.database(database) }}/-/queries/analyze">
     <div class="query-create-fields">
         <p class="query-create-field"><label for="query-title">Title</label> <input id="query-title" name="title" type="text" value="{{ title or "" }}"></p>
-        <p class="query-create-field"><label for="query-url-slug">URL</label> <span class="query-create-url-control"><span class="query-create-url-prefix">{{ urls.database(database) }}/</span><input id="query-url-slug" name="name" type="text" value="{{ name or "" }}"></span></p>
+        <p class="query-create-field"><label>URL</label> <span class="query-create-url-static">{{ query_url }}</span></p>
         <p class="query-create-field"><label for="query-description">Description</label> <textarea id="query-description" name="description" rows="3">{{ description or "" }}</textarea></p>
     </div>
 
@@ -34,9 +34,9 @@
         <span class="query-create-analysis-note" data-query-create-analysis-note aria-live="polite">{% if analysis_error %}This query cannot be saved until the SQL is valid.{% elif not has_sql %}Enter SQL to analyze this query.{% elif analysis_is_write %}This query updates data in the database.{% else %}This is a read-only query.{% endif %}</span>
         <input type="hidden" name="is_private" value="0">
         <label><input type="checkbox" name="is_private" value="1"{% if is_private %} checked{% endif %}> Private</label>
-        <span class="query-create-option-note">Queries marked private can only be seen by you, their creator.</span>
+        <span class="query-create-option-note">Queries marked private can only be seen and edited by you, their owner.</span>
     </p>
-    <p class="query-create-submit"><input type="submit" value="Save query" data-query-create-submit{% if save_disabled %} disabled{% endif %}></p>
+    <p class="query-create-submit"><input type="submit" value="Save changes" data-query-create-submit{% if save_disabled %} disabled{% endif %}> <a href="{{ query_url }}">Cancel</a></p>
 
     <div class="query-create-analysis" id="query-create-analysis-section"{% if not has_sql %} hidden{% endif %}>
         {% if has_sql %}
@@ -78,36 +78,6 @@
 {% include "_codemirror_foot.html" %}
 {% include "_sql_parameter_scripts.html" %}
 {% include "_execute_write_analysis_scripts.html" %}
-
-<script>
-window.addEventListener("DOMContentLoaded", () => {
-  const titleInput = document.querySelector("#query-title");
-  const urlInput = document.querySelector("#query-url-slug");
-  let urlEdited = Boolean(urlInput && urlInput.value);
-
-  function slugify(value) {
-    return value
-      .normalize("NFKD")
-      .replace(/[\u0300-\u036f]/g, "")
-      .toLowerCase()
-      .trim()
-      .replace(/[^a-z0-9_-]+/g, "-")
-      .replace(/-+/g, "-")
-      .replace(/^-|-$/g, "");
-  }
-
-  if (titleInput && urlInput) {
-    titleInput.addEventListener("input", () => {
-      if (!urlEdited) {
-        urlInput.value = slugify(titleInput.value);
-      }
-    });
-    urlInput.addEventListener("input", () => {
-      urlEdited = true;
-    });
-  }
-});
-</script>
 
 <script>
 window.addEventListener("DOMContentLoaded", () => {

--- a/datasette/templates/query_list.html
+++ b/datasette/templates/query_list.html
@@ -205,32 +205,32 @@
 
 <h1 style="padding-left: 10px; border-left: 10px solid #{% if database_color %}{{ database_color }}{% else %}666{% endif %}">Queries</h1>
 
-<form class="query-list-filters core" action="{{ query_list_path }}" method="get">
-    <p class="query-list-search">
-        <label for="query-search">Search</label>
-        <input id="query-search" type="search" name="q" value="{{ filters.q }}">
-        {% if filters.is_write %}<input type="hidden" name="is_write" value="{{ filters.is_write }}">{% endif %}
-        {% if filters.is_private %}<input type="hidden" name="is_private" value="{{ filters.is_private }}">{% endif %}
-        {% if filters.source %}<input type="hidden" name="source" value="{{ filters.source }}">{% endif %}
-        {% if filters.owner_id %}<input type="hidden" name="owner_id" value="{{ filters.owner_id }}">{% endif %}
-        <button type="submit">Search</button>
-    </p>
-</form>
-
-<nav class="query-list-facets" aria-label="Query filters">
-    {% for facet in facets %}
-        <section class="query-list-facet">
-            <h2>{{ facet.title }}</h2>
-            <ul>
-                {% for item in facet["items"] %}
-                    <li>{% if item.href %}<a class="query-list-facet-link{% if item.active %} query-list-facet-link-active{% endif %}" href="{{ item.href }}"{% if item.active %} aria-current="true"{% endif %}>{% else %}<span class="query-list-facet-link query-list-facet-disabled">{% endif %}<span>{{ item.label }}</span><span class="query-list-facet-count">{{ item.count }}</span>{% if item.href %}</a>{% else %}</span>{% endif %}</li>
-                {% endfor %}
-            </ul>
-        </section>
-    {% endfor %}
-</nav>
-
 {% if queries %}
+    <form class="query-list-filters core" action="{{ query_list_path }}" method="get">
+        <p class="query-list-search">
+            <label for="query-search">Search</label>
+            <input id="query-search" type="search" name="q" value="{{ filters.q }}">
+            {% if filters.is_write %}<input type="hidden" name="is_write" value="{{ filters.is_write }}">{% endif %}
+            {% if filters.is_private %}<input type="hidden" name="is_private" value="{{ filters.is_private }}">{% endif %}
+            {% if filters.source %}<input type="hidden" name="source" value="{{ filters.source }}">{% endif %}
+            {% if filters.owner_id %}<input type="hidden" name="owner_id" value="{{ filters.owner_id }}">{% endif %}
+            <button type="submit">Search</button>
+        </p>
+    </form>
+
+    <nav class="query-list-facets" aria-label="Query filters">
+        {% for facet in facets %}
+            <section class="query-list-facet">
+                <h2>{{ facet.title }}</h2>
+                <ul>
+                    {% for item in facet["items"] %}
+                        <li>{% if item.href %}<a class="query-list-facet-link{% if item.active %} query-list-facet-link-active{% endif %}" href="{{ item.href }}"{% if item.active %} aria-current="true"{% endif %}>{% else %}<span class="query-list-facet-link query-list-facet-disabled">{% endif %}<span>{{ item.label }}</span><span class="query-list-facet-count">{{ item.count }}</span>{% if item.href %}</a>{% else %}</span>{% endif %}</li>
+                    {% endfor %}
+                </ul>
+            </section>
+        {% endfor %}
+    </nav>
+
     <div class="table-wrapper"><table class="query-list-results">
         <thead>
             <tr>

--- a/datasette/views/query_helpers.py
+++ b/datasette/views/query_helpers.py
@@ -436,6 +436,35 @@ async def _query_create_form_context(
     }
 
 
+async def _query_edit_form_context(
+    datasette,
+    request,
+    db,
+    existing: StoredQuery,
+    *,
+    sql=None,
+    title=None,
+    description=None,
+    is_private=None,
+):
+    sql = existing.sql if sql is None else sql
+    title = existing.title if title is None else title
+    description = existing.description if description is None else description
+    is_private = existing.is_private if is_private is None else is_private
+    analysis_data = await _query_create_analysis_data(datasette, db, sql, request.actor)
+    return {
+        "database": db.name,
+        "database_color": db.color,
+        "name": existing.name,
+        "sql": sql,
+        "title": title or "",
+        "description": description or "",
+        "is_private": is_private,
+        "query_url": datasette.urls.table(db.name, existing.name),
+        **analysis_data,
+    }
+
+
 async def _inserted_row_url(datasette, db, analysis, cursor):
     if cursor.rowcount != 1:
         return None

--- a/datasette/views/stored_queries.py
+++ b/datasette/views/stored_queries.py
@@ -641,6 +641,4 @@ class QueryDeleteView(BaseView):
             "Query “{}” deleted".format(existing.title or query_name),
             self.ds.INFO,
         )
-        return Response.redirect(
-            self.ds.urls.path(self.ds.urls.database(db.name) + "/-/queries")
-        )
+        return Response.redirect(self.ds.urls.path(self.ds.urls.database(db.name)))

--- a/datasette/views/stored_queries.py
+++ b/datasette/views/stored_queries.py
@@ -18,6 +18,7 @@ from .query_helpers import (
     _query_create_analysis_data,
     _query_create_form_context,
     _query_create_form_error_message,
+    _query_edit_form_context,
     _query_list_limit,
 )
 
@@ -464,13 +465,164 @@ class QueryUpdateView(BaseView):
         return Response.json({"ok": True})
 
 
-class QueryDeleteView(BaseView):
-    name = "query-delete"
+class QueryEditView(BaseView):
+    name = "query-edit"
+    has_json_alternate = False
 
-    async def post(self, request):
+    async def _load(self, request):
         db = await self.ds.resolve_database(request)
         query_name = tilde_decode(request.url_vars["query"])
         existing = await self.ds.get_query(db.name, query_name)
+        return db, query_name, existing
+
+    async def _render_form(
+        self,
+        request,
+        db,
+        existing,
+        *,
+        sql=None,
+        title=None,
+        description=None,
+        is_private=None,
+        status=200,
+    ):
+        response = await self.render(
+            ["query_edit.html"],
+            request,
+            await _query_edit_form_context(
+                self.ds,
+                request,
+                db,
+                existing,
+                sql=sql,
+                title=title,
+                description=description,
+                is_private=is_private,
+            ),
+        )
+        response.status = status
+        return response
+
+    async def get(self, request):
+        db, query_name, existing = await self._load(request)
+        if existing is None:
+            return _error(["Query not found: {}".format(query_name)], 404)
+        await self.ds.ensure_permission(
+            action="update-query",
+            resource=QueryResource(db.name, query_name),
+            actor=request.actor,
+        )
+        if existing.is_trusted:
+            return _error(["Trusted queries cannot be edited"], 403)
+        return await self._render_form(request, db, existing)
+
+    async def post(self, request):
+        db, query_name, existing = await self._load(request)
+        if existing is None:
+            return _error(["Query not found: {}".format(query_name)], 404)
+        if not await self.ds.allowed(
+            action="update-query",
+            resource=QueryResource(db.name, query_name),
+            actor=request.actor,
+        ):
+            return _error(["Permission denied: need update-query"], 403)
+        if existing.is_trusted:
+            return _error(["Trusted queries cannot be edited"], 403)
+
+        data, _ = await _json_or_form_payload(request)
+        if not isinstance(data, dict):
+            return _error(["Invalid form submission"], 400)
+        sql = data.get("sql")
+        sql = existing.sql if sql is None else sql.strip()
+        title = data.get("title") or ""
+        description = data.get("description") or ""
+        is_private = _as_bool(data.get("is_private"))
+
+        update = {
+            "title": title,
+            "description": description,
+            "is_private": is_private,
+        }
+        if sql != existing.sql:
+            if not await self.ds.allowed(
+                action="execute-sql",
+                resource=DatabaseResource(db.name),
+                actor=request.actor,
+            ):
+                self.ds.add_message(
+                    request,
+                    "Permission denied: need execute-sql to change the SQL",
+                    self.ds.ERROR,
+                )
+                return await self._render_form(
+                    request,
+                    db,
+                    existing,
+                    sql=sql,
+                    title=title,
+                    description=description,
+                    is_private=is_private,
+                    status=403,
+                )
+            update["sql"] = sql
+
+        try:
+            update_kwargs = await _prepare_query_update(
+                self.ds, request, db, existing, update
+            )
+        except QueryValidationError as ex:
+            self.ds.add_message(request, ex.message, self.ds.ERROR)
+            return await self._render_form(
+                request,
+                db,
+                existing,
+                sql=sql,
+                title=title,
+                description=description,
+                is_private=is_private,
+                status=ex.status,
+            )
+
+        await self.ds.update_query(db.name, query_name, **update_kwargs)
+        self.ds.add_message(request, "Query updated", self.ds.INFO)
+        return Response.redirect(
+            self.ds.urls.path(self.ds.urls.table(db.name, query_name))
+        )
+
+
+class QueryDeleteView(BaseView):
+    name = "query-delete"
+    has_json_alternate = False
+
+    async def _load(self, request):
+        db = await self.ds.resolve_database(request)
+        query_name = tilde_decode(request.url_vars["query"])
+        existing = await self.ds.get_query(db.name, query_name)
+        return db, query_name, existing
+
+    async def get(self, request):
+        db, query_name, existing = await self._load(request)
+        if existing is None:
+            return _error(["Query not found: {}".format(query_name)], 404)
+        await self.ds.ensure_permission(
+            action="delete-query",
+            resource=QueryResource(db.name, query_name),
+            actor=request.actor,
+        )
+        return await self.render(
+            ["query_delete.html"],
+            request,
+            {
+                "database": db.name,
+                "database_color": db.color,
+                "query": stored_query_to_dict(existing),
+                "query_url": self.ds.urls.table(db.name, query_name),
+            },
+        )
+
+    async def post(self, request):
+        db, query_name, existing = await self._load(request)
         if existing is None:
             return _error(["Query not found: {}".format(query_name)], 404)
         if not await self.ds.allowed(
@@ -479,5 +631,16 @@ class QueryDeleteView(BaseView):
             actor=request.actor,
         ):
             return _error(["Permission denied: need delete-query"], 403)
+
+        data, is_json = await _json_or_form_payload(request)
         await self.ds.remove_query(db.name, query_name)
-        return Response.json({"ok": True})
+        if is_json:
+            return Response.json({"ok": True})
+        self.ds.add_message(
+            request,
+            "Query “{}” deleted".format(existing.title or query_name),
+            self.ds.INFO,
+        )
+        return Response.redirect(
+            self.ds.urls.path(self.ds.urls.database(db.name) + "/-/queries")
+        )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,13 @@
 Changelog
 =========
 
+.. _v1_0_a33:
+
+1.0a33 (unreleased)
+-------------------
+
+- Stored queries can now be edited and deleted from the web interface. The stored query page gained a "Query actions" menu with **Edit this query** and **Delete this query** links for actors with the necessary permissions. The owner of a query can always edit or delete it; for queries that are not private, any actor with the :ref:`update-query <actions_update_query>` or :ref:`delete-query <actions_delete_query>` permission can do so too. Private queries remain editable and deletable only by their owner. See :ref:`stored_queries` for details. (:issue:`2735`)
+
 .. _v1_0_a32:
 
 1.0a32 (2026-05-31)

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -272,6 +272,15 @@ If you run ``datasette plugins --all`` it will include default plugins that ship
             ]
         },
         {
+            "name": "datasette.default_query_actions",
+            "static": false,
+            "templates": false,
+            "version": null,
+            "hooks": [
+                "query_actions"
+            ]
+        },
+        {
             "name": "datasette.events",
             "static": false,
             "templates": false,

--- a/docs/sql_queries.rst
+++ b/docs/sql_queries.rst
@@ -142,6 +142,15 @@ Datasette stores both configured queries and user-created queries in the ``queri
 
 Stored queries created by users default to private. Private stored queries can only be viewed, updated or deleted by the actor that created them. Broad ``view-query``, ``update-query`` or ``delete-query`` permission grants still do not allow other actors to access another actor's private stored queries.
 
+Editing and deleting stored queries
++++++++++++++++++++++++++++++++++++
+
+The page for a stored query includes a "Query actions" menu with **Edit this query** and **Delete this query** links for actors who have permission to use them.
+
+The owner of a stored query can always edit and delete it. For queries that are not private, any actor granted the ``update-query`` or ``delete-query`` permission can edit or delete the query, even if they did not create it. Private queries can only be edited or deleted by their owner, regardless of any broad permission grants.
+
+Editing a query lets you change its title, description, SQL and whether it is private. Changing the SQL also requires the ``execute-sql`` permission (and the relevant write permissions for writable queries). The same operations are available through the JSON API by sending a ``POST`` to ``/<database>/<query>/-/update`` or ``/<database>/<query>/-/delete``. Trusted stored queries cannot be edited or deleted through the web interface or the JSON API.
+
 Stored queries created by users are untrusted. This means they execute using the permissions of the actor who runs them, as if that actor had pasted the SQL into the regular custom SQL interface or write SQL interface. Read-only stored queries require ``execute-sql``. Writable stored queries require ``execute-write-sql`` plus the relevant table-level write permissions. SQL functions are allowed and are not separately restricted by Datasette permissions.
 
 .. _trusted_stored_queries:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -77,6 +77,7 @@ def documented_views():
             "QueryCreateAnalyzeView",
             "QueryDeleteView",
             "QueryDefinitionView",
+            "QueryEditView",
             "QueryListView",
             "QueryParametersView",
             "QueryStoreView",

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -3,6 +3,7 @@ import re
 from html import unescape
 
 import pytest
+from bs4 import BeautifulSoup as Soup
 
 from datasette.app import Datasette
 from datasette.resources import DatabaseResource, QueryResource
@@ -712,6 +713,10 @@ async def test_query_list_search_filter_and_html():
         "/data/-/queries?is_private=1",
         actor={"id": "root"},
     )
+    no_results_response = await ds.client.get(
+        "/data/-/queries?q=nope",
+        actor={"id": "root"},
+    )
 
     assert html_response.status_code == 200
     assert "Demo query 02" in html_response.text
@@ -799,6 +804,13 @@ async def test_query_list_search_filter_and_html():
         '<span class="query-list-facet-link query-list-facet-disabled"><span>Not private</span><span class="query-list-facet-count">0</span></span>'
         not in filtered_private_response.text
     )
+    assert no_results_response.status_code == 200
+    assert "No queries found." in no_results_response.text
+    assert 'class="query-list-filters core"' not in no_results_response.text
+    assert 'id="query-search"' not in no_results_response.text
+    assert 'class="query-list-facets"' not in no_results_response.text
+    assert "<h2>Mode</h2>" not in no_results_response.text
+    assert "<h2>Visibility</h2>" not in no_results_response.text
 
 
 @pytest.mark.asyncio
@@ -1274,6 +1286,11 @@ async def test_query_delete_confirmation_and_form_delete():
     assert get_response.status_code == 200
     assert "Are you sure" in get_response.text
     assert "select * from dogs" in get_response.text
+    soup = Soup(get_response.text, "html.parser")
+    form = soup.select_one("form.query-delete-form")
+    assert form is not None
+    assert "core" in form["class"]
+    assert form.select_one('input[type="submit"][value="Delete query"]') is not None
 
     post_response = await ds.client.post(
         "/data/saved/-/delete",
@@ -1281,7 +1298,7 @@ async def test_query_delete_confirmation_and_form_delete():
         data={},
     )
     assert post_response.status_code == 302
-    assert post_response.headers["location"] == "/data/-/queries"
+    assert post_response.headers["location"] == "/data"
     assert await ds.get_query("data", "saved") is None
 
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1114,6 +1114,222 @@ async def test_query_update_api_rejects_trusted_queries_but_internal_update_allo
     assert query.title == "Internal"
 
 
+async def _make_ds_with_user_query(name, *, is_private=False, owner_id="owner"):
+    ds = Datasette(memory=True, settings={"default_allow_sql": True})
+    db = ds.add_memory_database(name, name="data")
+    await db.execute_write("create table dogs (id integer primary key, name text)")
+    await ds.invoke_startup()
+    await ds.add_query(
+        "data",
+        "saved",
+        "select * from dogs",
+        title="Saved query",
+        description="A saved query",
+        source="user",
+        owner_id=owner_id,
+        is_private=is_private,
+    )
+    return ds
+
+
+@pytest.mark.asyncio
+async def test_query_edit_form_renders_and_updates_for_owner():
+    ds = await _make_ds_with_user_query("query_edit_owner")
+    actor = {"id": "owner"}
+
+    # GET renders the form pre-filled with existing values
+    get_response = await ds.client.get("/data/saved/-/edit", actor=actor)
+    assert get_response.status_code == 200
+    assert 'value="Saved query"' in get_response.text
+    assert ">A saved query</textarea>" in get_response.text
+    assert "select * from dogs" in get_response.text
+    # URL slug is shown but not editable
+    assert 'name="name"' not in get_response.text
+
+    # POST updates the query and redirects back to the query page
+    post_response = await ds.client.post(
+        "/data/saved/-/edit",
+        actor=actor,
+        data={
+            "title": "Updated title",
+            "description": "Updated description",
+            "sql": "select id from dogs",
+            "is_private": "1",
+        },
+    )
+    assert post_response.status_code == 302
+    assert post_response.headers["location"] == "/data/saved"
+
+    query = await ds.get_query("data", "saved")
+    assert query.title == "Updated title"
+    assert query.description == "Updated description"
+    assert query.sql == "select id from dogs"
+    assert query.is_private is True
+
+
+@pytest.mark.asyncio
+async def test_query_edit_metadata_only_does_not_require_execute_sql():
+    # An owner who can no longer execute SQL can still edit title/description
+    ds = await _make_ds_with_user_query("query_edit_metadata_only")
+    actor = {"id": "owner"}
+
+    post_response = await ds.client.post(
+        "/data/saved/-/edit",
+        actor=actor,
+        data={
+            "title": "Renamed",
+            "description": "A saved query",
+            "sql": "select * from dogs",
+        },
+    )
+    assert post_response.status_code == 302
+    query = await ds.get_query("data", "saved")
+    assert query.title == "Renamed"
+
+
+@pytest.mark.asyncio
+async def test_private_query_edit_delete_restricted_to_owner():
+    ds = await _make_ds_with_user_query(
+        "query_edit_private", is_private=True, owner_id="owner"
+    )
+
+    # A different actor cannot view, edit or delete the private query
+    other = {"id": "intruder"}
+    assert (await ds.client.get("/data/saved/-/edit", actor=other)).status_code == 403
+    assert (
+        await ds.client.get("/data/saved/-/delete", actor=other)
+    ).status_code == 403
+    delete_attempt = await ds.client.post(
+        "/data/saved/-/delete",
+        actor=other,
+        data={},
+    )
+    assert delete_attempt.status_code == 403
+    assert await ds.get_query("data", "saved") is not None
+
+    # The owner can edit and delete
+    owner = {"id": "owner"}
+    assert (await ds.client.get("/data/saved/-/edit", actor=owner)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_non_private_query_editable_by_permitted_non_owner():
+    ds = Datasette(
+        memory=True,
+        default_deny=True,
+        config={
+            "databases": {
+                "data": {
+                    "permissions": {
+                        "execute-sql": {"id": "editor"},
+                        "update-query": {"id": "editor"},
+                        "delete-query": {"id": "editor"},
+                    }
+                }
+            }
+        },
+    )
+    db = ds.add_memory_database("query_non_private_editor", name="data")
+    await db.execute_write("create table dogs (id integer primary key, name text)")
+    await ds.invoke_startup()
+    await ds.add_query(
+        "data",
+        "saved",
+        "select * from dogs",
+        title="Shared",
+        source="user",
+        owner_id="owner",
+        is_private=False,
+    )
+
+    editor = {"id": "editor"}
+    # Editor (not the owner) can edit because the query is not private
+    post_response = await ds.client.post(
+        "/data/saved/-/edit",
+        actor=editor,
+        data={
+            "title": "Edited by editor",
+            "description": "",
+            "sql": "select * from dogs",
+        },
+    )
+    assert post_response.status_code == 302
+    query = await ds.get_query("data", "saved")
+    assert query.title == "Edited by editor"
+
+    # Editor can also delete it
+    delete_response = await ds.client.post(
+        "/data/saved/-/delete",
+        actor=editor,
+        data={},
+    )
+    assert delete_response.status_code == 302
+    assert await ds.get_query("data", "saved") is None
+
+
+@pytest.mark.asyncio
+async def test_query_delete_confirmation_and_form_delete():
+    ds = await _make_ds_with_user_query("query_delete_form")
+    actor = {"id": "owner"}
+
+    get_response = await ds.client.get("/data/saved/-/delete", actor=actor)
+    assert get_response.status_code == 200
+    assert "Are you sure" in get_response.text
+    assert "select * from dogs" in get_response.text
+
+    post_response = await ds.client.post(
+        "/data/saved/-/delete",
+        actor=actor,
+        data={},
+    )
+    assert post_response.status_code == 302
+    assert post_response.headers["location"] == "/data/-/queries"
+    assert await ds.get_query("data", "saved") is None
+
+
+@pytest.mark.asyncio
+async def test_query_action_menu_shows_edit_and_delete_for_owner():
+    ds = await _make_ds_with_user_query("query_action_menu")
+
+    owner_response = await ds.client.get("/data/saved", actor={"id": "owner"})
+    assert owner_response.status_code == 200
+    assert "/data/saved/-/edit" in owner_response.text
+    assert "/data/saved/-/delete" in owner_response.text
+
+    # A different actor (the query is public) cannot edit/delete by default
+    other_response = await ds.client.get("/data/saved", actor={"id": "stranger"})
+    assert other_response.status_code == 200
+    assert "/data/saved/-/edit" not in other_response.text
+    assert "/data/saved/-/delete" not in other_response.text
+
+
+@pytest.mark.asyncio
+async def test_query_edit_rejected_for_trusted_query():
+    ds = Datasette(
+        memory=True,
+        default_deny=True,
+        config={
+            "databases": {
+                "data": {
+                    "permissions": {
+                        "execute-sql": {"id": "editor"},
+                        "update-query": {"id": "editor"},
+                    },
+                    "queries": {"trusted_report": {"sql": "select 1 as one"}},
+                }
+            }
+        },
+    )
+    ds.add_memory_database("query_edit_trusted", name="data")
+    await ds.invoke_startup()
+
+    response = await ds.client.get("/data/trusted_report/-/edit", actor={"id": "editor"})
+    assert response.status_code == 403
+    # Edit/delete links should not appear on a trusted/config query page
+    page = await ds.client.get("/data/trusted_report", actor={"id": "editor"})
+    assert "/data/trusted_report/-/edit" not in page.text
+
+
 @pytest.mark.asyncio
 async def test_query_store_api_rejects_magic_parameters():
     ds = Datasette(memory=True, default_deny=True)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1196,9 +1196,7 @@ async def test_private_query_edit_delete_restricted_to_owner():
     # A different actor cannot view, edit or delete the private query
     other = {"id": "intruder"}
     assert (await ds.client.get("/data/saved/-/edit", actor=other)).status_code == 403
-    assert (
-        await ds.client.get("/data/saved/-/delete", actor=other)
-    ).status_code == 403
+    assert (await ds.client.get("/data/saved/-/delete", actor=other)).status_code == 403
     delete_attempt = await ds.client.post(
         "/data/saved/-/delete",
         actor=other,
@@ -1323,7 +1321,9 @@ async def test_query_edit_rejected_for_trusted_query():
     ds.add_memory_database("query_edit_trusted", name="data")
     await ds.invoke_startup()
 
-    response = await ds.client.get("/data/trusted_report/-/edit", actor={"id": "editor"})
+    response = await ds.client.get(
+        "/data/trusted_report/-/edit", actor={"id": "editor"}
+    )
     assert response.status_code == 403
     # Edit/delete links should not appear on a trusted/config query page
     page = await ds.client.get("/data/trusted_report", actor={"id": "editor"})


### PR DESCRIPTION
> Review recent changes, add the ability for users to edit and delete the canned queries that they saved
> 
> Private should only be editable deletable by the owning user
> 
> Non-private should allow edit and delete from any user with the necessary permissions


<details><summary>Claude Code output</summary>

Stored query pages now offer Edit and Delete actions in the query
actions menu, gated by the update-query and delete-query permissions.

- New QueryEditView (GET/POST at /<db>/<query>/-/edit) renders a
  pre-filled form for editing a query's title, description, SQL and
  privacy, reusing the create-query analysis UI. Changing the SQL still
  requires execute-sql; metadata-only edits do not.
- QueryDeleteView gains a GET confirmation page and HTML form POST that
  redirects to the query list, while keeping the existing JSON API.
- New default query_actions hook adds the Edit/Delete links for stored
  (non-config, non-trusted) queries the actor is allowed to manage.

Permission semantics (already enforced by default_query_permissions_sql)
are surfaced in the UI: owners can always edit/delete their queries;
non-private queries can be edited/deleted by any actor with the relevant
permission; private queries remain owner-only.

Shared the create-query form styles into _query_form_styles.html so the
edit form can reuse them.

</details>

https://claude.ai/code/session_019GU9g3pZAERukLKYNa4uAL

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2764.org.readthedocs.build/en/2764/

<!-- readthedocs-preview datasette end -->