### PR TITLE
fix: remove chunked database download header

### DIFF
--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -444,7 +444,6 @@ async def database_download(request, datasette):
         if_none_match = request.headers.get("if-none-match")
         if if_none_match and if_none_match == etag:
             return Response("", status=304)
-    headers["Transfer-Encoding"] = "chunked"
     return AsgiFileDownload(
         filepath,
         filename=os.path.basename(filepath),

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -548,12 +548,12 @@ def test_database_download_for_immutable():
         content_length = download_response.headers["content-length"]
         assert content_length.isdigit()
         assert int(content_length) > 100
+        assert "transfer-encoding" not in download_response.headers
         assert "content-disposition" in download_response.headers
         assert (
             download_response.headers["content-disposition"]
             == 'attachment; filename="fixtures.db"'
         )
-        assert download_response.headers["transfer-encoding"] == "chunked"
         # ETag header should be present and match db.hash
         assert "etag" in download_response.headers
         etag = download_response.headers["etag"]


### PR DESCRIPTION
## Problem

Database downloads include both a `Content-Length` header and an explicit `Transfer-Encoding: chunked` header. Browsers do not show download progress for that response shape, even though the file size is already known.

Closes #2663.

## Solution

I removed the manual `Transfer-Encoding: chunked` header from immutable database downloads and updated the existing download test to assert that the response keeps `Content-Length` without setting `transfer-encoding`.

## Testing

- `uv run ruff check datasette\views\database.py tests\test_html.py`
- `uv run black --check datasette\views\database.py tests\test_html.py`
- `git diff --check`

I also ran `uv run pytest tests\test_html.py -k database_download_for_immutable -q`. The response assertions completed, but the test fails during Windows temporary directory cleanup with `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process`; that looks like the existing Windows file-handle cleanup issue tracked separately from this header change.