### PR TITLE
Fix named_parameters when string literals contain comment markers

### DIFF
--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -1245,10 +1245,18 @@ class StartupError(Exception):
     pass
 
 
-_single_line_comment_re = re.compile(r"--.*")
-_multi_line_comment_re = re.compile(r"/\*.*?\*/", re.DOTALL)
-_single_quote_re = re.compile(r"'(?:''|[^'])*'")
-_double_quote_re = re.compile(r'"(?:\"\"|[^"])*"')
+# Comments and string literals, matched in a single pass so that whichever
+# construct starts first "wins" - this ensures a comment marker inside a string
+# literal (or a quote inside a comment) does not confuse the parameter scan.
+_comments_and_strings_re = re.compile(
+    r"""
+    --[^\n]*            # single line comment
+    | /\*.*?\*/         # multi line comment
+    | '(?:''|[^'])*'    # single quoted string ('' escapes a quote)
+    | "(?:""|[^"])*"    # double quoted identifier ("" escapes a quote)
+    """,
+    re.DOTALL | re.VERBOSE,
+)
 _named_param_re = re.compile(r":(\w+)")
 
 
@@ -1259,10 +1267,9 @@ def named_parameters(sql: str) -> List[str]:
 
     e.g. for ``select * from foo where id=:id`` this would return ``["id"]``
     """
-    sql = _single_line_comment_re.sub("", sql)
-    sql = _multi_line_comment_re.sub("", sql)
-    sql = _single_quote_re.sub("", sql)
-    sql = _double_quote_re.sub("", sql)
+    # Strip comments and string literals first so that any ":name" sequences
+    # inside them are not mistaken for named parameters
+    sql = _comments_and_strings_re.sub("", sql)
     # Extract parameters from what is left
     return _named_param_re.findall(sql)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -733,6 +733,16 @@ def test_parse_metadata(content, expected):
         ("select 1 + :one + :two", ["one", "two"]),
         ("select 'bob' || '0:00' || :cat", ["cat"]),
         ("select this is invalid :one, :two, :three", ["one", "two", "three"]),
+        # A string literal containing a comment marker should not hide
+        # parameters that come after it
+        ("select * from t where note = '-- TODO' and id = :id", ["id"]),
+        ("select '--' || :y", ["y"]),
+        ("select * from t where note = '/* x */' and id = :id", ["id"]),
+        # Parameters that live inside a comment should be ignored
+        ("select :x -- and :ignored", ["x"]),
+        ("select :x /* and :ignored */ from t", ["x"]),
+        # Parameters inside a string literal should be ignored
+        ("select ':ignored' || :real", ["real"]),
     ),
 )
 @pytest.mark.parametrize("use_async_version", (False, True))


### PR DESCRIPTION
## Bug

`named_parameters()` (and therefore `derive_named_parameters()`) stripped SQL comments before string literals, in separate regex passes. A string literal that contains a comment marker is then mistaken for the start of a comment.

For example:

```sql
select * from t where note = '-- TODO' and id = :id
```

returned `[]` instead of `["id"]` — the `--` inside the `'-- TODO'` string literal was treated as the start of a line comment, which swallowed the rest of the line and hid the `:id` parameter. In the query UI this means the parameter input form silently loses fields for any query whose string literals contain `--` or `/* */`.

## Fix

Match comments and string literals in a single left-to-right pass so that whichever construct *starts first* wins — this is how SQL is actually tokenized, so a `--` inside a string is part of the string, and a quote inside a comment is part of the comment. This also keeps the existing behaviour of ignoring parameters that appear inside comments or string literals.

## Verification

```
uv run pytest tests/test_utils.py -k test_named_parameters
```

Result: `22 passed`. New parametrized cases cover string literals containing `--` / `/* */`, parameters inside comments, and parameters inside string literals. The full `tests/test_utils.py` (213 tests) and the query-page HTML tests still pass.
