### PR TITLE
Fix _col=<pk> producing duplicate column in output

### DIFF
--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -865,8 +865,8 @@ async def _columns_to_select(table_columns, pks, request):
                 "_col={} - invalid columns".format(", ".join(bad_columns)),
                 status=400,
             )
-        # De-duplicate maintaining order:
-        columns.extend(dict.fromkeys(_cols))
+        # De-duplicate maintaining order, skipping columns already added (pks):
+        columns.extend(c for c in dict.fromkeys(_cols) if c not in columns)
     if "_nocol" in request.args:
         # Return all columns EXCEPT these
         bad_columns = [

--- a/tests/test_table_api.py
+++ b/tests/test_table_api.py
@@ -1421,6 +1421,16 @@ def test_generated_columns_are_visible_in_datasette():
             ["pk", "state"],
         ),
         (
+            # https://github.com/simonw/datasette/issues/1975
+            "/fixtures/facetable.json?_col=pk&_col=state",
+            ["pk", "state"],
+        ),
+        (
+            # https://github.com/simonw/datasette/issues/1975
+            "/fixtures/facetable.json?_col=pk",
+            ["pk"],
+        ),
+        (
             "/fixtures/facetable.json?_col=state&_col=created&_nocol=created",
             ["pk", "state"],
         ),


### PR DESCRIPTION
Fixes:
- #1975

When `_col=<pk_column>` is passed (e.g. `?_col=id&_col=title&_col=body` on a table whose pk is `id`), `_columns_to_select` starts `columns` with the pks and then extends it with the deduplicated `_col` list — but the dedup is only within `_col` itself, not against the pks already in `columns`. So `id` ends up in the SELECT twice:

```
$ /simonwillisonblog/blog_entry.csv?_col=id&_col=title&_col=body&_size=1
id,id,title,body
1,1,WaSP Phase II,...
```

This skips `_col` values that already appear in `columns` (i.e. the pks) when extending:

```python
columns.extend(c for c in dict.fromkeys(_cols) if c not in columns)
```

Behavior notes:
- Pks still appear first in the configured order; ordering of additional `_col` values is unchanged.
- Existing `_col=state&_col=state` dedup-within-`_col` behavior is preserved.
- `_nocol` interaction is unchanged — it still filters the final list.

Added two regression cases to `test_col_nocol`, both linked to the issue:

- `?_col=pk&_col=state` → `["pk", "state"]`
- `?_col=pk` → `["pk"]`

Also probed multi-pk tables (`pk=[a,b]`) and pk-only requests; both produce the expected dedup behavior.

Prepared with AI assistance.