### PR TITLE
Bulk insert mechanism in the insert row dialog

### DIFF
--- a/datasette/static/app.css
+++ b/datasette/static/app.css
@@ -1819,20 +1819,30 @@ textarea.row-edit-input {
     display: none;
 }
 
-.row-edit-bulk-label {
-    color: var(--ink);
-    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    font-size: 0.82rem;
-}
-
 .row-edit-bulk-actions {
     display: flex;
-    justify-content: flex-end;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-start;
 }
 
 .row-edit-bulk-actions .btn {
     padding-left: 12px;
     padding-right: 12px;
+}
+
+.row-edit-copy-template-label-narrow {
+    display: none;
+}
+
+.row-edit-bulk-template-note {
+    color: var(--muted);
+    font-size: 0.82rem;
+}
+
+.row-edit-bulk-template-note-narrow {
+    display: none;
 }
 
 .row-edit-bulk-textarea {
@@ -1853,6 +1863,28 @@ textarea.row-edit-input {
     color: var(--muted);
     font-size: 0.82rem;
     margin: 0;
+}
+
+.row-edit-bulk-note .button-as-link {
+    font: inherit;
+}
+
+@media (max-width: 640px) {
+    .row-edit-copy-template-label-wide {
+        display: none;
+    }
+
+    .row-edit-copy-template-label-narrow {
+        display: inline;
+    }
+
+    .row-edit-bulk-template-note-wide {
+        display: none;
+    }
+
+    .row-edit-bulk-template-note-narrow {
+        display: inline;
+    }
 }
 
 .row-edit-bulk-preview {

--- a/datasette/static/app.css
+++ b/datasette/static/app.css
@@ -1865,6 +1865,7 @@ textarea.row-edit-input {
     margin: 0;
 }
 
+.row-edit-bulk-note label,
 .row-edit-bulk-note .button-as-link {
     font: inherit;
 }
@@ -1924,10 +1925,11 @@ textarea.row-edit-input {
     border-bottom: 1px solid var(--rule);
     border-right: 1px solid var(--rule);
     max-width: 18rem;
+    overflow-wrap: anywhere;
     padding: 6px 8px;
     text-align: left;
     vertical-align: top;
-    white-space: nowrap;
+    white-space: normal;
 }
 
 .row-edit-bulk-preview-table th {
@@ -2296,6 +2298,11 @@ select.table-create-input {
     margin: 0;
 }
 
+.table-create-data-note label,
+.table-create-data-note .button-as-link {
+    font: inherit;
+}
+
 .table-create-data-preview {
     display: grid;
     gap: 10px;
@@ -2335,10 +2342,11 @@ select.table-create-input {
     border-bottom: 1px solid var(--rule);
     border-right: 1px solid var(--rule);
     max-width: 18rem;
+    overflow-wrap: anywhere;
     padding: 6px 8px;
     text-align: left;
     vertical-align: top;
-    white-space: nowrap;
+    white-space: normal;
 }
 
 .table-create-data-preview-table th {

--- a/datasette/static/app.css
+++ b/datasette/static/app.css
@@ -1832,6 +1832,34 @@ textarea.row-edit-input {
     padding-right: 12px;
 }
 
+.row-edit-bulk-conflict {
+    display: grid;
+    grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
+    gap: 8px 12px;
+    align-items: start;
+}
+
+.row-edit-bulk-conflict[hidden] {
+    display: none;
+}
+
+.row-edit-bulk-conflict-label {
+    color: var(--ink);
+    font-size: 0.82rem;
+    padding-top: 8px;
+}
+
+.row-edit-bulk-conflict-control {
+    display: grid;
+    gap: 4px;
+}
+
+.row-edit-bulk-conflict-help {
+    color: var(--muted);
+    font-size: 0.78rem;
+    margin: 0;
+}
+
 .row-edit-copy-template-label-narrow {
     display: none;
 }
@@ -3340,6 +3368,15 @@ select.table-alter-input {
     }
 
     .row-edit-label {
+        padding-top: 0;
+    }
+
+    .row-edit-bulk-conflict {
+        grid-template-columns: 1fr;
+        gap: 5px;
+    }
+
+    .row-edit-bulk-conflict-label {
         padding-top: 0;
     }
 

--- a/datasette/static/app.css
+++ b/datasette/static/app.css
@@ -2225,6 +2225,114 @@ select.table-create-input {
     gap: 10px;
 }
 
+.table-create-columns[hidden],
+.table-create-data[hidden],
+.table-create-data-editor[hidden],
+.table-create-data-preview[hidden] {
+    display: none;
+}
+
+.table-create-data,
+.table-create-data-editor {
+    display: grid;
+    gap: 8px;
+}
+
+.table-create-data-label {
+    color: var(--ink);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.82rem;
+}
+
+.table-create-data-textarea {
+    min-height: 16rem;
+    resize: vertical;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.82rem;
+    line-height: 1.45;
+}
+
+.table-create-data-textarea.table-create-data-drop-target {
+    border-color: var(--accent);
+    background: #f8fbff;
+    outline: 3px solid rgba(26, 86, 219, 0.12);
+}
+
+.table-create-data-note {
+    color: var(--muted);
+    font-size: 0.82rem;
+    margin: 0;
+}
+
+.table-create-data-preview {
+    display: grid;
+    gap: 10px;
+}
+
+.table-create-data-preview-summary {
+    color: var(--ink);
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.table-create-data-pk-field {
+    display: grid;
+    grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
+    gap: 12px;
+    align-items: center;
+}
+
+.table-create-data-preview-table-wrap {
+    border: 1px solid var(--rule);
+    border-radius: 5px;
+    max-height: 18rem;
+    overflow: auto;
+    background: #fff;
+}
+
+.table-create-data-preview-table {
+    border-collapse: collapse;
+    font-size: 0.78rem;
+    min-width: 100%;
+    width: max-content;
+}
+
+.table-create-data-preview-table th,
+.table-create-data-preview-table td {
+    border-bottom: 1px solid var(--rule);
+    border-right: 1px solid var(--rule);
+    max-width: 18rem;
+    padding: 6px 8px;
+    text-align: left;
+    vertical-align: top;
+    white-space: nowrap;
+}
+
+.table-create-data-preview-table th {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-weight: 600;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+.table-create-data-preview-table tr:last-child td {
+    border-bottom: none;
+}
+
+.table-create-data-preview-table th:last-child,
+.table-create-data-preview-table td:last-child {
+    border-right: none;
+}
+
+.table-create-data-preview-null {
+    color: var(--muted);
+    font-style: italic;
+}
+
 .table-create-column-list {
     display: grid;
     gap: 8px;
@@ -2450,6 +2558,16 @@ select.table-create-input {
     gap: 10px;
     flex-shrink: 0;
     background: var(--paper);
+}
+
+.table-create-mode-link {
+    color: var(--accent);
+    font-size: 0.9rem;
+    margin-right: auto;
+}
+
+.table-create-mode-link[hidden] {
+    display: none;
 }
 
 .table-create-dialog .btn {
@@ -3214,6 +3332,11 @@ select.table-alter-input {
 
     .table-create-label {
         padding-top: 0;
+    }
+
+    .table-create-data-pk-field {
+        grid-template-columns: 1fr;
+        gap: 5px;
     }
 
     .table-create-column-headings {

--- a/datasette/static/app.css
+++ b/datasette/static/app.css
@@ -1979,7 +1979,8 @@ textarea.row-edit-input {
     border-right: none;
 }
 
-.row-edit-bulk-preview-null {
+.row-edit-bulk-preview-null,
+.row-edit-bulk-preview-auto {
     color: var(--muted);
     font-style: italic;
 }

--- a/datasette/static/app.css
+++ b/datasette/static/app.css
@@ -1641,6 +1641,11 @@ dialog.row-edit-dialog::backdrop {
     overflow-y: auto;
 }
 
+.row-edit-fields[hidden],
+.row-edit-bulk[hidden] {
+    display: none;
+}
+
 .row-edit-field {
     display: grid;
     grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
@@ -1798,6 +1803,144 @@ textarea.row-edit-input {
     margin: 0;
 }
 
+.row-edit-bulk {
+    display: grid;
+    gap: 8px;
+    padding: 16px 24px 24px;
+    overflow-y: auto;
+}
+
+.row-edit-bulk-editor {
+    display: grid;
+    gap: 8px;
+}
+
+.row-edit-bulk-editor[hidden] {
+    display: none;
+}
+
+.row-edit-bulk-label {
+    color: var(--ink);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.82rem;
+}
+
+.row-edit-bulk-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.row-edit-bulk-actions .btn {
+    padding-left: 12px;
+    padding-right: 12px;
+}
+
+.row-edit-bulk-textarea {
+    min-height: 16rem;
+    resize: vertical;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.82rem;
+    line-height: 1.45;
+}
+
+.row-edit-bulk-textarea.row-edit-bulk-drop-target {
+    border-color: var(--accent);
+    background: #f8fbff;
+    outline: 3px solid rgba(26, 86, 219, 0.12);
+}
+
+.row-edit-bulk-note {
+    color: var(--muted);
+    font-size: 0.82rem;
+    margin: 0;
+}
+
+.row-edit-bulk-preview {
+    display: grid;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.row-edit-bulk-preview[hidden] {
+    display: none;
+}
+
+.row-edit-bulk-preview-summary {
+    color: var(--ink);
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+.row-edit-bulk-preview-table-wrap {
+    border: 1px solid var(--rule);
+    border-radius: 5px;
+    max-height: 18rem;
+    overflow: auto;
+    background: #fff;
+}
+
+.row-edit-bulk-preview-table {
+    border-collapse: collapse;
+    font-size: 0.78rem;
+    min-width: 100%;
+    width: max-content;
+}
+
+.row-edit-bulk-preview-table th,
+.row-edit-bulk-preview-table td {
+    border-bottom: 1px solid var(--rule);
+    border-right: 1px solid var(--rule);
+    max-width: 18rem;
+    padding: 6px 8px;
+    text-align: left;
+    vertical-align: top;
+    white-space: nowrap;
+}
+
+.row-edit-bulk-preview-table th {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-weight: 600;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+.row-edit-bulk-preview-table tr:last-child td {
+    border-bottom: none;
+}
+
+.row-edit-bulk-preview-table th:last-child,
+.row-edit-bulk-preview-table td:last-child {
+    border-right: none;
+}
+
+.row-edit-bulk-preview-null {
+    color: var(--muted);
+    font-style: italic;
+}
+
+.row-edit-bulk-progress {
+    display: grid;
+    gap: 6px;
+}
+
+.row-edit-bulk-progress[hidden] {
+    display: none;
+}
+
+.row-edit-bulk-progress-bar {
+    width: 100%;
+}
+
+.row-edit-bulk-progress-status {
+    color: var(--ink);
+    font-size: 0.9rem;
+    margin: 0;
+}
+
 datasette-autocomplete {
     display: block;
     position: relative;
@@ -1874,6 +2017,16 @@ datasette-autocomplete input[type="text"],
     gap: 10px;
     flex-shrink: 0;
     background: var(--paper);
+}
+
+.row-edit-mode-link {
+    color: var(--accent);
+    font-size: 0.9rem;
+    margin-right: auto;
+}
+
+.row-edit-mode-link[hidden] {
+    display: none;
 }
 
 .row-edit-dialog .btn {
@@ -3012,7 +3165,8 @@ select.table-alter-input {
     .row-edit-dialog .modal-header,
     .row-edit-summary,
     .row-edit-loading,
-    .row-edit-fields {
+    .row-edit-fields,
+    .row-edit-bulk {
         padding-left: 18px;
         padding-right: 18px;
     }

--- a/datasette/static/edit-tools.js
+++ b/datasette/static/edit-tools.js
@@ -5611,7 +5611,7 @@ async function loadBulkInsertTextFile(state, file) {
 }
 
 function bulkInsertTemplateText(state) {
-  return (state.bulkInsertColumns || []).join("\t");
+  return (state.bulkInsertTemplateColumns || []).join("\t");
 }
 
 async function copyTextToClipboard(text) {
@@ -5893,8 +5893,7 @@ function bulkInsertLiveValidationShouldWait(message) {
   return (
     message === "Paste rows before previewing." ||
     message === "No data rows found to preview." ||
-    (message.indexOf("Invalid JSON:") === 0 &&
-      message.indexOf("Unexpected end") !== -1)
+    message.indexOf("Invalid JSON:") === 0
   );
 }
 
@@ -6607,7 +6606,10 @@ function renderRowInsertFields(state, data) {
   state.bulkInsertColumns = bulkColumns.map(function (column) {
     return column.name;
   });
-  state.copyTemplateButton.disabled = !state.bulkInsertColumns.length;
+  state.bulkInsertTemplateColumns = columns.map(function (column) {
+    return column.name;
+  });
+  state.copyTemplateButton.disabled = !state.bulkInsertTemplateColumns.length;
   setBulkInsertCopyButtonReady(state);
   syncBulkInsertConflictUi(state);
   clearTimeout(state.copyTemplateResetTimer);
@@ -6784,6 +6786,7 @@ function ensureRowEditDialog(manager) {
     bulkInsertHasPrimaryKeyColumns: false,
     bulkInsertLiveValidationError: null,
     bulkInsertColumns: [],
+    bulkInsertTemplateColumns: [],
     bulkInsertColumnDetails: [],
     bulkInsertPreviewRows: null,
     bulkInsertPreviewReady: false,

--- a/datasette/static/edit-tools.js
+++ b/datasette/static/edit-tools.js
@@ -4435,12 +4435,51 @@ function showRowEditDialogError(state, message) {
   state.error.focus();
 }
 
+function rowEditIsMultipleInsert(state) {
+  return state.mode === "insert" && state.insertMode === "multiple";
+}
+
+function syncRowEditInsertModeUi(state) {
+  var isInsert = state.mode === "insert";
+  var isMultiple = rowEditIsMultipleInsert(state);
+  state.fields.hidden = isMultiple;
+  state.bulkInsertPanel.hidden = !isMultiple;
+  state.bulkInsertEditor.hidden = !isMultiple || state.bulkInsertPreviewReady;
+  state.bulkInsertPreview.hidden = !isMultiple || !state.bulkInsertPreviewReady;
+  state.bulkInsertLink.hidden = !isInsert || isMultiple;
+  state.singleInsertLink.hidden = !isInsert || !isMultiple;
+}
+
 function updateRowEditDialogButtons(state) {
   state.saveButton.disabled =
-    state.isLoading || state.isSaving || !state.hasLoaded;
+    state.isLoading ||
+    state.isSaving ||
+    !state.hasLoaded ||
+    state.bulkInsertInserted;
   state.cancelButton.disabled = state.isSaving;
-  var saveLabel = state.mode === "insert" ? "Insert row" : "Save";
-  state.saveButton.textContent = state.isSaving ? "Saving..." : saveLabel;
+  syncRowEditInsertModeUi(state);
+  state.cancelButton.textContent =
+    rowEditIsMultipleInsert(state) &&
+    state.bulkInsertPreviewReady &&
+    !state.bulkInsertInserted
+      ? "Back"
+      : state.bulkInsertInserted
+        ? "Close and view table"
+        : "Cancel";
+  var saveLabel = rowEditIsMultipleInsert(state)
+    ? state.bulkInsertInserted
+      ? "Inserted"
+      : state.bulkInsertPreviewReady
+        ? "Insert these rows"
+        : "Preview rows"
+    : state.mode === "insert"
+      ? "Insert row"
+      : "Save";
+  state.saveButton.textContent = state.isSaving
+    ? rowEditIsMultipleInsert(state)
+      ? "Inserting..."
+      : "Saving..."
+    : saveLabel;
   state.form.setAttribute(
     "aria-busy",
     state.isLoading || state.isSaving ? "true" : "false",
@@ -4631,6 +4670,16 @@ function rowEditDialogHasChanges(state) {
   if (!state || !state.hasLoaded || state.isLoading) {
     return false;
   }
+  if (state.bulkInsertInserted) {
+    return false;
+  }
+  if (
+    state.mode === "insert" &&
+    state.bulkInsertTextarea &&
+    state.bulkInsertTextarea.value.trim()
+  ) {
+    return true;
+  }
   var fields = state.fields.querySelectorAll(".row-edit-field");
   for (var i = 0; i < fields.length; i += 1) {
     var fieldApi = fields[i]._datasetteColumnFormField;
@@ -4662,6 +4711,549 @@ function closeRowEditDialogIfConfirmed(state) {
   state.shouldRestoreFocus = true;
   state.dialog.close();
   return true;
+}
+
+function setRowInsertDialogTitle(state) {
+  var insertData = tableInsertData() || {};
+  var title = rowEditIsMultipleInsert(state)
+    ? "Insert multiple rows"
+    : "Insert row";
+  setRowDialogTitle(
+    state.title,
+    insertData.tableName ? title + " into " + insertData.tableName : title,
+  );
+}
+
+function showMultipleRowInsert(state) {
+  if (!state || state.mode !== "insert" || state.isSaving) {
+    return;
+  }
+  state.insertMode = "multiple";
+  if (state.bulkInsertPreviewReady || state.bulkInsertInserted) {
+    resetBulkInsertPreview(state);
+  }
+  clearRowEditDialogError(state);
+  setRowInsertDialogTitle(state);
+  updateRowEditDialogButtons(state);
+  state.bulkInsertTextarea.focus();
+}
+
+function showSingleRowInsert(state) {
+  if (!state || state.mode !== "insert" || state.isSaving) {
+    return;
+  }
+  state.insertMode = "single";
+  clearRowEditDialogError(state);
+  setRowInsertDialogTitle(state);
+  updateRowEditDialogButtons(state);
+  if (!focusFirstRowEditControl(state, { skipReadonly: true })) {
+    state.saveButton.focus();
+  }
+}
+
+function readTextFile(file) {
+  if (file.text) {
+    return file.text();
+  }
+  return new Promise(function (resolve, reject) {
+    var reader = new FileReader();
+    reader.onload = function () {
+      resolve(reader.result || "");
+    };
+    reader.onerror = function () {
+      reject(reader.error);
+    };
+    reader.readAsText(file);
+  });
+}
+
+function bulkInsertTemplateText(state) {
+  return (state.bulkInsertColumns || []).join("\t");
+}
+
+async function copyTextToClipboard(text) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  var textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "-1000px";
+  textarea.style.left = "-1000px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  var copied = document.execCommand("copy");
+  textarea.remove();
+  if (!copied) {
+    throw new Error("copy failed");
+  }
+}
+
+function setBulkInsertCopyButtonCopied(state) {
+  state.copyTemplateButton.textContent = "Copied";
+  clearTimeout(state.copyTemplateResetTimer);
+  state.copyTemplateResetTimer = setTimeout(function () {
+    state.copyTemplateButton.textContent = "Copy spreadsheet template";
+  }, 1500);
+}
+
+function resetBulkInsertPreview(state) {
+  state.bulkInsertPreviewRows = null;
+  state.bulkInsertPreviewReady = false;
+  state.bulkInsertInserted = false;
+  state.bulkInsertInsertedCount = 0;
+  state.bulkInsertPreview.hidden = true;
+  state.bulkInsertPreview.textContent = "";
+  state.bulkInsertProgress.hidden = true;
+  state.bulkInsertProgressBar.value = 0;
+  state.bulkInsertProgressBar.max = 1;
+  state.bulkInsertProgressStatus.textContent = "";
+  syncRowEditInsertModeUi(state);
+}
+
+function normalizeBulkInsertCell(column, value, isMissing) {
+  if (isMissing || typeof value === "undefined") {
+    return column.notnull ? "" : null;
+  }
+  if (value === null) {
+    return column.notnull ? "" : null;
+  }
+  if (value === "" && column.notnull) {
+    return "";
+  }
+  if (column.value_kind === "number" && typeof value === "string") {
+    return valueFromRowEditText(column.name, value, "number");
+  }
+  return value;
+}
+
+function rowObjectForBulkInsert(valuesByColumn, columns) {
+  var row = {};
+  columns.forEach(function (column) {
+    var hasValue = Object.prototype.hasOwnProperty.call(
+      valuesByColumn,
+      column.name,
+    );
+    row[column.name] = normalizeBulkInsertCell(
+      column,
+      hasValue ? valuesByColumn[column.name] : undefined,
+      !hasValue,
+    );
+  });
+  return row;
+}
+
+function splitDelimitedRows(text, delimiter) {
+  var rows = [];
+  var row = [];
+  var cell = "";
+  var inQuotes = false;
+
+  for (var i = 0; i < text.length; i += 1) {
+    var character = text[i];
+    if (inQuotes) {
+      if (character === '"') {
+        if (text[i + 1] === '"') {
+          cell += '"';
+          i += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cell += character;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      inQuotes = true;
+    } else if (character === delimiter) {
+      row.push(cell);
+      cell = "";
+    } else if (character === "\n" || character === "\r") {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+      if (character === "\r" && text[i + 1] === "\n") {
+        i += 1;
+      }
+    } else {
+      cell += character;
+    }
+  }
+
+  if (inQuotes) {
+    throw new Error("Unclosed quoted value.");
+  }
+  row.push(cell);
+  rows.push(row);
+
+  while (rows.length && bulkInsertDelimitedRowIsBlank(rows[rows.length - 1])) {
+    rows.pop();
+  }
+  return rows;
+}
+
+function bulkInsertDelimitedRowIsBlank(row) {
+  return row.every(function (value) {
+    return value.trim() === "";
+  });
+}
+
+function delimiterPreviewRows(text, delimiter) {
+  try {
+    return splitDelimitedRows(text, delimiter);
+  } catch (_error) {
+    return [];
+  }
+}
+
+function splitSingleColumnRows(text) {
+  var rows = text.split(/\r\n|\n|\r/).map(function (line) {
+    return [line];
+  });
+  while (rows.length && bulkInsertDelimitedRowIsBlank(rows[rows.length - 1])) {
+    rows.pop();
+  }
+  return rows;
+}
+
+function detectBulkInsertDelimiter(text, columns) {
+  var firstLine =
+    text.split(/\r\n|\n|\r/).find(function (line) {
+      return line.trim() !== "";
+    }) || "";
+  var csvRows = delimiterPreviewRows(firstLine, ",");
+  var tsvRows = delimiterPreviewRows(firstLine, "\t");
+  var csvColumns = csvRows.length ? csvRows[0].length : 0;
+  var tsvColumns = tsvRows.length ? tsvRows[0].length : 0;
+
+  if (firstLine.indexOf("\t") !== -1 && firstLine.indexOf(",") === -1) {
+    return "\t";
+  }
+  if (tsvColumns > csvColumns) {
+    return "\t";
+  }
+  if (csvColumns > 1) {
+    return ",";
+  }
+  if (tsvColumns > 1) {
+    return "\t";
+  }
+  if (columns.length === 1 || bulkInsertColumnMap(columns)[firstLine.trim()]) {
+    return null;
+  }
+  throw new Error("Could not detect CSV or TSV columns.");
+}
+
+function bulkInsertColumnMap(columns) {
+  var map = {};
+  columns.forEach(function (column) {
+    map[column.name] = column;
+  });
+  return map;
+}
+
+function parseJsonBulkInsertRows(text, columns) {
+  var parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error("Invalid JSON: " + error.message);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("JSON must be an array of objects.");
+  }
+  if (!parsed.length) {
+    throw new Error("No rows found to preview.");
+  }
+
+  var columnMap = bulkInsertColumnMap(columns);
+  return parsed.map(function (item, index) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new Error("JSON row " + (index + 1) + " must be an object.");
+    }
+    Object.keys(item).forEach(function (key) {
+      if (!columnMap[key]) {
+        throw new Error(
+          "JSON row " + (index + 1) + " has unknown column " + key + ".",
+        );
+      }
+    });
+    return rowObjectForBulkInsert(item, columns);
+  });
+}
+
+function parseDelimitedBulkInsertRows(text, columns) {
+  var delimiter = detectBulkInsertDelimiter(text, columns);
+  var rows = (
+    delimiter === null
+      ? splitSingleColumnRows(text)
+      : splitDelimitedRows(text, delimiter)
+  ).filter(function (row) {
+    return !bulkInsertDelimitedRowIsBlank(row);
+  });
+  if (!rows.length) {
+    throw new Error("No rows found to preview.");
+  }
+
+  var columnMap = bulkInsertColumnMap(columns);
+  var header = rows[0].map(function (value) {
+    return value.trim();
+  });
+  var headerMatches = header.filter(function (name) {
+    return !!columnMap[name];
+  }).length;
+  var hasHeader = headerMatches > 0;
+  var dataRows = hasHeader ? rows.slice(1) : rows;
+  var headers = hasHeader
+    ? header
+    : columns.map(function (column) {
+        return column.name;
+      });
+  var seenHeaders = {};
+
+  if (hasHeader) {
+    headers.forEach(function (name) {
+      if (!name) {
+        return;
+      }
+      if (!columnMap[name]) {
+        throw new Error("Unknown column " + name + " in header row.");
+      }
+      if (seenHeaders[name]) {
+        throw new Error("Duplicate column " + name + " in header row.");
+      }
+      seenHeaders[name] = true;
+    });
+  }
+
+  if (!dataRows.length) {
+    throw new Error("No data rows found to preview.");
+  }
+
+  return dataRows.map(function (row, rowIndex) {
+    if (row.length > headers.length) {
+      throw new Error(
+        "Row " +
+          (rowIndex + 1) +
+          " has " +
+          row.length +
+          " values, but only " +
+          headers.length +
+          " columns were provided.",
+      );
+    }
+    var valuesByColumn = {};
+    row.forEach(function (value, index) {
+      var columnName = headers[index];
+      if (columnMap[columnName]) {
+        valuesByColumn[columnName] = value;
+      }
+    });
+    return rowObjectForBulkInsert(valuesByColumn, columns);
+  });
+}
+
+function parseBulkInsertRows(text, columns) {
+  var trimmed = text.trim();
+  if (!trimmed) {
+    throw new Error("Paste rows before previewing.");
+  }
+  if (trimmed[0] === "[" || trimmed[0] === "{") {
+    return parseJsonBulkInsertRows(trimmed, columns);
+  }
+  return parseDelimitedBulkInsertRows(trimmed, columns);
+}
+
+function bulkInsertPreviewValue(value) {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function renderBulkInsertPreview(state, rows) {
+  state.bulkInsertPreview.textContent = "";
+  var summary = document.createElement("p");
+  summary.className = "row-edit-bulk-preview-summary";
+  summary.textContent =
+    "Previewing " + rows.length + " row" + (rows.length === 1 ? "." : "s.");
+  state.bulkInsertPreview.appendChild(summary);
+
+  var tableWrap = document.createElement("div");
+  tableWrap.className = "row-edit-bulk-preview-table-wrap";
+  var table = document.createElement("table");
+  table.className = "row-edit-bulk-preview-table";
+  var thead = document.createElement("thead");
+  var headerRow = document.createElement("tr");
+  state.bulkInsertColumnDetails.forEach(function (column) {
+    var th = document.createElement("th");
+    th.scope = "col";
+    th.textContent = column.name;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  var tbody = document.createElement("tbody");
+  rows.forEach(function (row) {
+    var tr = document.createElement("tr");
+    state.bulkInsertColumnDetails.forEach(function (column) {
+      var td = document.createElement("td");
+      var value = row[column.name];
+      td.textContent = bulkInsertPreviewValue(value);
+      if (value === null) {
+        td.className = "row-edit-bulk-preview-null";
+      }
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  tableWrap.appendChild(table);
+  state.bulkInsertPreview.appendChild(tableWrap);
+  state.bulkInsertPreview.hidden = false;
+}
+
+function previewBulkInsertRows(state) {
+  clearRowEditDialogError(state);
+  resetBulkInsertPreview(state);
+  try {
+    var rows = parseBulkInsertRows(
+      state.bulkInsertTextarea.value,
+      state.bulkInsertColumnDetails,
+    );
+    state.bulkInsertPreviewRows = rows;
+    state.bulkInsertPreviewReady = true;
+    renderBulkInsertPreview(state, rows);
+    updateRowEditDialogButtons(state);
+  } catch (error) {
+    showRowEditDialogError(state, error.message || "Could not preview rows.");
+    updateRowEditDialogButtons(state);
+  }
+}
+
+function updateBulkInsertProgress(state, inserted, total) {
+  state.bulkInsertProgress.hidden = false;
+  state.bulkInsertProgressBar.max = total || 1;
+  state.bulkInsertProgressBar.value = inserted;
+  state.bulkInsertProgressStatus.textContent =
+    inserted >= total
+      ? total + " row" + (total === 1 ? " inserted." : "s inserted.")
+      : "Inserting " + inserted + " of " + total + " rows...";
+}
+
+function bulkInsertBatches(rows, batchSize) {
+  var batches = [];
+  var size = Math.max(1, batchSize || 1);
+  for (var index = 0; index < rows.length; index += size) {
+    batches.push(rows.slice(index, index + size));
+  }
+  return batches;
+}
+
+function animateBulkInsertProgress(state, from, to, total, duration) {
+  state.bulkInsertProgress.hidden = false;
+  state.bulkInsertProgressBar.max = total || 1;
+  if (duration <= 0 || !window.requestAnimationFrame) {
+    updateBulkInsertProgress(state, to, total);
+    return Promise.resolve();
+  }
+
+  return new Promise(function (resolve) {
+    var startTime = null;
+    var step = function (timestamp) {
+      if (startTime === null) {
+        startTime = timestamp;
+      }
+      var progress = Math.min((timestamp - startTime) / duration, 1);
+      var easedProgress = 1 - Math.pow(1 - progress, 3);
+      var value = from + (to - from) * easedProgress;
+      var displayValue = progress === 1 ? to : Math.floor(value);
+      state.bulkInsertProgressBar.value = value;
+      state.bulkInsertProgressStatus.textContent =
+        displayValue >= total
+          ? total + " row" + (total === 1 ? " inserted." : "s inserted.")
+          : "Inserting " + displayValue + " of " + total + " rows...";
+      if (progress < 1) {
+        window.requestAnimationFrame(step);
+      } else {
+        updateBulkInsertProgress(state, to, total);
+        resolve();
+      }
+    };
+    window.requestAnimationFrame(step);
+  });
+}
+
+async function insertBulkPreviewRows(state) {
+  if (!state.bulkInsertPreviewRows || state.bulkInsertInserted) {
+    return;
+  }
+  if (!state.currentInsertUrl) {
+    showRowEditDialogError(state, "Could not find the row insert URL.");
+    return;
+  }
+
+  var rows = state.bulkInsertPreviewRows;
+  var total = rows.length;
+  var inserted = state.bulkInsertInsertedCount || 0;
+  var batches = bulkInsertBatches(
+    rows.slice(inserted),
+    state.bulkInsertMaxRows,
+  );
+  var progressAnimationDuration = 500 / Math.max(batches.length, 1);
+
+  clearRowEditDialogError(state);
+  updateBulkInsertProgress(state, inserted, total);
+  setRowEditDialogSaving(state, true);
+  try {
+    for (var batchIndex = 0; batchIndex < batches.length; batchIndex += 1) {
+      var batch = batches[batchIndex];
+      var response = await fetch(state.currentInsertUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ rows: batch }),
+      });
+      var data = null;
+      try {
+        data = await response.json();
+      } catch (_error) {
+        data = null;
+      }
+      if (!response.ok || (data && data.ok === false)) {
+        throw rowMutationRequestError(response, data);
+      }
+      var previousInserted = inserted;
+      inserted += batch.length;
+      state.bulkInsertInsertedCount = inserted;
+      await animateBulkInsertProgress(
+        state,
+        previousInserted,
+        inserted,
+        total,
+        progressAnimationDuration,
+      );
+    }
+    state.bulkInsertInserted = true;
+    state.shouldReloadOnClose = true;
+    state.redirectOnCloseUrl = tableBaseUrl().toString();
+    updateBulkInsertProgress(state, inserted, total);
+  } catch (error) {
+    showRowEditDialogError(state, error.message || "Could not insert rows.");
+  } finally {
+    setRowEditDialogSaving(state, false);
+  }
 }
 
 function scheduleCloseRowEditDialogIfConfirmed(state) {
@@ -4760,6 +5352,14 @@ function addInsertedRowToPage(rowElement) {
 
 async function saveRowEditDialog(state) {
   if (state.isLoading || state.isSaving || !state.hasLoaded) {
+    return;
+  }
+  if (rowEditIsMultipleInsert(state)) {
+    if (!state.bulkInsertPreviewReady) {
+      previewBulkInsertRows(state);
+    } else if (!state.bulkInsertInserted) {
+      await insertBulkPreviewRows(state);
+    }
     return;
   }
   clearRowEditDialogError(state);
@@ -4920,6 +5520,7 @@ function renderRowEditFields(state, data) {
   var primaryKeys = data.primary_keys || [];
   var columnTypes = data.column_types || {};
 
+  state.insertMode = "single";
   destroyRowEditFields(state);
   columns.forEach(function (column, index) {
     state.fields.appendChild(
@@ -4951,6 +5552,17 @@ function renderRowEditFields(state, data) {
 function renderRowInsertFields(state, data) {
   var columns = data.columns || [];
 
+  state.insertMode = "single";
+  state.bulkInsertColumnDetails = columns.slice();
+  state.bulkInsertMaxRows = data.maxInsertRows || 100;
+  state.bulkInsertColumns = columns.map(function (column) {
+    return column.name;
+  });
+  state.copyTemplateButton.disabled = !state.bulkInsertColumns.length;
+  state.copyTemplateButton.textContent = "Copy spreadsheet template";
+  clearTimeout(state.copyTemplateResetTimer);
+  state.copyTemplateResetTimer = null;
+  resetBulkInsertPreview(state);
   destroyRowEditFields(state);
   columns.forEach(function (column, index) {
     state.fields.appendChild(
@@ -5040,7 +5652,24 @@ function ensureRowEditDialog(manager) {
       <p class="row-edit-loading" role="status" aria-live="polite">Loading row...</p>
       <p class="row-edit-error" role="alert" tabindex="-1" hidden></p>
       <div class="row-edit-fields"></div>
+      <div class="row-edit-bulk" hidden>
+        <div class="row-edit-bulk-editor">
+          <label class="row-edit-bulk-label" for="row-edit-bulk-textarea">Rows to insert</label>
+          <div class="row-edit-bulk-actions">
+            <button type="button" class="btn btn-ghost row-edit-copy-template">Copy spreadsheet template</button>
+          </div>
+          <textarea class="row-edit-input row-edit-bulk-textarea" id="row-edit-bulk-textarea" name="_bulk_rows" rows="12" spellcheck="false"></textarea>
+          <p class="row-edit-bulk-note">Paste TSV, CSV, or JSON. You can also drop a text file onto this textarea.</p>
+        </div>
+        <div class="row-edit-bulk-preview" hidden></div>
+        <div class="row-edit-bulk-progress" hidden>
+          <progress class="row-edit-bulk-progress-bar" value="0" max="1"></progress>
+          <p class="row-edit-bulk-progress-status" role="status" aria-live="polite"></p>
+        </div>
+      </div>
       <div class="modal-footer">
+        <a href="#" class="row-edit-mode-link row-edit-bulk-insert" hidden>Insert multiple rows</a>
+        <a href="#" class="row-edit-mode-link row-edit-single-insert" hidden>Insert single row</a>
         <button type="button" class="btn btn-ghost row-edit-cancel">Cancel</button>
         <button type="submit" class="btn btn-primary row-edit-save" disabled>Save</button>
       </div>
@@ -5056,6 +5685,18 @@ function ensureRowEditDialog(manager) {
     loading: dialog.querySelector(".row-edit-loading"),
     error: dialog.querySelector(".row-edit-error"),
     fields: dialog.querySelector(".row-edit-fields"),
+    bulkInsertPanel: dialog.querySelector(".row-edit-bulk"),
+    bulkInsertEditor: dialog.querySelector(".row-edit-bulk-editor"),
+    bulkInsertTextarea: dialog.querySelector(".row-edit-bulk-textarea"),
+    bulkInsertPreview: dialog.querySelector(".row-edit-bulk-preview"),
+    bulkInsertProgress: dialog.querySelector(".row-edit-bulk-progress"),
+    bulkInsertProgressBar: dialog.querySelector(".row-edit-bulk-progress-bar"),
+    bulkInsertProgressStatus: dialog.querySelector(
+      ".row-edit-bulk-progress-status",
+    ),
+    copyTemplateButton: dialog.querySelector(".row-edit-copy-template"),
+    bulkInsertLink: dialog.querySelector(".row-edit-bulk-insert"),
+    singleInsertLink: dialog.querySelector(".row-edit-single-insert"),
     cancelButton: dialog.querySelector(".row-edit-cancel"),
     saveButton: dialog.querySelector(".row-edit-save"),
     currentButton: null,
@@ -5066,6 +5707,17 @@ function ensureRowEditDialog(manager) {
     currentUpdateUrl: null,
     currentFragmentUrl: null,
     mode: "edit",
+    insertMode: "single",
+    bulkInsertColumns: [],
+    bulkInsertColumnDetails: [],
+    bulkInsertPreviewRows: null,
+    bulkInsertPreviewReady: false,
+    bulkInsertInserted: false,
+    bulkInsertInsertedCount: 0,
+    bulkInsertMaxRows: 100,
+    shouldReloadOnClose: false,
+    redirectOnCloseUrl: null,
+    copyTemplateResetTimer: null,
     loadId: 0,
     manager: manager,
     isLoading: false,
@@ -5081,10 +5733,119 @@ function ensureRowEditDialog(manager) {
   });
 
   rowEditDialogState.cancelButton.addEventListener("click", function () {
+    if (
+      rowEditIsMultipleInsert(rowEditDialogState) &&
+      rowEditDialogState.bulkInsertPreviewReady &&
+      !rowEditDialogState.bulkInsertInserted &&
+      !rowEditDialogState.isSaving
+    ) {
+      resetBulkInsertPreview(rowEditDialogState);
+      updateRowEditDialogButtons(rowEditDialogState);
+      rowEditDialogState.bulkInsertTextarea.focus();
+      return;
+    }
     if (!rowEditDialogState.isSaving) {
       rowEditDialogState.shouldRestoreFocus = true;
       dialog.close();
     }
+  });
+
+  rowEditDialogState.bulkInsertLink.addEventListener("click", function (ev) {
+    ev.preventDefault();
+    showMultipleRowInsert(rowEditDialogState);
+  });
+
+  rowEditDialogState.singleInsertLink.addEventListener("click", function (ev) {
+    ev.preventDefault();
+    showSingleRowInsert(rowEditDialogState);
+  });
+
+  rowEditDialogState.copyTemplateButton.addEventListener(
+    "click",
+    async function () {
+      try {
+        await copyTextToClipboard(bulkInsertTemplateText(rowEditDialogState));
+        clearRowEditDialogError(rowEditDialogState);
+        setBulkInsertCopyButtonCopied(rowEditDialogState);
+      } catch (_error) {
+        showRowEditDialogError(
+          rowEditDialogState,
+          "Could not copy the spreadsheet template.",
+        );
+      }
+    },
+  );
+
+  rowEditDialogState.bulkInsertTextarea.addEventListener(
+    "dragenter",
+    function (ev) {
+      ev.preventDefault();
+      rowEditDialogState.bulkInsertTextarea.classList.add(
+        "row-edit-bulk-drop-target",
+      );
+    },
+  );
+
+  rowEditDialogState.bulkInsertTextarea.addEventListener(
+    "dragover",
+    function (ev) {
+      ev.preventDefault();
+      rowEditDialogState.bulkInsertTextarea.classList.add(
+        "row-edit-bulk-drop-target",
+      );
+    },
+  );
+
+  rowEditDialogState.bulkInsertTextarea.addEventListener(
+    "dragleave",
+    function () {
+      rowEditDialogState.bulkInsertTextarea.classList.remove(
+        "row-edit-bulk-drop-target",
+      );
+    },
+  );
+
+  rowEditDialogState.bulkInsertTextarea.addEventListener(
+    "drop",
+    async function (ev) {
+      ev.preventDefault();
+      rowEditDialogState.bulkInsertTextarea.classList.remove(
+        "row-edit-bulk-drop-target",
+      );
+      var files = ev.dataTransfer && ev.dataTransfer.files;
+      if (!files || !files.length) {
+        return;
+      }
+      try {
+        rowEditDialogState.bulkInsertTextarea.value = await readTextFile(
+          files[0],
+        );
+        rowEditDialogState.bulkInsertTextarea.dispatchEvent(
+          new Event("input", { bubbles: true }),
+        );
+        clearRowEditDialogError(rowEditDialogState);
+      } catch (_error) {
+        showRowEditDialogError(
+          rowEditDialogState,
+          "Could not read that text file.",
+        );
+      }
+    },
+  );
+
+  rowEditDialogState.bulkInsertTextarea.addEventListener(
+    "dragend",
+    function () {
+      rowEditDialogState.bulkInsertTextarea.classList.remove(
+        "row-edit-bulk-drop-target",
+      );
+    },
+  );
+
+  rowEditDialogState.bulkInsertTextarea.addEventListener("input", function () {
+    resetBulkInsertPreview(rowEditDialogState);
+    clearRowEditDialogError(rowEditDialogState);
+    updateRowEditDialogButtons(rowEditDialogState);
   });
 
   dialog.addEventListener("click", function (ev) {
@@ -5108,8 +5869,16 @@ function ensureRowEditDialog(manager) {
 
   dialog.addEventListener("close", function () {
     var state = rowEditDialogState;
+    var shouldReloadOnClose = state.shouldReloadOnClose;
+    var redirectOnCloseUrl = state.redirectOnCloseUrl;
     state.loadId += 1;
     state.isClosePending = false;
+    state.shouldReloadOnClose = false;
+    state.redirectOnCloseUrl = null;
+    clearTimeout(state.copyTemplateResetTimer);
+    state.copyTemplateResetTimer = null;
+    state.copyTemplateButton.textContent = "Copy spreadsheet template";
+    resetBulkInsertPreview(state);
     clearRowEditDialogError(state);
     state.hasLoaded = false;
     destroyRowEditFields(state);
@@ -5121,6 +5890,13 @@ function ensureRowEditDialog(manager) {
       document.contains(state.currentButton)
     ) {
       state.currentButton.focus();
+    }
+    if (shouldReloadOnClose) {
+      if (redirectOnCloseUrl) {
+        location.href = redirectOnCloseUrl;
+      } else {
+        location.reload();
+      }
     }
   });
 
@@ -5146,6 +5922,7 @@ async function openRowEditDialog(button, manager) {
   state.currentInsertUrl = null;
   state.currentUpdateUrl = rowUpdateUrl(row);
   state.currentFragmentUrl = rowFragmentUrl(row);
+  state.insertMode = "single";
   if (state.currentUpdateUrl) {
     state.form.action = new URL(
       state.currentUpdateUrl,
@@ -5171,6 +5948,7 @@ async function openRowEditDialog(button, manager) {
   );
   state.summary.hidden = true;
   state.summary.textContent = "";
+  syncRowEditInsertModeUi(state);
 
   if (!state.dialog.open) {
     state.dialog.showModal();
@@ -5221,6 +5999,11 @@ function openRowInsertDialog(button, manager) {
   state.currentInsertUrl = tableInsertUrl();
   state.currentUpdateUrl = null;
   state.currentFragmentUrl = null;
+  state.insertMode = "single";
+  state.bulkInsertTextarea.value = "";
+  state.shouldReloadOnClose = false;
+  state.redirectOnCloseUrl = null;
+  resetBulkInsertPreview(state);
   state.shouldRestoreFocus = true;
   state.hasLoaded = false;
   state.loadId += 1;
@@ -5238,14 +6021,10 @@ function openRowInsertDialog(button, manager) {
   setRowEditDialogLoading(state, false);
   destroyRowEditFields(state);
   state.dialog.removeAttribute("aria-describedby");
-  setRowDialogTitle(
-    state.title,
-    insertData.tableName
-      ? "Insert row into " + insertData.tableName
-      : "Insert row",
-  );
+  setRowInsertDialogTitle(state);
   state.summary.hidden = true;
   state.summary.textContent = "";
+  syncRowEditInsertModeUi(state);
 
   if (!state.dialog.open) {
     state.dialog.showModal();

--- a/datasette/static/edit-tools.js
+++ b/datasette/static/edit-tools.js
@@ -1612,7 +1612,7 @@ function inferCreateTableDelimitedColumnType(values) {
 function coerceCreateTableDelimitedValue(value, type) {
   var trimmed = String(value).trim();
   if (trimmed === "") {
-    return "";
+    return type === "integer" || type === "float" ? null : "";
   }
   if (type === "integer") {
     return parseInt(trimmed, 10);

--- a/datasette/static/edit-tools.js
+++ b/datasette/static/edit-tools.js
@@ -6038,6 +6038,25 @@ function bulkInsertPreviewValue(value) {
   return String(value);
 }
 
+function bulkInsertPreviewCell(column, hasValue, value) {
+  if (!hasValue && column.is_auto_pk) {
+    return {
+      text: "auto",
+      className: "row-edit-bulk-preview-auto",
+    };
+  }
+  if (value === null) {
+    return {
+      text: bulkInsertPreviewValue(value),
+      className: "row-edit-bulk-preview-null",
+    };
+  }
+  return {
+    text: hasValue ? bulkInsertPreviewValue(value) : "",
+    className: "",
+  };
+}
+
 function renderBulkInsertPreview(state, rows) {
   state.bulkInsertPreview.textContent = "";
   var summary = document.createElement("p");
@@ -6068,9 +6087,10 @@ function renderBulkInsertPreview(state, rows) {
       var td = document.createElement("td");
       var hasValue = Object.prototype.hasOwnProperty.call(row, column.name);
       var value = hasValue ? row[column.name] : "";
-      td.textContent = hasValue ? bulkInsertPreviewValue(value) : "";
-      if (value === null) {
-        td.className = "row-edit-bulk-preview-null";
+      var cell = bulkInsertPreviewCell(column, hasValue, value);
+      td.textContent = cell.text;
+      if (cell.className) {
+        td.className = cell.className;
       }
       tr.appendChild(td);
     });

--- a/datasette/static/edit-tools.js
+++ b/datasette/static/edit-tools.js
@@ -822,6 +822,11 @@ function tableCreateSaveButtonText(state) {
   return "Create table";
 }
 
+function tableCreateCanInsertRows() {
+  var data = databaseCreateTableData() || {};
+  return !!data.canInsertRows;
+}
+
 function syncTableCreateModeUi(state) {
   if (!state) {
     return;
@@ -831,7 +836,7 @@ function syncTableCreateModeUi(state) {
   state.dataPanel.hidden = !isDataMode;
   state.dataEditor.hidden = !isDataMode || state.dataPreviewReady;
   state.dataPreview.hidden = !isDataMode || !state.dataPreviewReady;
-  state.createFromDataLink.hidden = isDataMode;
+  state.createFromDataLink.hidden = isDataMode || !tableCreateCanInsertRows();
   state.manualCreateLink.hidden = !isDataMode;
 }
 
@@ -1303,7 +1308,7 @@ function resetTableCreateDialog(state) {
 }
 
 function showTableCreateDataMode(state) {
-  if (!state || state.isSaving) {
+  if (!state || state.isSaving || !tableCreateCanInsertRows()) {
     return;
   }
   state.mode = "data";

--- a/datasette/static/edit-tools.js
+++ b/datasette/static/edit-tools.js
@@ -5586,8 +5586,8 @@ function resetBulkInsertPreview(state) {
   syncRowEditInsertModeUi(state);
 }
 
-function normalizeBulkInsertCell(column, value, isMissing) {
-  if (isMissing || typeof value === "undefined") {
+function normalizeBulkInsertCell(column, value) {
+  if (typeof value === "undefined") {
     return column.notnull ? "" : null;
   }
   if (value === null) {
@@ -5609,11 +5609,10 @@ function rowObjectForBulkInsert(valuesByColumn, columns) {
       valuesByColumn,
       column.name,
     );
-    row[column.name] = normalizeBulkInsertCell(
-      column,
-      hasValue ? valuesByColumn[column.name] : undefined,
-      !hasValue,
-    );
+    if (!hasValue) {
+      return;
+    }
+    row[column.name] = normalizeBulkInsertCell(column, valuesByColumn[column.name]);
   });
   return row;
 }
@@ -5869,8 +5868,9 @@ function renderBulkInsertPreview(state, rows) {
     var tr = document.createElement("tr");
     state.bulkInsertColumnDetails.forEach(function (column) {
       var td = document.createElement("td");
-      var value = row[column.name];
-      td.textContent = bulkInsertPreviewValue(value);
+      var hasValue = Object.prototype.hasOwnProperty.call(row, column.name);
+      var value = hasValue ? row[column.name] : "";
+      td.textContent = hasValue ? bulkInsertPreviewValue(value) : "";
       if (value === null) {
         td.className = "row-edit-bulk-preview-null";
       }

--- a/datasette/static/edit-tools.js
+++ b/datasette/static/edit-tools.js
@@ -4,6 +4,7 @@ var ROW_EDIT_DIALOG_ID = "row-edit-dialog";
 var rowEditDialogState = null;
 var TABLE_CREATE_DIALOG_ID = "table-create-dialog";
 var tableCreateDialogState = null;
+var TABLE_CREATE_AUTOMATIC_PK = "__datasette_automatic_pk__";
 var TABLE_ALTER_DIALOG_ID = "table-alter-dialog";
 var tableAlterDialogState = null;
 
@@ -810,13 +811,61 @@ async function loadTableCreateForeignKeyTargets(state) {
   );
 }
 
+function tableCreateIsDataMode(state) {
+  return state && state.mode === "data";
+}
+
+function tableCreateSaveButtonText(state) {
+  if (tableCreateIsDataMode(state)) {
+    return state.dataPreviewReady ? "Create table" : "Preview rows";
+  }
+  return "Create table";
+}
+
+function syncTableCreateModeUi(state) {
+  if (!state) {
+    return;
+  }
+  var isDataMode = tableCreateIsDataMode(state);
+  state.columnsPanel.hidden = isDataMode;
+  state.dataPanel.hidden = !isDataMode;
+  state.dataEditor.hidden = !isDataMode || state.dataPreviewReady;
+  state.dataPreview.hidden = !isDataMode || !state.dataPreviewReady;
+  state.createFromDataLink.hidden = isDataMode;
+  state.manualCreateLink.hidden = !isDataMode;
+}
+
+function updateTableCreateDialogButtons(state) {
+  if (!state) {
+    return;
+  }
+  syncTableCreateModeUi(state);
+  state.cancelButton.disabled = state.isSaving;
+  state.saveButton.disabled = state.isSaving;
+  state.addColumnButton.disabled = state.isSaving;
+  state.cancelButton.textContent =
+    tableCreateIsDataMode(state) && state.dataPreviewReady ? "Back" : "Cancel";
+  state.saveButton.textContent = state.isSaving
+    ? "Creating..."
+    : tableCreateSaveButtonText(state);
+}
+
 function tableCreateDialogSignature(state) {
   if (!state || !state.form) {
     return "";
   }
-  return JSON.stringify({
+  var signature = {
+    mode: state.mode || "manual",
     table: state.tableName.value,
-    columns: tableCreateDialogRows(state).map(function (row) {
+    data: state.dataTextarea ? state.dataTextarea.value : "",
+    dataPrimaryKey: state.dataPkSelect
+      ? state.dataPkSelect.value
+      : TABLE_CREATE_AUTOMATIC_PK,
+  };
+  if (tableCreateIsDataMode(state)) {
+    signature.previewReady = !!state.dataPreviewReady;
+  } else {
+    signature.columns = tableCreateDialogRows(state).map(function (row) {
       return {
         name: row.querySelector(".table-create-column-name").value,
         type: row.querySelector(".table-create-column-type").value,
@@ -837,8 +886,9 @@ function tableCreateDialogSignature(state) {
             }
           ).value || "",
       };
-    }),
-  });
+    });
+  }
+  return JSON.stringify(signature);
 }
 
 function tableCreateDialogHasChanges(state) {
@@ -864,18 +914,23 @@ function showTableCreateDialogError(state, message) {
 
 function setTableCreateDialogSaving(state, isSaving) {
   state.isSaving = isSaving;
-  state.cancelButton.disabled = isSaving;
-  state.saveButton.disabled = isSaving;
-  state.addColumnButton.disabled = isSaving;
-  state.saveButton.textContent = isSaving ? "Creating..." : "Create table";
   state.columnList
     .querySelectorAll("input, select, button")
     .forEach(function (control) {
       control.disabled = isSaving;
     });
+  state.fields
+    .querySelectorAll(
+      ".table-create-data input, .table-create-data select, .table-create-data textarea, .table-create-data button",
+    )
+    .forEach(function (control) {
+      control.disabled = isSaving;
+    });
+  state.tableName.disabled = isSaving;
   if (!isSaving) {
     updateTableCreateColumnRules(state);
   }
+  updateTableCreateDialogButtons(state);
   updateTableCreateMoveButtons(state);
 }
 
@@ -1231,8 +1286,11 @@ function addTableCreateColumn(state, column) {
 }
 
 function resetTableCreateDialog(state) {
+  state.mode = "manual";
   state.nextColumnIndex = 0;
   state.tableName.value = "";
+  state.dataTextarea.value = "";
+  resetTableCreateDataPreview(state);
   state.columnList.textContent = "";
   addTableCreateColumn(state, {
     name: "id",
@@ -1245,7 +1303,37 @@ function resetTableCreateDialog(state) {
     primaryKey: false,
   });
   updateTableCreateColumnRules(state);
+  updateTableCreateDialogButtons(state);
   state.initialSignature = tableCreateDialogSignature(state);
+}
+
+function showTableCreateDataMode(state) {
+  if (!state || state.isSaving) {
+    return;
+  }
+  state.mode = "data";
+  clearTableCreateDialogError(state);
+  updateTableCreateDialogButtons(state);
+  if (state.dataPreviewReady && state.dataPkSelect) {
+    state.dataPkSelect.focus();
+  } else {
+    state.dataTextarea.focus();
+  }
+}
+
+function showTableCreateManualMode(state) {
+  if (!state || state.isSaving) {
+    return;
+  }
+  state.mode = "manual";
+  clearTableCreateDialogError(state);
+  updateTableCreateDialogButtons(state);
+  var firstInput = state.columnList.querySelector(".table-create-column-name");
+  if (firstInput) {
+    firstInput.focus();
+  } else {
+    state.tableName.focus();
+  }
 }
 
 function collectTableCreatePayload(state) {
@@ -1315,14 +1403,9 @@ function collectTableCreateColumnTypeAssignments(state) {
 }
 
 function validateTableCreatePayload(payload) {
-  if (!payload.table) {
-    return "Table name is required.";
-  }
-  if (payload.table.indexOf("\n") !== -1) {
-    return "Table name cannot contain newlines.";
-  }
-  if (/^sqlite_/i.test(payload.table)) {
-    return "Table name cannot start with sqlite_.";
+  var tableNameError = validateTableCreateTableName(payload.table);
+  if (tableNameError) {
+    return tableNameError;
   }
   if (!payload.columns.length) {
     return "At least one column is required.";
@@ -1352,6 +1435,19 @@ function validateTableCreatePayload(payload) {
   return null;
 }
 
+function validateTableCreateTableName(tableName) {
+  if (!tableName) {
+    return "Table name is required.";
+  }
+  if (tableName.indexOf("\n") !== -1) {
+    return "Table name cannot contain newlines.";
+  }
+  if (/^sqlite_/i.test(tableName)) {
+    return "Table name cannot start with sqlite_.";
+  }
+  return null;
+}
+
 function validateTableCreateColumnTypeAssignments(assignments) {
   for (var i = 0; i < assignments.length; i += 1) {
     var assignment = assignments[i];
@@ -1370,6 +1466,446 @@ function validateTableCreateColumnTypeAssignments(assignments) {
         "."
       );
     }
+  }
+  return null;
+}
+
+function normalizeCreateTableDataJsonValue(value) {
+  if (typeof value === "undefined") {
+    return null;
+  }
+  if (Array.isArray(value) || (value && typeof value === "object")) {
+    return JSON.stringify(value);
+  }
+  return value;
+}
+
+function createTableDataColumnObjects(names) {
+  return names.map(function (name) {
+    return { name: name };
+  });
+}
+
+function validateCreateTableDataHeaders(headers) {
+  if (!headers.length) {
+    throw new Error("No columns found to preview.");
+  }
+  var seen = {};
+  headers.forEach(function (name, index) {
+    if (!name) {
+      throw new Error("Column header " + (index + 1) + " is blank.");
+    }
+    if (name.indexOf("\n") !== -1) {
+      throw new Error("Column names cannot contain newlines.");
+    }
+    var key = name.toLowerCase();
+    if (seen[key]) {
+      throw new Error("Duplicate column name: " + name);
+    }
+    seen[key] = true;
+  });
+}
+
+function jsonRowIsObject(item) {
+  return !!(item && typeof item === "object" && !Array.isArray(item));
+}
+
+function extractJsonObjectRows(parsed) {
+  if (Array.isArray(parsed)) {
+    return parsed;
+  }
+  if (!jsonRowIsObject(parsed)) {
+    throw new Error(
+      "JSON must be an array of objects, or an object containing an array of objects.",
+    );
+  }
+
+  var bestRows = null;
+  Object.keys(parsed).forEach(function (key) {
+    var value = parsed[key];
+    if (!Array.isArray(value) || !value.every(jsonRowIsObject)) {
+      return;
+    }
+    if (!bestRows || value.length > bestRows.length) {
+      bestRows = value;
+    }
+  });
+  if (!bestRows) {
+    throw new Error(
+      "JSON object must contain at least one root key with an array of objects.",
+    );
+  }
+  return bestRows;
+}
+
+function parseJsonObjectRows(text) {
+  var parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error("Invalid JSON: " + error.message);
+  }
+  var rows = extractJsonObjectRows(parsed);
+  if (!rows.length) {
+    throw new Error("No rows found to preview.");
+  }
+  return rows;
+}
+
+function parseJsonCreateTableRows(text) {
+  var parsed = parseJsonObjectRows(text);
+
+  var columnNames = [];
+  var columnMap = {};
+  parsed.forEach(function (item, index) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new Error("JSON row " + (index + 1) + " must be an object.");
+    }
+    Object.keys(item).forEach(function (name) {
+      if (!columnMap[name]) {
+        columnMap[name] = true;
+        columnNames.push(name);
+      }
+    });
+  });
+  validateCreateTableDataHeaders(columnNames);
+
+  var rows = parsed.map(function (item) {
+    var row = {};
+    columnNames.forEach(function (name) {
+      row[name] = Object.prototype.hasOwnProperty.call(item, name)
+        ? normalizeCreateTableDataJsonValue(item[name])
+        : null;
+    });
+    return row;
+  });
+  return {
+    columns: createTableDataColumnObjects(columnNames),
+    rows: rows,
+  };
+}
+
+function createTableDelimitedValueIsInteger(value) {
+  return /^[-+]?\d+$/.test(String(value).trim());
+}
+
+function createTableDelimitedValueIsFloat(value) {
+  var trimmed = String(value).trim();
+  if (!trimmed) {
+    return false;
+  }
+  var numberValue = Number(trimmed);
+  return Number.isFinite(numberValue);
+}
+
+function inferCreateTableDelimitedColumnType(values) {
+  var nonBlankValues = values.filter(function (value) {
+    return String(value).trim() !== "";
+  });
+  if (!nonBlankValues.length) {
+    return "text";
+  }
+  if (nonBlankValues.every(createTableDelimitedValueIsInteger)) {
+    return "integer";
+  }
+  if (nonBlankValues.every(createTableDelimitedValueIsFloat)) {
+    return "float";
+  }
+  return "text";
+}
+
+function coerceCreateTableDelimitedValue(value, type) {
+  var trimmed = String(value).trim();
+  if (trimmed === "") {
+    return "";
+  }
+  if (type === "integer") {
+    return parseInt(trimmed, 10);
+  }
+  if (type === "float") {
+    return Number(trimmed);
+  }
+  return value;
+}
+
+function detectCreateTableDataDelimiter(text) {
+  var firstLine =
+    text.split(/\r\n|\n|\r/).find(function (line) {
+      return line.trim() !== "";
+    }) || "";
+  var csvRows = delimiterPreviewRows(firstLine, ",");
+  var tsvRows = delimiterPreviewRows(firstLine, "\t");
+  var csvColumns = csvRows.length ? csvRows[0].length : 0;
+  var tsvColumns = tsvRows.length ? tsvRows[0].length : 0;
+
+  if (firstLine.indexOf("\t") !== -1 && firstLine.indexOf(",") === -1) {
+    return "\t";
+  }
+  if (tsvColumns > csvColumns) {
+    return "\t";
+  }
+  if (csvColumns > 1) {
+    return ",";
+  }
+  if (tsvColumns > 1) {
+    return "\t";
+  }
+  return null;
+}
+
+function parseDelimitedCreateTableRows(text) {
+  var delimiter = detectCreateTableDataDelimiter(text);
+  var rows = (
+    delimiter === null
+      ? splitSingleColumnRows(text)
+      : splitDelimitedRows(text, delimiter)
+  ).filter(function (row) {
+    return !bulkInsertDelimitedRowIsBlank(row);
+  });
+  if (!rows.length) {
+    throw new Error("No rows found to preview.");
+  }
+
+  var headers = rows[0].map(function (value) {
+    return value.trim();
+  });
+  validateCreateTableDataHeaders(headers);
+  var dataRows = rows.slice(1);
+  if (!dataRows.length) {
+    throw new Error("No data rows found to preview.");
+  }
+
+  dataRows.forEach(function (row, index) {
+    if (row.length > headers.length) {
+      throw new Error(
+        "Row " +
+          (index + 1) +
+          " has " +
+          row.length +
+          " values, but only " +
+          headers.length +
+          " columns were provided.",
+      );
+    }
+  });
+
+  var columnTypes = headers.map(function (_name, columnIndex) {
+    return inferCreateTableDelimitedColumnType(
+      dataRows.map(function (row) {
+        return row[columnIndex] || "";
+      }),
+    );
+  });
+
+  return {
+    columns: createTableDataColumnObjects(headers),
+    rows: dataRows.map(function (row) {
+      var rowObject = {};
+      headers.forEach(function (name, columnIndex) {
+        rowObject[name] = coerceCreateTableDelimitedValue(
+          row[columnIndex] || "",
+          columnTypes[columnIndex],
+        );
+      });
+      return rowObject;
+    }),
+  };
+}
+
+function parseCreateTableDataRows(text) {
+  var trimmed = text.trim();
+  if (!trimmed) {
+    throw new Error("Paste rows before previewing.");
+  }
+  if (trimmed[0] === "[" || trimmed[0] === "{") {
+    return parseJsonCreateTableRows(trimmed);
+  }
+  return parseDelimitedCreateTableRows(trimmed);
+}
+
+function tableCreateDataRecommendedPrimaryKey(columns, rows) {
+  var candidates = [];
+  columns.forEach(function (column, columnIndex) {
+    var distinctValues = {};
+    var maxLength = 0;
+    var valid = rows.length > 0;
+    rows.forEach(function (row) {
+      if (!valid) {
+        return;
+      }
+      var value = row[column.name];
+      if (value === null || typeof value === "undefined") {
+        valid = false;
+        return;
+      }
+      var text = String(value).trim();
+      if (!text || text.length >= 20 || /\s/.test(text)) {
+        valid = false;
+        return;
+      }
+      if (distinctValues[text]) {
+        valid = false;
+        return;
+      }
+      distinctValues[text] = true;
+      maxLength = Math.max(maxLength, text.length);
+    });
+    if (valid) {
+      candidates.push({
+        name: column.name,
+        maxLength: maxLength,
+        columnIndex: columnIndex,
+      });
+    }
+  });
+  candidates.sort(function (left, right) {
+    if (left.maxLength !== right.maxLength) {
+      return left.maxLength - right.maxLength;
+    }
+    return left.columnIndex - right.columnIndex;
+  });
+  return candidates.length ? candidates[0].name : TABLE_CREATE_AUTOMATIC_PK;
+}
+
+function renderTableCreateDataPreview(state, preview) {
+  state.dataPreview.textContent = "";
+
+  var summary = document.createElement("p");
+  summary.className = "table-create-data-preview-summary";
+  summary.textContent =
+    "Previewing " +
+    preview.rows.length +
+    " row" +
+    (preview.rows.length === 1 ? "." : "s.");
+  state.dataPreview.appendChild(summary);
+
+  var pkField = document.createElement("div");
+  pkField.className = "table-create-data-pk-field";
+  var pkLabel = document.createElement("label");
+  pkLabel.className = "table-create-data-label";
+  pkLabel.setAttribute("for", "table-create-data-primary-key");
+  pkLabel.textContent = "Primary key";
+  var pkSelect = document.createElement("select");
+  pkSelect.id = "table-create-data-primary-key";
+  pkSelect.className = "table-create-input table-create-data-primary-key";
+  var automaticOption = document.createElement("option");
+  automaticOption.value = TABLE_CREATE_AUTOMATIC_PK;
+  automaticOption.textContent = "Automatic ID column";
+  pkSelect.appendChild(automaticOption);
+  preview.columns.forEach(function (column) {
+    var option = document.createElement("option");
+    option.value = column.name;
+    option.textContent = column.name;
+    pkSelect.appendChild(option);
+  });
+  pkSelect.value = tableCreateDataRecommendedPrimaryKey(
+    preview.columns,
+    preview.rows,
+  );
+  pkSelect.addEventListener("change", function () {
+    clearTableCreateDialogError(state);
+  });
+  state.dataPkSelect = pkSelect;
+  pkField.appendChild(pkLabel);
+  pkField.appendChild(pkSelect);
+  state.dataPreview.appendChild(pkField);
+
+  var tableWrap = document.createElement("div");
+  tableWrap.className = "table-create-data-preview-table-wrap";
+  var table = document.createElement("table");
+  table.className = "table-create-data-preview-table";
+  var thead = document.createElement("thead");
+  var headerRow = document.createElement("tr");
+  preview.columns.forEach(function (column) {
+    var th = document.createElement("th");
+    th.scope = "col";
+    th.textContent = column.name;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  var tbody = document.createElement("tbody");
+  preview.rows.forEach(function (row) {
+    var tr = document.createElement("tr");
+    preview.columns.forEach(function (column) {
+      var td = document.createElement("td");
+      var value = row[column.name];
+      td.textContent = bulkInsertPreviewValue(value);
+      if (value === null) {
+        td.className = "table-create-data-preview-null";
+      }
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  tableWrap.appendChild(table);
+  state.dataPreview.appendChild(tableWrap);
+  state.dataPreview.hidden = false;
+}
+
+function resetTableCreateDataPreview(state) {
+  state.dataPreviewRows = null;
+  state.dataPreviewColumns = [];
+  state.dataPreviewReady = false;
+  state.dataPkSelect = null;
+  state.dataPreview.hidden = true;
+  state.dataPreview.textContent = "";
+  syncTableCreateModeUi(state);
+}
+
+function previewTableCreateDataRows(state) {
+  clearTableCreateDialogError(state);
+  resetTableCreateDataPreview(state);
+  try {
+    var preview = parseCreateTableDataRows(state.dataTextarea.value);
+    state.dataPreviewRows = preview.rows;
+    state.dataPreviewColumns = preview.columns;
+    state.dataPreviewReady = true;
+    renderTableCreateDataPreview(state, preview);
+    updateTableCreateDialogButtons(state);
+  } catch (error) {
+    showTableCreateDialogError(
+      state,
+      error.message || "Could not preview rows.",
+    );
+    updateTableCreateDialogButtons(state);
+  }
+}
+
+function collectTableCreateDataPayload(state) {
+  var payload = {
+    table: state.tableName.value.trim(),
+    rows: state.dataPreviewRows || [],
+  };
+  var primaryKey = state.dataPkSelect
+    ? state.dataPkSelect.value
+    : TABLE_CREATE_AUTOMATIC_PK;
+  payload.pk =
+    primaryKey === TABLE_CREATE_AUTOMATIC_PK ? "id" : primaryKey || undefined;
+  return payload;
+}
+
+function validateTableCreateDataPayload(payload, state) {
+  var tableNameError = validateTableCreateTableName(payload.table);
+  if (tableNameError) {
+    return tableNameError;
+  }
+  if (!payload.rows.length) {
+    return "No rows found to create.";
+  }
+  if (
+    state.dataPkSelect &&
+    state.dataPkSelect.value === TABLE_CREATE_AUTOMATIC_PK &&
+    payload.rows.some(function (row) {
+      return Object.prototype.hasOwnProperty.call(row, "id");
+    })
+  ) {
+    return (
+      "Automatic ID column cannot be used because the pasted data " +
+      "already has an id column."
+    );
   }
   return null;
 }
@@ -1441,6 +1977,57 @@ async function assignTableCreateColumnTypes(
   }
 }
 
+async function createTableFromDataPreview(state) {
+  var data = databaseCreateTableData();
+  if (!data || !data.path) {
+    showTableCreateDialogError(state, "Could not find the create table URL.");
+    return;
+  }
+  var payload = collectTableCreateDataPayload(state);
+  var validationError = validateTableCreateDataPayload(payload, state);
+  if (validationError) {
+    showTableCreateDialogError(state, validationError);
+    return;
+  }
+  clearTableCreateDialogError(state);
+  setTableCreateDialogSaving(state, true);
+  try {
+    var response = await fetch(data.path, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+    var responseData = null;
+    try {
+      responseData = await response.json();
+    } catch (_error) {
+      responseData = null;
+    }
+    if (!response.ok || (responseData && responseData.ok === false)) {
+      throw rowMutationRequestError(response, responseData);
+    }
+    var tableUrl =
+      responseData.table_url ||
+      fallbackTableUrl(responseData.table || payload.table);
+    state.shouldRestoreFocus = false;
+    state.dialog.close();
+    if (tableUrl) {
+      location.href = tableUrl;
+    } else {
+      location.reload();
+    }
+  } catch (error) {
+    setTableCreateDialogSaving(state, false);
+    showTableCreateDialogError(
+      state,
+      error.message || "Could not create table",
+    );
+  }
+}
+
 async function saveTableCreateDialog(state) {
   if (state.isSaving) {
     return;
@@ -1448,6 +2035,14 @@ async function saveTableCreateDialog(state) {
   var data = databaseCreateTableData();
   if (!data || !data.path) {
     showTableCreateDialogError(state, "Could not find the create table URL.");
+    return;
+  }
+  if (tableCreateIsDataMode(state)) {
+    if (!state.dataPreviewReady) {
+      previewTableCreateDataRows(state);
+    } else {
+      await createTableFromDataPreview(state);
+    }
     return;
   }
   clearTableCreateDialogError(state);
@@ -1560,8 +2155,18 @@ function ensureTableCreateDialog(manager) {
           <div class="table-create-column-list"></div>
           <button type="button" class="table-create-add-column"><svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg><span>Add column</span></button>
         </div>
+        <div class="table-create-data" hidden>
+          <div class="table-create-data-editor">
+            <label class="table-create-data-label" for="table-create-data-textarea">Rows for the new table</label>
+            <textarea class="table-create-input table-create-data-textarea" id="table-create-data-textarea" name="_create_rows" rows="12" spellcheck="false"></textarea>
+            <p class="table-create-data-note">Paste TSV, CSV, or JSON. You can also drop a text file onto this textarea.</p>
+          </div>
+          <div class="table-create-data-preview" hidden></div>
+        </div>
       </div>
       <div class="modal-footer">
+        <a href="#" class="table-create-mode-link table-create-from-data">Create table from data</a>
+        <a href="#" class="table-create-mode-link table-create-manual" hidden>Create table manually</a>
         <button type="button" class="btn btn-ghost table-create-cancel">Cancel</button>
         <button type="submit" class="btn btn-primary table-create-save">Create table</button>
       </div>
@@ -1576,13 +2181,25 @@ function ensureTableCreateDialog(manager) {
     error: dialog.querySelector(".table-create-error"),
     fields: dialog.querySelector(".table-create-fields"),
     tableName: dialog.querySelector(".table-create-table-name"),
+    columnsPanel: dialog.querySelector(".table-create-columns"),
     columnList: dialog.querySelector(".table-create-column-list"),
     addColumnButton: dialog.querySelector(".table-create-add-column"),
+    dataPanel: dialog.querySelector(".table-create-data"),
+    dataEditor: dialog.querySelector(".table-create-data-editor"),
+    dataTextarea: dialog.querySelector(".table-create-data-textarea"),
+    dataPreview: dialog.querySelector(".table-create-data-preview"),
+    createFromDataLink: dialog.querySelector(".table-create-from-data"),
+    manualCreateLink: dialog.querySelector(".table-create-manual"),
     cancelButton: dialog.querySelector(".table-create-cancel"),
     saveButton: dialog.querySelector(".table-create-save"),
     currentButton: null,
     shouldRestoreFocus: true,
     isSaving: false,
+    mode: "manual",
+    dataPreviewRows: null,
+    dataPreviewColumns: [],
+    dataPreviewReady: false,
+    dataPkSelect: null,
     initialSignature: "",
     nextColumnIndex: 0,
     foreignKeyTargets: [],
@@ -1606,11 +2223,106 @@ function ensureTableCreateDialog(manager) {
   });
 
   tableCreateDialogState.cancelButton.addEventListener("click", function () {
+    if (
+      tableCreateIsDataMode(tableCreateDialogState) &&
+      tableCreateDialogState.dataPreviewReady &&
+      !tableCreateDialogState.isSaving
+    ) {
+      resetTableCreateDataPreview(tableCreateDialogState);
+      updateTableCreateDialogButtons(tableCreateDialogState);
+      tableCreateDialogState.dataTextarea.focus();
+      return;
+    }
     closeTableCreateDialogIfConfirmed(tableCreateDialogState);
   });
 
+  tableCreateDialogState.createFromDataLink.addEventListener(
+    "click",
+    function (ev) {
+      ev.preventDefault();
+      showTableCreateDataMode(tableCreateDialogState);
+    },
+  );
+
+  tableCreateDialogState.manualCreateLink.addEventListener(
+    "click",
+    function (ev) {
+      ev.preventDefault();
+      showTableCreateManualMode(tableCreateDialogState);
+    },
+  );
+
   tableCreateDialogState.tableName.addEventListener("input", function () {
     clearTableCreateDialogError(tableCreateDialogState);
+  });
+
+  tableCreateDialogState.dataTextarea.addEventListener(
+    "dragenter",
+    function (ev) {
+      ev.preventDefault();
+      tableCreateDialogState.dataTextarea.classList.add(
+        "table-create-data-drop-target",
+      );
+    },
+  );
+
+  tableCreateDialogState.dataTextarea.addEventListener(
+    "dragover",
+    function (ev) {
+      ev.preventDefault();
+      tableCreateDialogState.dataTextarea.classList.add(
+        "table-create-data-drop-target",
+      );
+    },
+  );
+
+  tableCreateDialogState.dataTextarea.addEventListener(
+    "dragleave",
+    function () {
+      tableCreateDialogState.dataTextarea.classList.remove(
+        "table-create-data-drop-target",
+      );
+    },
+  );
+
+  tableCreateDialogState.dataTextarea.addEventListener(
+    "drop",
+    async function (ev) {
+      ev.preventDefault();
+      tableCreateDialogState.dataTextarea.classList.remove(
+        "table-create-data-drop-target",
+      );
+      var files = ev.dataTransfer && ev.dataTransfer.files;
+      if (!files || !files.length) {
+        return;
+      }
+      try {
+        tableCreateDialogState.dataTextarea.value = await readTextFile(
+          files[0],
+        );
+        tableCreateDialogState.dataTextarea.dispatchEvent(
+          new Event("input", { bubbles: true }),
+        );
+        clearTableCreateDialogError(tableCreateDialogState);
+      } catch (_error) {
+        showTableCreateDialogError(
+          tableCreateDialogState,
+          "Could not read that text file.",
+        );
+      }
+    },
+  );
+
+  tableCreateDialogState.dataTextarea.addEventListener("dragend", function () {
+    tableCreateDialogState.dataTextarea.classList.remove(
+      "table-create-data-drop-target",
+    );
+  });
+
+  tableCreateDialogState.dataTextarea.addEventListener("input", function () {
+    resetTableCreateDataPreview(tableCreateDialogState);
+    clearTableCreateDialogError(tableCreateDialogState);
+    updateTableCreateDialogButtons(tableCreateDialogState);
   });
 
   dialog.addEventListener("click", function (ev) {
@@ -4958,18 +5670,7 @@ function bulkInsertColumnMap(columns) {
 }
 
 function parseJsonBulkInsertRows(text, columns) {
-  var parsed;
-  try {
-    parsed = JSON.parse(text);
-  } catch (error) {
-    throw new Error("Invalid JSON: " + error.message);
-  }
-  if (!Array.isArray(parsed)) {
-    throw new Error("JSON must be an array of objects.");
-  }
-  if (!parsed.length) {
-    throw new Error("No rows found to preview.");
-  }
+  var parsed = parseJsonObjectRows(text);
 
   var columnMap = bulkInsertColumnMap(columns);
   return parsed.map(function (item, index) {

--- a/datasette/static/edit-tools.js
+++ b/datasette/static/edit-tools.js
@@ -855,17 +855,12 @@ function tableCreateDialogSignature(state) {
     return "";
   }
   var signature = {
-    mode: state.mode || "manual",
     table: state.tableName.value,
     data: state.dataTextarea ? state.dataTextarea.value : "",
     dataPrimaryKey: state.dataPkSelect
       ? state.dataPkSelect.value
       : TABLE_CREATE_AUTOMATIC_PK,
-  };
-  if (tableCreateIsDataMode(state)) {
-    signature.previewReady = !!state.dataPreviewReady;
-  } else {
-    signature.columns = tableCreateDialogRows(state).map(function (row) {
+    columns: tableCreateDialogRows(state).map(function (row) {
       return {
         name: row.querySelector(".table-create-column-name").value,
         type: row.querySelector(".table-create-column-type").value,
@@ -886,8 +881,8 @@ function tableCreateDialogSignature(state) {
             }
           ).value || "",
       };
-    });
-  }
+    }),
+  };
   return JSON.stringify(signature);
 }
 

--- a/datasette/static/edit-tools.js
+++ b/datasette/static/edit-tools.js
@@ -5474,6 +5474,22 @@ function readTextFile(file) {
   });
 }
 
+async function loadBulkInsertTextFile(state, file) {
+  if (!file) {
+    return;
+  }
+  try {
+    state.bulkInsertTextarea.value = await readTextFile(file);
+    state.bulkInsertTextarea.dispatchEvent(
+      new Event("input", { bubbles: true }),
+    );
+    clearRowEditDialogError(state);
+    state.bulkInsertTextarea.focus();
+  } catch (_error) {
+    showRowEditDialogError(state, "Could not read that text file.");
+  }
+}
+
 function bulkInsertTemplateText(state) {
   return (state.bulkInsertColumns || []).join("\t");
 }
@@ -5498,11 +5514,23 @@ async function copyTextToClipboard(text) {
   }
 }
 
+function setBulkInsertCopyButtonReady(state) {
+  state.copyTemplateButton.textContent = "";
+  var wideLabel = document.createElement("span");
+  wideLabel.className = "row-edit-copy-template-label-wide";
+  wideLabel.textContent = "Copy spreadsheet template";
+  state.copyTemplateButton.appendChild(wideLabel);
+  var narrowLabel = document.createElement("span");
+  narrowLabel.className = "row-edit-copy-template-label-narrow";
+  narrowLabel.textContent = "Copy template";
+  state.copyTemplateButton.appendChild(narrowLabel);
+}
+
 function setBulkInsertCopyButtonCopied(state) {
   state.copyTemplateButton.textContent = "Copied";
   clearTimeout(state.copyTemplateResetTimer);
   state.copyTemplateResetTimer = setTimeout(function () {
-    state.copyTemplateButton.textContent = "Copy spreadsheet template";
+    setBulkInsertCopyButtonReady(state);
   }, 1500);
 }
 
@@ -6255,7 +6283,7 @@ function renderRowInsertFields(state, data) {
     return column.name;
   });
   state.copyTemplateButton.disabled = !state.bulkInsertColumns.length;
-  state.copyTemplateButton.textContent = "Copy spreadsheet template";
+  setBulkInsertCopyButtonReady(state);
   clearTimeout(state.copyTemplateResetTimer);
   state.copyTemplateResetTimer = null;
   resetBulkInsertPreview(state);
@@ -6350,12 +6378,13 @@ function ensureRowEditDialog(manager) {
       <div class="row-edit-fields"></div>
       <div class="row-edit-bulk" hidden>
         <div class="row-edit-bulk-editor">
-          <label class="row-edit-bulk-label" for="row-edit-bulk-textarea">Rows to insert</label>
+          <p class="row-edit-bulk-note">Paste TSV, CSV, or JSON. You can also <button type="button" class="button-as-link row-edit-bulk-open-file">open a file</button> or drop it onto this textarea</p>
+          <input class="row-edit-bulk-file-input" type="file" accept=".csv,.tsv,.json,.txt,text/csv,text/tab-separated-values,application/json,text/plain" hidden>
+          <textarea class="row-edit-input row-edit-bulk-textarea" id="row-edit-bulk-textarea" name="_bulk_rows" rows="12" spellcheck="false" aria-label="Bulk rows"></textarea>
           <div class="row-edit-bulk-actions">
-            <button type="button" class="btn btn-ghost row-edit-copy-template">Copy spreadsheet template</button>
+            <button type="button" class="btn btn-ghost row-edit-copy-template"><span class="row-edit-copy-template-label-wide">Copy spreadsheet template</span><span class="row-edit-copy-template-label-narrow">Copy template</span></button>
+            <span class="row-edit-bulk-template-note"><span class="row-edit-bulk-template-note-wide">You can paste the template into Google Sheets or Excel.</span><span class="row-edit-bulk-template-note-narrow">Paste into Google Sheets or Excel</span></span>
           </div>
-          <textarea class="row-edit-input row-edit-bulk-textarea" id="row-edit-bulk-textarea" name="_bulk_rows" rows="12" spellcheck="false"></textarea>
-          <p class="row-edit-bulk-note">Paste TSV, CSV, or JSON. You can also drop a text file onto this textarea.</p>
         </div>
         <div class="row-edit-bulk-preview" hidden></div>
         <div class="row-edit-bulk-progress" hidden>
@@ -6391,6 +6420,8 @@ function ensureRowEditDialog(manager) {
       ".row-edit-bulk-progress-status",
     ),
     copyTemplateButton: dialog.querySelector(".row-edit-copy-template"),
+    bulkInsertOpenFileButton: dialog.querySelector(".row-edit-bulk-open-file"),
+    bulkInsertFileInput: dialog.querySelector(".row-edit-bulk-file-input"),
     bulkInsertLink: dialog.querySelector(".row-edit-bulk-insert"),
     singleInsertLink: dialog.querySelector(".row-edit-single-insert"),
     cancelButton: dialog.querySelector(".row-edit-cancel"),
@@ -6472,6 +6503,25 @@ function ensureRowEditDialog(manager) {
     },
   );
 
+  rowEditDialogState.bulkInsertOpenFileButton.addEventListener(
+    "click",
+    function () {
+      rowEditDialogState.bulkInsertFileInput.click();
+    },
+  );
+
+  rowEditDialogState.bulkInsertFileInput.addEventListener(
+    "change",
+    async function (ev) {
+      var files = ev.target.files;
+      await loadBulkInsertTextFile(
+        rowEditDialogState,
+        files && files.length ? files[0] : null,
+      );
+      ev.target.value = "";
+    },
+  );
+
   rowEditDialogState.bulkInsertTextarea.addEventListener(
     "dragenter",
     function (ev) {
@@ -6512,20 +6562,7 @@ function ensureRowEditDialog(manager) {
       if (!files || !files.length) {
         return;
       }
-      try {
-        rowEditDialogState.bulkInsertTextarea.value = await readTextFile(
-          files[0],
-        );
-        rowEditDialogState.bulkInsertTextarea.dispatchEvent(
-          new Event("input", { bubbles: true }),
-        );
-        clearRowEditDialogError(rowEditDialogState);
-      } catch (_error) {
-        showRowEditDialogError(
-          rowEditDialogState,
-          "Could not read that text file.",
-        );
-      }
+      await loadBulkInsertTextFile(rowEditDialogState, files[0]);
     },
   );
 
@@ -6573,7 +6610,7 @@ function ensureRowEditDialog(manager) {
     state.redirectOnCloseUrl = null;
     clearTimeout(state.copyTemplateResetTimer);
     state.copyTemplateResetTimer = null;
-    state.copyTemplateButton.textContent = "Copy spreadsheet template";
+    setBulkInsertCopyButtonReady(state);
     resetBulkInsertPreview(state);
     clearRowEditDialogError(state);
     state.hasLoaded = false;

--- a/datasette/static/edit-tools.js
+++ b/datasette/static/edit-tools.js
@@ -4332,6 +4332,14 @@ function tableInsertUrl() {
   return url.toString();
 }
 
+function tableUpsertUrl() {
+  var data = tableInsertData();
+  if (data && data.upsertPath) {
+    return new URL(data.upsertPath, location.href).toString();
+  }
+  return null;
+}
+
 function rowResourceUrl(row) {
   var rowId = row.getAttribute("data-row");
   if (!rowId) {
@@ -5179,10 +5187,12 @@ function clearRowEditDialogError(state) {
   state.error.textContent = "";
 }
 
-function showRowEditDialogError(state, message) {
+function showRowEditDialogError(state, message, options) {
   state.error.hidden = false;
   state.error.textContent = message;
-  state.error.focus();
+  if (!options || options.focus !== false) {
+    state.error.focus();
+  }
 }
 
 function rowEditIsMultipleInsert(state) {
@@ -5205,7 +5215,10 @@ function updateRowEditDialogButtons(state) {
     state.isLoading ||
     state.isSaving ||
     !state.hasLoaded ||
-    state.bulkInsertInserted;
+    state.bulkInsertInserted ||
+    (rowEditIsMultipleInsert(state) &&
+      !state.bulkInsertPreviewReady &&
+      !!state.bulkInsertLiveValidationError);
   state.cancelButton.disabled = state.isSaving;
   syncRowEditInsertModeUi(state);
   state.cancelButton.textContent =
@@ -5220,14 +5233,16 @@ function updateRowEditDialogButtons(state) {
     ? state.bulkInsertInserted
       ? "Inserted"
       : state.bulkInsertPreviewReady
-        ? "Insert these rows"
+        ? bulkInsertSaveLabel(state)
         : "Preview rows"
     : state.mode === "insert"
       ? "Insert row"
       : "Save";
   state.saveButton.textContent = state.isSaving
     ? rowEditIsMultipleInsert(state)
-      ? "Inserting..."
+      ? bulkInsertConflictMode(state) === "upsert"
+        ? "Updating..."
+        : "Inserting..."
       : "Saving..."
     : saveLabel;
   state.form.setAttribute(
@@ -5484,6 +5499,8 @@ function showMultipleRowInsert(state) {
   }
   clearRowEditDialogError(state);
   setRowInsertDialogTitle(state);
+  syncBulkInsertConflictUi(state);
+  syncBulkInsertTextareaValidation(state);
   updateRowEditDialogButtons(state);
   state.bulkInsertTextarea.focus();
 }
@@ -5499,6 +5516,67 @@ function showSingleRowInsert(state) {
   if (!focusFirstRowEditControl(state, { skipReadonly: true })) {
     state.saveButton.focus();
   }
+}
+
+function bulkInsertConflictMode(state) {
+  if (!state || !state.bulkInsertHasPrimaryKeyColumns) {
+    return "insert";
+  }
+  return state.bulkInsertConflictMode || "ignore";
+}
+
+function syncBulkInsertConflictUi(state) {
+  if (!state || !state.bulkInsertConflictField) {
+    return;
+  }
+  var insertData = tableInsertData() || {};
+  var primaryKeys = insertData.primaryKeys || [];
+  var hasPrimaryKeys = primaryKeys.length > 0;
+  var hasPrimaryKeyColumns =
+    hasPrimaryKeys &&
+    bulkInsertTextIncludesPrimaryKeyColumns(
+      state.bulkInsertTextarea.value,
+      state.bulkInsertColumnDetails,
+      primaryKeys,
+    );
+  state.bulkInsertHasPrimaryKeyColumns = hasPrimaryKeyColumns;
+  var canUpsert = hasPrimaryKeyColumns && !!state.currentUpsertUrl;
+  var upsertOption = state.bulkInsertConflictSelect.querySelector(
+    'option[value="upsert"]',
+  );
+  if (upsertOption) {
+    upsertOption.disabled = !canUpsert;
+    upsertOption.hidden = !canUpsert;
+  }
+  if (
+    !hasPrimaryKeyColumns ||
+    (!canUpsert && bulkInsertConflictMode(state) === "upsert")
+  ) {
+    state.bulkInsertConflictMode = hasPrimaryKeys ? "ignore" : "insert";
+    state.bulkInsertConflictSelect.value = state.bulkInsertConflictMode;
+  }
+  state.bulkInsertConflictField.hidden = !hasPrimaryKeyColumns;
+  state.bulkInsertConflictSelect.value = bulkInsertConflictMode(state);
+  var helpText = "";
+  if (bulkInsertConflictMode(state) === "upsert") {
+    helpText =
+      "Rows with existing primary keys will be updated; new primary keys will be inserted.";
+  } else if (bulkInsertConflictMode(state) === "ignore") {
+    helpText = "Rows with existing primary keys will be skipped.";
+  } else {
+    helpText = "Rows with existing primary keys will stop the import.";
+  }
+  state.bulkInsertConflictHelp.textContent = helpText;
+}
+
+function bulkInsertSaveLabel(state) {
+  if (!state.bulkInsertPreviewReady) {
+    return "Preview rows";
+  }
+  if (bulkInsertConflictMode(state) === "upsert") {
+    return "Update or insert rows";
+  }
+  return "Insert these rows";
 }
 
 function readTextFile(file) {
@@ -5526,7 +5604,6 @@ async function loadBulkInsertTextFile(state, file) {
     state.bulkInsertTextarea.dispatchEvent(
       new Event("input", { bubbles: true }),
     );
-    clearRowEditDialogError(state);
     state.bulkInsertTextarea.focus();
   } catch (_error) {
     showRowEditDialogError(state, "Could not read that text file.");
@@ -5588,6 +5665,7 @@ function resetBulkInsertPreview(state) {
   state.bulkInsertProgressBar.value = 0;
   state.bulkInsertProgressBar.max = 1;
   state.bulkInsertProgressStatus.textContent = "";
+  syncBulkInsertConflictUi(state);
   syncRowEditInsertModeUi(state);
 }
 
@@ -5617,7 +5695,10 @@ function rowObjectForBulkInsert(valuesByColumn, columns) {
     if (!hasValue) {
       return;
     }
-    row[column.name] = normalizeBulkInsertCell(column, valuesByColumn[column.name]);
+    row[column.name] = normalizeBulkInsertCell(
+      column,
+      valuesByColumn[column.name],
+    );
   });
   return row;
 }
@@ -5732,6 +5813,118 @@ function bulkInsertColumnMap(columns) {
     map[column.name] = column;
   });
   return map;
+}
+
+function bulkInsertTextIncludesPrimaryKeyColumns(text, columns, primaryKeys) {
+  if (!primaryKeys.length || !text.trim()) {
+    return false;
+  }
+  var trimmed = text.trim();
+  try {
+    if (trimmed[0] === "[" || trimmed[0] === "{") {
+      return jsonBulkInsertTextIncludesPrimaryKeyColumns(trimmed, primaryKeys);
+    }
+    return delimitedBulkInsertTextIncludesPrimaryKeyColumns(
+      trimmed,
+      columns,
+      primaryKeys,
+    );
+  } catch (_error) {
+    return false;
+  }
+}
+
+function jsonBulkInsertTextIncludesPrimaryKeyColumns(text, primaryKeys) {
+  var rows = parseJsonObjectRows(text);
+  var seenKeys = {};
+  rows.forEach(function (row) {
+    Object.keys(row).forEach(function (key) {
+      seenKeys[key] = true;
+    });
+  });
+  return primaryKeys.every(function (key) {
+    return !!seenKeys[key];
+  });
+}
+
+function delimitedBulkInsertTextIncludesPrimaryKeyColumns(
+  text,
+  columns,
+  primaryKeys,
+) {
+  var delimiter = detectBulkInsertDelimiter(text, columns);
+  var rows = (
+    delimiter === null
+      ? splitSingleColumnRows(text)
+      : splitDelimitedRows(text, delimiter)
+  ).filter(function (row) {
+    return !bulkInsertDelimitedRowIsBlank(row);
+  });
+  if (!rows.length) {
+    return false;
+  }
+
+  var columnMap = bulkInsertColumnMap(columns);
+  var header = rows[0].map(function (value) {
+    return value.trim();
+  });
+  var headerMatches = header.filter(function (name) {
+    return !!columnMap[name];
+  }).length;
+  if (headerMatches > 0) {
+    return primaryKeys.every(function (key) {
+      return header.indexOf(key) !== -1;
+    });
+  }
+
+  var headers = columns.map(function (column) {
+    return column.name;
+  });
+  var suppliedColumnCount = rows.reduce(function (count, row) {
+    return Math.max(count, row.length);
+  }, 0);
+  return primaryKeys.every(function (key) {
+    var index = headers.indexOf(key);
+    return index !== -1 && index < suppliedColumnCount;
+  });
+}
+
+function bulkInsertLiveValidationShouldWait(message) {
+  return (
+    message === "Paste rows before previewing." ||
+    message === "No data rows found to preview." ||
+    (message.indexOf("Invalid JSON:") === 0 &&
+      message.indexOf("Unexpected end") !== -1)
+  );
+}
+
+function bulkInsertLiveValidationError(state) {
+  var text = state.bulkInsertTextarea.value;
+  if (!text.trim()) {
+    return null;
+  }
+  try {
+    parseBulkInsertRows(text, state.bulkInsertColumnDetails);
+  } catch (error) {
+    var message = error.message || "Could not preview rows.";
+    return bulkInsertLiveValidationShouldWait(message) ? null : message;
+  }
+  return null;
+}
+
+function syncBulkInsertTextareaValidation(state) {
+  if (!rowEditIsMultipleInsert(state) || state.bulkInsertPreviewReady) {
+    state.bulkInsertLiveValidationError = null;
+    return;
+  }
+  state.bulkInsertLiveValidationError = bulkInsertLiveValidationError(state);
+  if (state.bulkInsertLiveValidationError) {
+    showRowEditDialogError(state, state.bulkInsertLiveValidationError, {
+      focus: false,
+    });
+  } else {
+    clearRowEditDialogError(state);
+  }
 }
 
 function parseJsonBulkInsertRows(text, columns) {
@@ -5892,6 +6085,7 @@ function renderBulkInsertPreview(state, rows) {
 function previewBulkInsertRows(state) {
   clearRowEditDialogError(state);
   resetBulkInsertPreview(state);
+  syncBulkInsertConflictUi(state);
   try {
     var rows = parseBulkInsertRows(
       state.bulkInsertTextarea.value,
@@ -5908,13 +6102,14 @@ function previewBulkInsertRows(state) {
 }
 
 function updateBulkInsertProgress(state, inserted, total) {
+  var words = bulkInsertProgressWords(state);
   state.bulkInsertProgress.hidden = false;
   state.bulkInsertProgressBar.max = total || 1;
   state.bulkInsertProgressBar.value = inserted;
   state.bulkInsertProgressStatus.textContent =
     inserted >= total
-      ? total + " row" + (total === 1 ? " inserted." : "s inserted.")
-      : "Inserting " + inserted + " of " + total + " rows...";
+      ? total + " row" + (total === 1 ? " " : "s ") + words.complete + "."
+      : words.active + " " + inserted + " of " + total + " rows...";
 }
 
 function bulkInsertBatches(rows, batchSize) {
@@ -5944,11 +6139,12 @@ function animateBulkInsertProgress(state, from, to, total, duration) {
       var easedProgress = 1 - Math.pow(1 - progress, 3);
       var value = from + (to - from) * easedProgress;
       var displayValue = progress === 1 ? to : Math.floor(value);
+      var words = bulkInsertProgressWords(state);
       state.bulkInsertProgressBar.value = value;
       state.bulkInsertProgressStatus.textContent =
         displayValue >= total
-          ? total + " row" + (total === 1 ? " inserted." : "s inserted.")
-          : "Inserting " + displayValue + " of " + total + " rows...";
+          ? total + " row" + (total === 1 ? " " : "s ") + words.complete + "."
+          : words.active + " " + displayValue + " of " + total + " rows...";
       if (progress < 1) {
         window.requestAnimationFrame(step);
       } else {
@@ -5960,16 +6156,77 @@ function animateBulkInsertProgress(state, from, to, total, duration) {
   });
 }
 
+function bulkInsertProgressWords(state) {
+  var mode = bulkInsertConflictMode(state);
+  if (mode === "upsert") {
+    return {
+      active: "Upserting",
+      complete: "upserted",
+    };
+  }
+  if (mode === "ignore") {
+    return {
+      active: "Processing",
+      complete: "processed",
+    };
+  }
+  return {
+    active: "Inserting",
+    complete: "inserted",
+  };
+}
+
+function validateBulkInsertConflictRows(state, rows) {
+  if (bulkInsertConflictMode(state) !== "upsert") {
+    return null;
+  }
+  var insertData = tableInsertData() || {};
+  var primaryKeys = insertData.primaryKeys || [];
+  for (var index = 0; index < rows.length; index += 1) {
+    var row = rows[index];
+    var missing = primaryKeys.filter(function (key) {
+      return (
+        !Object.prototype.hasOwnProperty.call(row, key) ||
+        row[key] === null ||
+        typeof row[key] === "undefined"
+      );
+    });
+    if (missing.length) {
+      return (
+        "Row " +
+        (index + 1) +
+        " is missing primary key " +
+        missing.join(", ") +
+        ". Upsert requires primary key values for every row."
+      );
+    }
+  }
+  return null;
+}
+
 async function insertBulkPreviewRows(state) {
   if (!state.bulkInsertPreviewRows || state.bulkInsertInserted) {
     return;
   }
-  if (!state.currentInsertUrl) {
-    showRowEditDialogError(state, "Could not find the row insert URL.");
+  var conflictMode = bulkInsertConflictMode(state);
+  var url =
+    conflictMode === "upsert" ? state.currentUpsertUrl : state.currentInsertUrl;
+  if (!url) {
+    showRowEditDialogError(
+      state,
+      conflictMode === "upsert"
+        ? "Could not find the row upsert URL."
+        : "Could not find the row insert URL.",
+    );
     return;
   }
 
   var rows = state.bulkInsertPreviewRows;
+  var validationError = validateBulkInsertConflictRows(state, rows);
+  if (validationError) {
+    showRowEditDialogError(state, validationError);
+    return;
+  }
   var total = rows.length;
   var inserted = state.bulkInsertInsertedCount || 0;
   var batches = bulkInsertBatches(
@@ -5984,13 +6241,17 @@ async function insertBulkPreviewRows(state) {
   try {
     for (var batchIndex = 0; batchIndex < batches.length; batchIndex += 1) {
       var batch = batches[batchIndex];
-      var response = await fetch(state.currentInsertUrl, {
+      var payload = { rows: batch };
+      if (conflictMode === "ignore") {
+        payload.ignore = true;
+      }
+      var response = await fetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Accept: "application/json",
         },
-        body: JSON.stringify({ rows: batch }),
+        body: JSON.stringify(payload),
       });
       var data = null;
       try {
@@ -6318,15 +6579,17 @@ function renderRowEditFields(state, data) {
 
 function renderRowInsertFields(state, data) {
   var columns = data.columns || [];
+  var bulkColumns = data.bulkColumns || columns;
 
   state.insertMode = "single";
-  state.bulkInsertColumnDetails = columns.slice();
+  state.bulkInsertColumnDetails = bulkColumns.slice();
   state.bulkInsertMaxRows = data.maxInsertRows || 100;
-  state.bulkInsertColumns = columns.map(function (column) {
+  state.bulkInsertColumns = bulkColumns.map(function (column) {
     return column.name;
   });
   state.copyTemplateButton.disabled = !state.bulkInsertColumns.length;
   setBulkInsertCopyButtonReady(state);
+  syncBulkInsertConflictUi(state);
   clearTimeout(state.copyTemplateResetTimer);
   state.copyTemplateResetTimer = null;
   resetBulkInsertPreview(state);
@@ -6424,6 +6687,17 @@ function ensureRowEditDialog(manager) {
           <p class="row-edit-bulk-note"><label for="row-edit-bulk-textarea">Paste TSV, CSV, or JSON</label>. You can also <button type="button" class="button-as-link row-edit-bulk-open-file">open a file</button> or drop it onto this textarea</p>
           <input class="row-edit-bulk-file-input" type="file" accept=".csv,.tsv,.json,.txt,text/csv,text/tab-separated-values,application/json,text/plain" hidden>
           <textarea class="row-edit-input row-edit-bulk-textarea" id="row-edit-bulk-textarea" name="_bulk_rows" rows="12" spellcheck="false"></textarea>
+          <div class="row-edit-bulk-conflict" hidden>
+            <label class="row-edit-bulk-conflict-label" for="row-edit-bulk-conflict-mode">If the row exists already</label>
+            <div class="row-edit-bulk-conflict-control">
+              <select class="row-edit-input row-edit-bulk-conflict-mode" id="row-edit-bulk-conflict-mode" aria-describedby="row-edit-bulk-conflict-help">
+                <option value="insert">Stop with an error</option>
+                <option value="ignore">Skip existing rows</option>
+                <option value="upsert">Update existing and insert new</option>
+              </select>
+              <p class="row-edit-bulk-conflict-help" id="row-edit-bulk-conflict-help"></p>
+            </div>
+          </div>
           <div class="row-edit-bulk-actions">
             <button type="button" class="btn btn-ghost row-edit-copy-template"><span class="row-edit-copy-template-label-wide">Copy spreadsheet template</span><span class="row-edit-copy-template-label-narrow">Copy template</span></button>
             <span class="row-edit-bulk-template-note"><span class="row-edit-bulk-template-note-wide">You can paste the template into Google Sheets or Excel.</span><span class="row-edit-bulk-template-note-narrow">Paste into Google Sheets or Excel</span></span>
@@ -6462,6 +6736,13 @@ function ensureRowEditDialog(manager) {
     bulkInsertProgressStatus: dialog.querySelector(
       ".row-edit-bulk-progress-status",
     ),
+    bulkInsertConflictField: dialog.querySelector(".row-edit-bulk-conflict"),
+    bulkInsertConflictSelect: dialog.querySelector(
+      ".row-edit-bulk-conflict-mode",
+    ),
+    bulkInsertConflictHelp: dialog.querySelector(
+      ".row-edit-bulk-conflict-help",
+    ),
     copyTemplateButton: dialog.querySelector(".row-edit-copy-template"),
     bulkInsertOpenFileButton: dialog.querySelector(".row-edit-bulk-open-file"),
     bulkInsertFileInput: dialog.querySelector(".row-edit-bulk-file-input"),
@@ -6474,10 +6755,14 @@ function ensureRowEditDialog(manager) {
     currentRowId: null,
     currentPkPath: null,
     currentInsertUrl: null,
+    currentUpsertUrl: null,
     currentUpdateUrl: null,
     currentFragmentUrl: null,
     mode: "edit",
     insertMode: "single",
+    bulkInsertConflictMode: "ignore",
+    bulkInsertHasPrimaryKeyColumns: false,
+    bulkInsertLiveValidationError: null,
     bulkInsertColumns: [],
     bulkInsertColumnDetails: [],
     bulkInsertPreviewRows: null,
@@ -6620,9 +6905,21 @@ function ensureRowEditDialog(manager) {
 
   rowEditDialogState.bulkInsertTextarea.addEventListener("input", function () {
     resetBulkInsertPreview(rowEditDialogState);
-    clearRowEditDialogError(rowEditDialogState);
+    syncBulkInsertTextareaValidation(rowEditDialogState);
     updateRowEditDialogButtons(rowEditDialogState);
   });
+
+  rowEditDialogState.bulkInsertConflictSelect.addEventListener(
+    "change",
+    function () {
+      rowEditDialogState.bulkInsertConflictMode =
+        rowEditDialogState.bulkInsertConflictSelect.value;
+      syncBulkInsertConflictUi(rowEditDialogState);
+      resetBulkInsertPreview(rowEditDialogState);
+      syncBulkInsertTextareaValidation(rowEditDialogState);
+      updateRowEditDialogButtons(rowEditDialogState);
+    },
+  );
 
   dialog.addEventListener("click", function (ev) {
     if (ev.target === dialog) {
@@ -6649,6 +6946,7 @@ function ensureRowEditDialog(manager) {
     var redirectOnCloseUrl = state.redirectOnCloseUrl;
     state.loadId += 1;
     state.isClosePending = false;
+    state.bulkInsertLiveValidationError = null;
     state.shouldReloadOnClose = false;
     state.redirectOnCloseUrl = null;
     clearTimeout(state.copyTemplateResetTimer);
@@ -6696,6 +6994,7 @@ async function openRowEditDialog(button, manager) {
   state.currentRowId = row.getAttribute("data-row") || "";
   state.currentPkPath = rowDisplayLabel(row);
   state.currentInsertUrl = null;
+  state.currentUpsertUrl = null;
   state.currentUpdateUrl = rowUpdateUrl(row);
   state.currentFragmentUrl = rowFragmentUrl(row);
   state.insertMode = "single";
@@ -6773,9 +7072,12 @@ function openRowInsertDialog(button, manager) {
   state.currentRowId = null;
   state.currentPkPath = null;
   state.currentInsertUrl = tableInsertUrl();
+  state.currentUpsertUrl = tableUpsertUrl();
   state.currentUpdateUrl = null;
   state.currentFragmentUrl = null;
   state.insertMode = "single";
+  state.bulkInsertConflictMode = "ignore";
+  state.bulkInsertLiveValidationError = null;
   state.bulkInsertTextarea.value = "";
   state.shouldReloadOnClose = false;
   state.redirectOnCloseUrl = null;

--- a/datasette/static/edit-tools.js
+++ b/datasette/static/edit-tools.js
@@ -1850,6 +1850,36 @@ function resetTableCreateDataPreview(state) {
   syncTableCreateModeUi(state);
 }
 
+function tableCreateTableNameFromFileName(fileName) {
+  var baseName = (fileName || "").replace(/^.*[\\/]/, "");
+  var nameWithoutExtension = baseName.replace(/\.[^.]*$/, "");
+  return nameWithoutExtension
+    .trim()
+    .replace(/\s+/g, "_")
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, "");
+}
+
+async function loadTableCreateDataTextFile(state, file) {
+  if (!file) {
+    return;
+  }
+  try {
+    var text = await readTextFile(file);
+    var tableName = tableCreateTableNameFromFileName(file.name);
+    if (tableName) {
+      state.tableName.value = tableName;
+      state.tableName.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+    state.dataTextarea.value = text;
+    state.dataTextarea.dispatchEvent(new Event("input", { bubbles: true }));
+    clearTableCreateDialogError(state);
+    state.dataTextarea.focus();
+  } catch (_error) {
+    showTableCreateDialogError(state, "Could not read that text file.");
+  }
+}
+
 function previewTableCreateDataRows(state) {
   clearTableCreateDialogError(state);
   resetTableCreateDataPreview(state);
@@ -2152,9 +2182,9 @@ function ensureTableCreateDialog(manager) {
         </div>
         <div class="table-create-data" hidden>
           <div class="table-create-data-editor">
-            <label class="table-create-data-label" for="table-create-data-textarea">Rows for the new table</label>
+            <p class="table-create-data-note"><label for="table-create-data-textarea">Paste TSV, CSV, or JSON</label>. You can also <button type="button" class="button-as-link table-create-data-open-file">open a file</button> or drop it onto this textarea</p>
+            <input class="table-create-data-file-input" type="file" accept=".csv,.tsv,.json,.txt,text/csv,text/tab-separated-values,application/json,text/plain" hidden>
             <textarea class="table-create-input table-create-data-textarea" id="table-create-data-textarea" name="_create_rows" rows="12" spellcheck="false"></textarea>
-            <p class="table-create-data-note">Paste TSV, CSV, or JSON. You can also drop a text file onto this textarea.</p>
           </div>
           <div class="table-create-data-preview" hidden></div>
         </div>
@@ -2182,6 +2212,8 @@ function ensureTableCreateDialog(manager) {
     dataPanel: dialog.querySelector(".table-create-data"),
     dataEditor: dialog.querySelector(".table-create-data-editor"),
     dataTextarea: dialog.querySelector(".table-create-data-textarea"),
+    dataOpenFileButton: dialog.querySelector(".table-create-data-open-file"),
+    dataFileInput: dialog.querySelector(".table-create-data-file-input"),
     dataPreview: dialog.querySelector(".table-create-data-preview"),
     createFromDataLink: dialog.querySelector(".table-create-from-data"),
     manualCreateLink: dialog.querySelector(".table-create-manual"),
@@ -2251,6 +2283,25 @@ function ensureTableCreateDialog(manager) {
     clearTableCreateDialogError(tableCreateDialogState);
   });
 
+  tableCreateDialogState.dataOpenFileButton.addEventListener(
+    "click",
+    function () {
+      tableCreateDialogState.dataFileInput.click();
+    },
+  );
+
+  tableCreateDialogState.dataFileInput.addEventListener(
+    "change",
+    async function (ev) {
+      var files = ev.target.files;
+      await loadTableCreateDataTextFile(
+        tableCreateDialogState,
+        files && files.length ? files[0] : null,
+      );
+      ev.target.value = "";
+    },
+  );
+
   tableCreateDialogState.dataTextarea.addEventListener(
     "dragenter",
     function (ev) {
@@ -2291,20 +2342,7 @@ function ensureTableCreateDialog(manager) {
       if (!files || !files.length) {
         return;
       }
-      try {
-        tableCreateDialogState.dataTextarea.value = await readTextFile(
-          files[0],
-        );
-        tableCreateDialogState.dataTextarea.dispatchEvent(
-          new Event("input", { bubbles: true }),
-        );
-        clearTableCreateDialogError(tableCreateDialogState);
-      } catch (_error) {
-        showTableCreateDialogError(
-          tableCreateDialogState,
-          "Could not read that text file.",
-        );
-      }
+      await loadTableCreateDataTextFile(tableCreateDialogState, files[0]);
     },
   );
 
@@ -6378,9 +6416,9 @@ function ensureRowEditDialog(manager) {
       <div class="row-edit-fields"></div>
       <div class="row-edit-bulk" hidden>
         <div class="row-edit-bulk-editor">
-          <p class="row-edit-bulk-note">Paste TSV, CSV, or JSON. You can also <button type="button" class="button-as-link row-edit-bulk-open-file">open a file</button> or drop it onto this textarea</p>
+          <p class="row-edit-bulk-note"><label for="row-edit-bulk-textarea">Paste TSV, CSV, or JSON</label>. You can also <button type="button" class="button-as-link row-edit-bulk-open-file">open a file</button> or drop it onto this textarea</p>
           <input class="row-edit-bulk-file-input" type="file" accept=".csv,.tsv,.json,.txt,text/csv,text/tab-separated-values,application/json,text/plain" hidden>
-          <textarea class="row-edit-input row-edit-bulk-textarea" id="row-edit-bulk-textarea" name="_bulk_rows" rows="12" spellcheck="false" aria-label="Bulk rows"></textarea>
+          <textarea class="row-edit-input row-edit-bulk-textarea" id="row-edit-bulk-textarea" name="_bulk_rows" rows="12" spellcheck="false"></textarea>
           <div class="row-edit-bulk-actions">
             <button type="button" class="btn btn-ghost row-edit-copy-template"><span class="row-edit-copy-template-label-wide">Copy spreadsheet template</span><span class="row-edit-copy-template-label-narrow">Copy template</span></button>
             <span class="row-edit-bulk-template-note"><span class="row-edit-bulk-template-note-wide">You can paste the template into Google Sheets or Excel.</span><span class="row-edit-bulk-template-note-narrow">Paste into Google Sheets or Excel</span></span>

--- a/datasette/views/database.py
+++ b/datasette/views/database.py
@@ -325,7 +325,7 @@ class DatabaseContext(Context):
     database_color: str = field(metadata={"help": "The color assigned to the database"})
     database_page_data: dict = field(
         metadata={
-            "help": 'JSON data used by JavaScript on the database page. Currently ``{}`` or ``{"createTable": {...}}`` where ``createTable`` includes ``path``, ``foreignKeyTargetsPath``, ``databaseName``, ``columnTypes``, ``defaultExpressions`` and optional ``customColumnTypes``.'
+            "help": 'JSON data used by JavaScript on the database page. Currently ``{}`` or ``{"createTable": {...}}`` where ``createTable`` includes ``path``, ``foreignKeyTargetsPath``, ``databaseName``, ``columnTypes``, ``defaultExpressions``, ``canInsertRows`` and optional ``customColumnTypes``.'
         }
     )
     database_actions: callable = field(

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -205,7 +205,7 @@ class TableContext(Context):
     )
     table_insert_ui: dict = field(
         metadata={
-            "help": "Information needed to enable the row insertion UI, or ``None`` if row insertion is not available to the current actor. When present it has ``path``, ``tableName``, ``columns`` and ``primaryKeys`` keys; each column includes ``name``, ``sqlite_type``, ``notnull``, ``default``, ``has_default``, ``is_pk``, ``value_kind`` and ``column_type`` keys."
+            "help": "Information needed to enable the row insertion UI, or ``None`` if row insertion is not available to the current actor. When present it has ``path``, ``tableName``, ``columns`` and ``primaryKeys`` keys; each column includes ``name``, ``sqlite_type``, ``notnull``, ``default``, ``has_default``, ``is_pk``, ``is_auto_pk``, ``value_kind`` and ``column_type`` keys."
         }
     )
     table_alter_ui: dict = field(
@@ -507,6 +507,7 @@ async def _table_insert_ui(
             "default": column.default_value,
             "has_default": column.default_value is not None,
             "is_pk": is_pk,
+            "is_auto_pk": is_auto_pk,
             "value_kind": _column_value_kind_for_insert_form(column),
             "column_type": (
                 {"type": column_type.name, "config": column_type.config}

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -480,8 +480,15 @@ async def _table_insert_ui(
     ):
         return None
 
+    can_update = await datasette.allowed(
+        action="update-row",
+        resource=TableResource(database=database_name, table=table_name),
+        actor=request.actor,
+    )
+
     column_types_map = await datasette.get_column_types(database_name, table_name)
     columns = []
+    bulk_columns = []
     column_details = await db.table_column_details(table_name)
     for column in column_details:
         if column.hidden:
@@ -492,33 +499,39 @@ async def _table_insert_ui(
             and len(pks) == 1
             and SQLiteType.from_declared_type(column.type) == SQLiteType.INTEGER
         )
+        column_type = column_types_map.get(column.name)
+        column_data = {
+            "name": column.name,
+            "sqlite_type": _column_sqlite_type_for_insert_form(column),
+            "notnull": column.notnull,
+            "default": column.default_value,
+            "has_default": column.default_value is not None,
+            "is_pk": is_pk,
+            "value_kind": _column_value_kind_for_insert_form(column),
+            "column_type": (
+                {"type": column_type.name, "config": column_type.config}
+                if column_type is not None
+                else None
+            ),
+        }
+        bulk_columns.append(column_data)
         if is_auto_pk:
             continue
-        column_type = column_types_map.get(column.name)
-        columns.append(
-            {
-                "name": column.name,
-                "sqlite_type": _column_sqlite_type_for_insert_form(column),
-                "notnull": column.notnull,
-                "default": column.default_value,
-                "has_default": column.default_value is not None,
-                "is_pk": is_pk,
-                "value_kind": _column_value_kind_for_insert_form(column),
-                "column_type": (
-                    {"type": column_type.name, "config": column_type.config}
-                    if column_type is not None
-                    else None
-                ),
-            }
-        )
+        columns.append(column_data)
 
-    return {
+    data = {
         "path": "{}/-/insert".format(datasette.urls.table(database_name, table_name)),
         "tableName": table_name,
         "columns": columns,
+        "bulkColumns": bulk_columns,
         "primaryKeys": pks,
         "maxInsertRows": datasette.setting("max_insert_rows"),
     }
+    if can_update:
+        data["upsertPath"] = "{}/-/upsert".format(
+            datasette.urls.table(database_name, table_name)
+        )
+    return data
 
 
 async def _table_alter_ui(

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -517,6 +517,7 @@ async def _table_insert_ui(
         "tableName": table_name,
         "columns": columns,
         "primaryKeys": pks,
+        "maxInsertRows": datasette.setting("max_insert_rows"),
     }
 
 

--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -205,7 +205,7 @@ class TableContext(Context):
     )
     table_insert_ui: dict = field(
         metadata={
-            "help": "Information needed to enable the row insertion UI, or ``None`` if row insertion is not available to the current actor. When present it has ``path``, ``tableName``, ``columns`` and ``primaryKeys`` keys; each column includes ``name``, ``sqlite_type``, ``notnull``, ``default``, ``has_default``, ``is_pk``, ``is_auto_pk``, ``value_kind`` and ``column_type`` keys."
+            "help": "Information needed to enable the row insertion UI, or ``None`` if row insertion is not available to the current actor. When present it has ``path``, ``tableName``, ``columns``, ``bulkColumns``, ``primaryKeys`` and ``maxInsertRows`` keys, plus optional ``upsertPath`` if the current actor has permission to update rows. ``columns`` lists columns for the single-row insert form, while ``bulkColumns`` lists columns for the bulk insert form. Each column includes ``name``, ``sqlite_type``, ``notnull``, ``default``, ``has_default``, ``is_pk``, ``is_auto_pk``, ``value_kind`` and ``column_type`` keys."
         }
     )
     table_alter_ui: dict = field(

--- a/datasette/views/table_create_alter.py
+++ b/datasette/views/table_create_alter.py
@@ -267,6 +267,11 @@ async def _create_table_ui_context(
         "databaseName": database_name,
         "columnTypes": CREATE_TABLE_COLUMN_TYPES,
         "defaultExpressions": default_expression_options(),
+        "canInsertRows": await datasette.allowed(
+            action="insert-row",
+            resource=DatabaseResource(database=database_name),
+            actor=request.actor,
+        ),
     }
     can_set_column_type = await datasette.allowed(
         action="set-column-type",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ Unreleased
 ----------
 
 - Table pages now offer an "Insert multiple rows" mode in the row insertion dialog. This accepts pasted TSV, CSV or JSON, previews the parsed rows before inserting them, validates unknown columns as data is pasted and displays omitted auto integer primary keys as ``auto`` in the preview. (:pr:`2813`)
-- The bulk insert UI can now skip rows with existing primary keys, or update existing rows and insert new rows using the existing ``/<database>/<table>/-/upsert`` API when the actor has both :ref:`insert-row <actions_insert_row>` and :ref:`update-row <actions_update_row>` permissions. (:pr:`2813`)
+- The bulk insert UI can skip rows with existing primary keys, or update existing rows and insert new rows using the existing ``/<database>/<table>/-/upsert`` API when the actor has both :ref:`insert-row <actions_insert_row>` and :ref:`update-row <actions_update_row>` permissions. (:pr:`2813`)
 - The "Create table" dialog now includes a "Create table from data" mode. Paste TSV, CSV or JSON rows to preview inferred columns and types, choose the table name and primary key, then create the table and insert those rows in one step. (:pr:`2813`)
 
 .. _v1_0_a35:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,15 @@
 Changelog
 =========
 
+.. _unreleased:
+
+Unreleased
+----------
+
+- Table pages now offer an "Insert multiple rows" mode in the row insertion dialog. This accepts pasted TSV, CSV or JSON, previews the parsed rows before inserting them, validates unknown columns as data is pasted and displays omitted auto integer primary keys as ``auto`` in the preview. (:pr:`2813`)
+- The bulk insert UI can now skip rows with existing primary keys, or update existing rows and insert new rows using the existing ``/<database>/<table>/-/upsert`` API when the actor has both :ref:`insert-row <actions_insert_row>` and :ref:`update-row <actions_update_row>` permissions. (:pr:`2813`)
+- The "Create table" dialog now includes a "Create table from data" mode. Paste TSV, CSV or JSON rows to preview inferred columns and types, choose the table name and primary key, then create the table and insert those rows in one step. (:pr:`2813`)
+
 .. _v1_0_a35:
 
 1.0a35 (2026-06-23)

--- a/docs/template_context.rst
+++ b/docs/template_context.rst
@@ -98,7 +98,7 @@ The page listing the tables, views and queries in a database, e.g. /fixtures. Re
     The color assigned to the database
 
 ``database_page_data`` - ``dict``
-    JSON data used by JavaScript on the database page. Currently ``{}`` or ``{"createTable": {...}}`` where ``createTable`` includes ``path``, ``foreignKeyTargetsPath``, ``databaseName``, ``columnTypes``, ``defaultExpressions`` and optional ``customColumnTypes``.
+    JSON data used by JavaScript on the database page. Currently ``{}`` or ``{"createTable": {...}}`` where ``createTable`` includes ``path``, ``foreignKeyTargetsPath``, ``databaseName``, ``columnTypes``, ``defaultExpressions``, ``canInsertRows`` and optional ``customColumnTypes``.
 
 ``editable`` - ``bool``
     Boolean indicating if the database is editable

--- a/docs/template_context.rst
+++ b/docs/template_context.rst
@@ -389,7 +389,7 @@ Many of these keys are shared with the :ref:`JSON API <json_api>` for this page.
     SQL definition for this table
 
 ``table_insert_ui`` - ``dict``
-    Information needed to enable the row insertion UI, or ``None`` if row insertion is not available to the current actor. When present it has ``path``, ``tableName``, ``columns`` and ``primaryKeys`` keys; each column includes ``name``, ``sqlite_type``, ``notnull``, ``default``, ``has_default``, ``is_pk``, ``value_kind`` and ``column_type`` keys.
+    Information needed to enable the row insertion UI, or ``None`` if row insertion is not available to the current actor. When present it has ``path``, ``tableName``, ``columns`` and ``primaryKeys`` keys; each column includes ``name``, ``sqlite_type``, ``notnull``, ``default``, ``has_default``, ``is_pk``, ``is_auto_pk``, ``value_kind`` and ``column_type`` keys.
 
 ``table_page_data`` - ``dict``
     JSON data used by JavaScript on the table page. Includes ``database``, ``table`` and ``tableUrl``, plus optional ``foreignKeys`` mapping column names to autocomplete URLs, optional ``insertRow`` data and optional ``alterTable`` data.

--- a/docs/template_context.rst
+++ b/docs/template_context.rst
@@ -389,7 +389,7 @@ Many of these keys are shared with the :ref:`JSON API <json_api>` for this page.
     SQL definition for this table
 
 ``table_insert_ui`` - ``dict``
-    Information needed to enable the row insertion UI, or ``None`` if row insertion is not available to the current actor. When present it has ``path``, ``tableName``, ``columns`` and ``primaryKeys`` keys; each column includes ``name``, ``sqlite_type``, ``notnull``, ``default``, ``has_default``, ``is_pk``, ``is_auto_pk``, ``value_kind`` and ``column_type`` keys.
+    Information needed to enable the row insertion UI, or ``None`` if row insertion is not available to the current actor. When present it has ``path``, ``tableName``, ``columns``, ``bulkColumns``, ``primaryKeys`` and ``maxInsertRows`` keys, plus optional ``upsertPath`` if the current actor has permission to update rows. ``columns`` lists columns for the single-row insert form, while ``bulkColumns`` lists columns for the bulk insert form. Each column includes ``name``, ``sqlite_type``, ``notnull``, ``default``, ``has_default``, ``is_pk``, ``is_auto_pk``, ``value_kind`` and ``column_type`` keys.
 
 ``table_page_data`` - ``dict``
     JSON data used by JavaScript on the table page. Includes ``database``, ``table`` and ``tableUrl``, plus optional ``foreignKeys`` mapping column names to autocomplete URLs, optional ``insertRow`` data and optional ``alterTable`` data.

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -914,9 +914,20 @@ def test_navigation_search_renders_jump_sections_from_javascript_plugins(
 
 @pytest.mark.playwright
 def test_insert_row_flow_uses_custom_column_field(page, datasette_server):
-    page.context.grant_permissions(
-        ["clipboard-read", "clipboard-write"], origin=datasette_server.rstrip("/")
-    )
+    page.add_init_script("""
+        (() => {
+            let clipboardText = "";
+            Object.defineProperty(navigator, "clipboard", {
+                configurable: true,
+                get: () => ({
+                    writeText: async (text) => {
+                        clipboardText = String(text);
+                    },
+                    readText: async () => clipboardText,
+                }),
+            });
+        })();
+        """)
     page.goto(f"{datasette_server}data/projects")
     page.locator('button[data-table-action="insert-row"]').click()
 

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -1109,10 +1109,14 @@ def test_insert_row_flow_uses_custom_column_field(page, datasette_server):
         "Previewing 1 row."
     )
     preview_text = dialog.locator(".row-edit-bulk-preview-table").inner_text()
+    assert "id" in preview_text
     assert "title" in preview_text
     assert "metadata" in preview_text
-    assert "id" not in preview_text
     assert "From CSV" in preview_text
+    assert (
+        dialog.locator(".row-edit-bulk-preview-auto").first.text_content()
+        == "auto"
+    )
     assert "null" not in preview_text
     assert "undefined" not in preview_text
     preview_cell_style = dialog.locator(

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -894,10 +894,32 @@ def test_insert_row_flow_uses_custom_column_field(page, datasette_server):
     assert dialog.locator(".row-edit-save").inner_text() == "Preview rows"
     assert (
         dialog.locator(".row-edit-bulk-note").inner_text()
-        == "Paste TSV, CSV, or JSON. You can also drop a text file onto this textarea."
+        == "Paste TSV, CSV, or JSON. You can also open a file or drop it onto this textarea"
+    )
+    assert dialog.locator(".row-edit-bulk-open-file").inner_text() == "open a file"
+    assert (
+        dialog.locator(".row-edit-bulk-editor").evaluate(
+            """node => Array.from(node.children)
+            .filter((child) => !child.hidden)
+            .map((child) => child.className)
+            .join(" ")"""
+        )
+        == (
+            "row-edit-bulk-note row-edit-input row-edit-bulk-textarea "
+            "row-edit-bulk-actions"
+        )
     )
     copy_template = dialog.locator(".row-edit-copy-template")
     assert copy_template.inner_text() == "Copy spreadsheet template"
+    assert dialog.locator(".row-edit-copy-template-label-narrow").text_content() == (
+        "Copy template"
+    )
+    assert dialog.locator(".row-edit-bulk-template-note").inner_text() == (
+        "You can paste the template into Google Sheets or Excel."
+    )
+    assert dialog.locator(".row-edit-bulk-template-note-narrow").text_content() == (
+        "Paste into Google Sheets or Excel"
+    )
     copy_template.click()
     page.wait_for_function(
         """() => document.querySelector(".row-edit-copy-template").textContent === "Copied" """

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -516,6 +516,53 @@ def test_create_table_from_data_flow(page, datasette_server):
 
 
 @pytest.mark.playwright
+def test_create_table_from_csv_keeps_numeric_type_when_values_are_blank(
+    page, datasette_server
+):
+    page.goto(f"{datasette_server}data")
+    page.locator("details.actions-menu-links summary").click()
+    page.locator('button[data-database-action="create-table"]').click()
+
+    dialog = page.locator("#table-create-dialog")
+    dialog.wait_for()
+    dialog.locator(".table-create-from-data").click()
+    dialog.locator(".table-create-table-name").fill("playwright_numeric_blanks")
+    dialog.locator(".table-create-data-textarea").fill("name,score\nA,1\nB,")
+    dialog.locator(".table-create-save").click()
+
+    assert dialog.locator(".table-create-save").inner_text() == "Create table"
+    preview_text = dialog.locator(".table-create-data-preview-table").inner_text()
+    assert "A" in preview_text
+    assert "1" in preview_text
+    assert "B" in preview_text
+    assert "null" in preview_text
+
+    dialog.locator(".table-create-save").click()
+    page.wait_for_url("**/data/playwright_numeric_blanks")
+
+    response = httpx.get(
+        f"{datasette_server}data/playwright_numeric_blanks.json?_shape=objects"
+    )
+    response.raise_for_status()
+    assert response.json()["rows"] == [
+        {"name": "A", "score": 1},
+        {"name": "B", "score": None},
+    ]
+
+    schema_response = httpx.get(
+        f"{datasette_server}data/-/query.json",
+        params={
+            "sql": (
+                "select type from pragma_table_info('playwright_numeric_blanks') "
+                "where name = 'score'"
+            )
+        },
+    )
+    schema_response.raise_for_status()
+    assert schema_response.json()["rows"] == [{"type": "INTEGER"}]
+
+
+@pytest.mark.playwright
 def test_create_table_foreign_key_selection_updates_column_type(page, datasette_server):
     page.goto(f"{datasette_server}data")
     page.locator("details.actions-menu-links summary").click()

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -399,14 +399,42 @@ def test_create_table_from_data_flow(page, datasette_server):
     assert dialog.locator(".table-create-save").inner_text() == "Preview rows"
     assert (
         dialog.locator(".table-create-data-note").inner_text()
-        == "Paste TSV, CSV, or JSON. You can also drop a text file onto this textarea."
+        == "Paste TSV, CSV, or JSON. You can also open a file or drop it onto this textarea"
+    )
+    assert dialog.locator(".table-create-data-open-file").inner_text() == "open a file"
+    assert (
+        dialog.locator(".table-create-data-editor").evaluate(
+            """node => Array.from(node.children)
+            .filter((child) => !child.hidden)
+            .map((child) => child.className)
+            .join(" ")"""
+        )
+        == ("table-create-data-note table-create-input table-create-data-textarea")
     )
     assert dialog.locator(".table-create-manual").inner_text() == (
         "Create table manually"
     )
+    assert (
+        dialog.get_by_label("Paste TSV, CSV, or JSON").get_attribute("id")
+        == "table-create-data-textarea"
+    )
+
+    textarea = dialog.locator(".table-create-data-textarea")
+    dropped_value = textarea.evaluate("""node => new Promise((resolve) => {
+            node.addEventListener("input", () => resolve(node.value), { once: true });
+            const file = new File(["short_id,name\\nx,Ada"], "Repo Export 2026!!.CSV", { type: "text/csv" });
+            const dataTransfer = new DataTransfer();
+            dataTransfer.items.add(file);
+            node.dispatchEvent(new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer }));
+            node.dispatchEvent(new DragEvent("dragover", { bubbles: true, cancelable: true, dataTransfer }));
+            node.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer }));
+        })""")
+    assert dropped_value == "short_id,name\nx,Ada"
+    assert dialog.locator(".table-create-table-name").input_value() == (
+        "repo_export_2026"
+    )
 
     dialog.locator(".table-create-table-name").fill("playwright_from_data")
-    textarea = dialog.locator(".table-create-data-textarea")
     textarea.fill(
         json.dumps(
             {
@@ -431,6 +459,18 @@ def test_create_table_from_data_flow(page, datasette_server):
     assert "short_id" in preview_text
     assert "Ada" in preview_text
     assert "2.5" in preview_text
+    preview_cell_style = dialog.locator(
+        ".table-create-data-preview-table td"
+    ).first.evaluate(
+        """node => ({
+            overflowWrap: getComputedStyle(node).overflowWrap,
+            whiteSpace: getComputedStyle(node).whiteSpace
+        })"""
+    )
+    assert preview_cell_style == {
+        "overflowWrap": "anywhere",
+        "whiteSpace": "normal",
+    }
 
     dialog.locator(".table-create-cancel").click()
     assert dialog.evaluate("node => node.open")
@@ -911,6 +951,10 @@ def test_insert_row_flow_uses_custom_column_field(page, datasette_server):
     )
     copy_template = dialog.locator(".row-edit-copy-template")
     assert copy_template.inner_text() == "Copy spreadsheet template"
+    assert (
+        dialog.get_by_label("Paste TSV, CSV, or JSON").get_attribute("id")
+        == "row-edit-bulk-textarea"
+    )
     assert dialog.locator(".row-edit-copy-template-label-narrow").text_content() == (
         "Copy template"
     )
@@ -953,6 +997,18 @@ def test_insert_row_flow_uses_custom_column_field(page, datasette_server):
     assert "id" not in preview_text
     assert "From CSV" in preview_text
     assert "null" in preview_text
+    preview_cell_style = dialog.locator(
+        ".row-edit-bulk-preview-table td"
+    ).first.evaluate(
+        """node => ({
+            overflowWrap: getComputedStyle(node).overflowWrap,
+            whiteSpace: getComputedStyle(node).whiteSpace
+        })"""
+    )
+    assert preview_cell_style == {
+        "overflowWrap": "anywhere",
+        "whiteSpace": "normal",
+    }
     assert dialog.locator(".row-edit-cancel").inner_text() == "Back"
     dialog.locator(".row-edit-cancel").click()
     assert dialog.evaluate("node => node.open")

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -17,7 +17,7 @@ def find_free_port():
         return sock.getsockname()[1]
 
 
-def wait_for_server(process, url, timeout=10):
+def wait_for_server(process, url, timeout=30):
     deadline = time.monotonic() + timeout
     last_error = None
     while time.monotonic() < deadline:
@@ -36,7 +36,20 @@ def wait_for_server(process, url, timeout=10):
         except httpx.HTTPError as ex:
             last_error = repr(ex)
         time.sleep(0.1)
-    raise AssertionError(f"Timed out waiting for {url}: {last_error}")
+    if process.poll() is None:
+        process.terminate()
+        try:
+            stdout, stderr = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+    else:
+        stdout, stderr = process.communicate()
+    raise AssertionError(
+        f"Timed out waiting for {url}: {last_error}\n"
+        f"stdout:\n{stdout}\n"
+        f"stderr:\n{stderr}"
+    )
 
 
 @pytest.fixture
@@ -1113,10 +1126,7 @@ def test_insert_row_flow_uses_custom_column_field(page, datasette_server):
     assert "title" in preview_text
     assert "metadata" in preview_text
     assert "From CSV" in preview_text
-    assert (
-        dialog.locator(".row-edit-bulk-preview-auto").first.text_content()
-        == "auto"
-    )
+    assert dialog.locator(".row-edit-bulk-preview-auto").first.text_content() == "auto"
     assert "null" not in preview_text
     assert "undefined" not in preview_text
     preview_cell_style = dialog.locator(

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -102,6 +102,12 @@ def write_playwright_database(db_path):
             id integer primary key,
             created_ms integer default (CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER))
         );
+        create table bulk_defaults (
+            id integer primary key,
+            title text not null,
+            status text not null default 'todo',
+            score integer default 5
+        );
         insert into projects (title, metadata, logo, notes, score) values
             (
                 'Build Datasette',
@@ -144,6 +150,11 @@ def write_playwright_config(config_path):
                             "defaults_demo": {
                                 "permissions": {
                                     "alter-table": True,
+                                },
+                            },
+                            "bulk_defaults": {
+                                "permissions": {
+                                    "insert-row": True,
                                 },
                             },
                         },
@@ -277,6 +288,16 @@ def project_row(datasette_server, pk):
     rows = project_rows(datasette_server, id=pk)
     assert len(rows) == 1
     return rows[0]
+
+
+def bulk_default_rows(datasette_server, **filters):
+    params = {
+        "_shape": "objects",
+        **{key: str(value) for key, value in filters.items()},
+    }
+    response = httpx.get(f"{datasette_server}data/bulk_defaults.json", params=params)
+    response.raise_for_status()
+    return response.json()["rows"]
 
 
 def open_jump_menu(page):
@@ -1007,7 +1028,8 @@ def test_insert_row_flow_uses_custom_column_field(page, datasette_server):
     assert "metadata" in preview_text
     assert "id" not in preview_text
     assert "From CSV" in preview_text
-    assert "null" in preview_text
+    assert "null" not in preview_text
+    assert "undefined" not in preview_text
     preview_cell_style = dialog.locator(
         ".row-edit-bulk-preview-table td"
     ).first.evaluate(
@@ -1098,6 +1120,38 @@ def test_bulk_insert_preview_inserts_rows(page, datasette_server):
 
 
 @pytest.mark.playwright
+def test_bulk_insert_omits_columns_absent_from_pasted_input(page, datasette_server):
+    page.goto(f"{datasette_server}data/bulk_defaults")
+    page.locator('button[data-table-action="insert-row"]').click()
+
+    dialog = page.locator("#row-edit-dialog")
+    dialog.wait_for()
+    dialog.locator(".row-edit-bulk-insert").click()
+    dialog.locator(".row-edit-bulk-textarea").fill("title\nOnly title")
+    dialog.locator(".row-edit-save").click()
+
+    assert dialog.locator(".row-edit-save").inner_text() == "Insert these rows"
+    preview_text = dialog.locator(".row-edit-bulk-preview-table").inner_text()
+    assert "Only title" in preview_text
+    assert "undefined" not in preview_text
+
+    dialog.locator(".row-edit-save").click()
+    dialog.locator(
+        ".row-edit-bulk-progress-status", has_text="1 row inserted."
+    ).wait_for()
+
+    rows = bulk_default_rows(datasette_server, title="Only title")
+    assert rows == [
+        {
+            "id": 1,
+            "title": "Only title",
+            "status": "todo",
+            "score": 5,
+        }
+    ]
+
+
+@pytest.mark.playwright
 def test_bulk_insert_preview_accepts_single_column_input(page, datasette_server):
     page.goto(f"{datasette_server}data/projects")
     page.locator('button[data-table-action="insert-row"]').click()
@@ -1116,7 +1170,8 @@ def test_bulk_insert_preview_accepts_single_column_input(page, datasette_server)
     assert "one" in preview_text
     assert "two" in preview_text
     assert "three" in preview_text
-    assert "null" in preview_text
+    assert "null" not in preview_text
+    assert "undefined" not in preview_text
 
 
 @pytest.mark.playwright

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -1329,6 +1329,7 @@ def test_bulk_insert_omits_columns_absent_from_pasted_input(page, datasette_serv
     preview_text = dialog.locator(".row-edit-bulk-preview-table").inner_text()
     assert "Only title" in preview_text
     assert "undefined" not in preview_text
+    assert dialog.locator(".row-edit-bulk-preview-auto").inner_text() == "auto"
 
     dialog.locator(".row-edit-save").click()
     dialog.locator(

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -108,6 +108,11 @@ def write_playwright_database(db_path):
             status text not null default 'todo',
             score integer default 5
         );
+        create table upsert_items (
+            id text primary key,
+            title text,
+            metadata text
+        );
         insert into projects (title, metadata, logo, notes, score) values
             (
                 'Build Datasette',
@@ -116,6 +121,8 @@ def write_playwright_database(db_path):
                 'Initial notes',
                 5
             );
+        insert into upsert_items (id, title, metadata) values
+            ('existing', 'Existing title', '{"old": true}');
         """)
     finally:
         conn.close()
@@ -155,6 +162,12 @@ def write_playwright_config(config_path):
                             "bulk_defaults": {
                                 "permissions": {
                                     "insert-row": True,
+                                },
+                            },
+                            "upsert_items": {
+                                "permissions": {
+                                    "insert-row": True,
+                                    "update-row": True,
                                 },
                             },
                         },
@@ -298,6 +311,31 @@ def bulk_default_rows(datasette_server, **filters):
     response = httpx.get(f"{datasette_server}data/bulk_defaults.json", params=params)
     response.raise_for_status()
     return response.json()["rows"]
+
+
+def upsert_item_rows(datasette_server, **filters):
+    params = {
+        "_shape": "objects",
+        **{key: str(value) for key, value in filters.items()},
+    }
+    response = httpx.get(f"{datasette_server}data/upsert_items.json", params=params)
+    response.raise_for_status()
+    return response.json()["rows"]
+
+
+def upsert_item_row(datasette_server, pk):
+    rows = upsert_item_rows(datasette_server, id=pk)
+    assert len(rows) == 1
+    return rows[0]
+
+
+def open_bulk_insert_dialog(page, url):
+    page.goto(url)
+    page.locator('button[data-table-action="insert-row"]').click()
+    dialog = page.locator("#row-edit-dialog")
+    dialog.wait_for()
+    dialog.locator(".row-edit-bulk-insert").click()
+    return dialog
 
 
 def open_jump_menu(page):
@@ -1164,6 +1202,116 @@ def test_bulk_insert_preview_inserts_rows(page, datasette_server):
 
     assert project_rows(datasette_server, title="Bulk one")
     assert project_rows(datasette_server, title="Bulk two")
+
+
+@pytest.mark.playwright
+def test_bulk_insert_upsert_option_updates_existing_and_inserts_new(
+    page, datasette_server
+):
+    dialog = open_bulk_insert_dialog(page, f"{datasette_server}data/upsert_items")
+    textarea = dialog.locator(".row-edit-bulk-textarea")
+    conflict_field = dialog.locator(".row-edit-bulk-conflict")
+    conflict_select = dialog.locator(".row-edit-bulk-conflict-mode")
+
+    assert conflict_field.is_hidden()
+    textarea.fill("title\nNo primary key")
+    assert conflict_field.is_hidden()
+
+    textarea.fill(
+        "id,title,metadata\nexisting,Updated by upsert,{}\nnew,Inserted by upsert,{}"
+    )
+    assert conflict_field.is_visible()
+    assert (
+        dialog.locator(".row-edit-bulk-conflict-label").inner_text()
+        == "If the row exists already"
+    )
+    assert conflict_select.input_value() == "ignore"
+    assert (
+        conflict_select.evaluate("""node => Array.from(node.options)
+        .filter((option) => !option.hidden)
+        .map((option) => option.textContent.trim())""")
+        == [
+            "Stop with an error",
+            "Skip existing rows",
+            "Update existing and insert new",
+        ]
+    )
+
+    conflict_select.select_option("upsert")
+    assert conflict_select.input_value() == "upsert"
+    dialog.locator(".row-edit-save").click()
+
+    assert dialog.locator(".row-edit-save").inner_text() == "Update or insert rows"
+    preview_text = dialog.locator(".row-edit-bulk-preview-table").inner_text()
+    assert "Updated by upsert" in preview_text
+    assert "Inserted by upsert" in preview_text
+
+    dialog.locator(".row-edit-save").click()
+    dialog.locator(
+        ".row-edit-bulk-progress-status", has_text="2 rows upserted."
+    ).wait_for()
+
+    assert upsert_item_row(datasette_server, "existing")["title"] == (
+        "Updated by upsert"
+    )
+    assert upsert_item_row(datasette_server, "new")["title"] == "Inserted by upsert"
+
+
+@pytest.mark.playwright
+def test_bulk_insert_conflicts_hide_upsert_without_update_permission(
+    page, datasette_server
+):
+    dialog = open_bulk_insert_dialog(page, f"{datasette_server}data/bulk_defaults")
+    textarea = dialog.locator(".row-edit-bulk-textarea")
+    conflict_field = dialog.locator(".row-edit-bulk-conflict")
+    conflict_select = dialog.locator(".row-edit-bulk-conflict-mode")
+
+    textarea.fill("title\nOnly title")
+    assert conflict_field.is_hidden()
+
+    textarea.fill("id,title\n1,Only title")
+    assert conflict_field.is_visible()
+    assert conflict_select.input_value() == "ignore"
+    assert (
+        conflict_select.evaluate("""node => Array.from(node.options)
+        .filter((option) => !option.hidden)
+        .map((option) => option.textContent.trim())""")
+        == [
+            "Stop with an error",
+            "Skip existing rows",
+        ]
+    )
+    assert conflict_select.locator('option[value="upsert"]').evaluate(
+        "node => node.hidden && node.disabled"
+    )
+
+
+@pytest.mark.playwright
+def test_bulk_insert_live_validation_reports_unknown_columns(page, datasette_server):
+    dialog = open_bulk_insert_dialog(page, f"{datasette_server}data/projects")
+    textarea = dialog.locator(".row-edit-bulk-textarea")
+    error = dialog.locator(".row-edit-error")
+    save = dialog.locator(".row-edit-save")
+
+    textarea.fill(json.dumps([{"id2": 1, "title": "Unknown column"}]))
+    error.wait_for()
+    assert error.inner_text() == "JSON row 1 has unknown column id2."
+    assert save.is_disabled()
+    assert textarea.evaluate("node => document.activeElement === node")
+
+    textarea.fill("id2,title\n1,Unknown column")
+    assert error.inner_text() == "Unknown column id2 in header row."
+    assert save.is_disabled()
+
+    textarea.fill("[")
+    assert error.is_hidden()
+    assert not save.is_disabled()
+
+    textarea.fill(json.dumps([{"id": 1, "title": "Known column"}]))
+    assert error.is_hidden()
+    assert not save.is_disabled()
+    assert dialog.locator(".row-edit-bulk-conflict").is_visible()
+    assert dialog.locator(".row-edit-bulk-conflict-mode").input_value() == "ignore"
 
 
 @pytest.mark.playwright

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -123,6 +123,7 @@ def write_playwright_config(config_path):
                     "data": {
                         "permissions": {
                             "create-table": True,
+                            "insert-row": True,
                             "set-column-type": True,
                         },
                         "tables": {
@@ -379,6 +380,78 @@ def test_create_table_flow(page, datasette_server):
     schema = schema_response.json()["rows"][0]["sql"]
     assert "title" in schema
     assert "NOT NULL DEFAULT 'Untitled'" in schema
+
+
+@pytest.mark.playwright
+def test_create_table_from_data_flow(page, datasette_server):
+    page.goto(f"{datasette_server}data")
+    page.locator("details.actions-menu-links summary").click()
+    page.locator('button[data-database-action="create-table"]').click()
+
+    dialog = page.locator("#table-create-dialog")
+    dialog.wait_for()
+    from_data = dialog.locator(".table-create-from-data")
+    assert from_data.inner_text() == "Create table from data"
+    from_data.click()
+
+    assert dialog.locator(".table-create-columns").is_hidden()
+    assert dialog.locator(".table-create-data").is_visible()
+    assert dialog.locator(".table-create-save").inner_text() == "Preview rows"
+    assert (
+        dialog.locator(".table-create-data-note").inner_text()
+        == "Paste TSV, CSV, or JSON. You can also drop a text file onto this textarea."
+    )
+    assert dialog.locator(".table-create-manual").inner_text() == (
+        "Create table manually"
+    )
+
+    dialog.locator(".table-create-table-name").fill("playwright_from_data")
+    textarea = dialog.locator(".table-create-data-textarea")
+    textarea.fill(
+        json.dumps(
+            {
+                "metadata": [{"short_id": "a", "name": "Ignored", "score": 9}],
+                "people": [
+                    {"short_id": "b", "name": "Ada", "score": 1},
+                    {"short_id": "c", "name": "Bob", "score": 2.5},
+                ],
+            }
+        )
+    )
+    dialog.locator(".table-create-save").click()
+
+    assert dialog.locator(".table-create-data-textarea").is_hidden()
+    assert dialog.locator(".table-create-save").inner_text() == "Create table"
+    assert dialog.locator(".table-create-cancel").inner_text() == "Back"
+    assert dialog.locator(".table-create-data-preview-summary").inner_text() == (
+        "Previewing 2 rows."
+    )
+    assert dialog.locator(".table-create-data-primary-key").input_value() == "short_id"
+    preview_text = dialog.locator(".table-create-data-preview-table").inner_text()
+    assert "short_id" in preview_text
+    assert "Ada" in preview_text
+    assert "2.5" in preview_text
+
+    dialog.locator(".table-create-cancel").click()
+    assert dialog.evaluate("node => node.open")
+    assert dialog.locator(".table-create-data-textarea").is_visible()
+    assert '"people"' in dialog.locator(".table-create-data-textarea").input_value()
+    assert dialog.locator(".table-create-save").inner_text() == "Preview rows"
+
+    dialog.locator(".table-create-save").click()
+    assert dialog.locator(".table-create-save").inner_text() == "Create table"
+    dialog.locator(".table-create-save").click()
+    page.wait_for_url("**/data/playwright_from_data")
+
+    response = httpx.get(
+        f"{datasette_server}data/playwright_from_data.json?_shape=objects"
+    )
+    response.raise_for_status()
+    data = response.json()
+    assert data["rows"] == [
+        {"short_id": "b", "name": "Ada", "score": 1},
+        {"short_id": "c", "name": "Bob", "score": 2.5},
+    ]
 
 
 @pytest.mark.playwright
@@ -910,7 +983,15 @@ def test_bulk_insert_preview_inserts_rows(page, datasette_server):
     dialog.wait_for()
     dialog.locator(".row-edit-bulk-insert").click()
     dialog.locator(".row-edit-bulk-textarea").fill(
-        "title\tmetadata\nBulk one\t{}\n\nBulk two\t{}"
+        json.dumps(
+            {
+                "metadata": [{"title": "Ignored", "metadata": "{}"}],
+                "projects": [
+                    {"title": "Bulk one", "metadata": "{}"},
+                    {"title": "Bulk two", "metadata": "{}"},
+                ],
+            }
+        )
     )
     dialog.locator(".row-edit-save").click()
     assert dialog.locator(".row-edit-save").inner_text() == "Insert these rows"

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -801,11 +801,77 @@ def test_navigation_search_renders_jump_sections_from_javascript_plugins(
 
 @pytest.mark.playwright
 def test_insert_row_flow_uses_custom_column_field(page, datasette_server):
+    page.context.grant_permissions(
+        ["clipboard-read", "clipboard-write"], origin=datasette_server.rstrip("/")
+    )
     page.goto(f"{datasette_server}data/projects")
     page.locator('button[data-table-action="insert-row"]').click()
 
     dialog = page.locator("#row-edit-dialog")
     dialog.wait_for()
+    bulk_insert = dialog.locator(".row-edit-bulk-insert")
+    bulk_insert.wait_for()
+    assert bulk_insert.inner_text() == "Insert multiple rows"
+    current_url = page.url
+    bulk_insert.click()
+    assert page.url == current_url
+    assert dialog.evaluate("node => node.open")
+    assert dialog.locator(".row-edit-fields").is_hidden()
+    assert dialog.locator(".row-edit-bulk").is_visible()
+    assert dialog.locator(".row-edit-save").inner_text() == "Preview rows"
+    assert (
+        dialog.locator(".row-edit-bulk-note").inner_text()
+        == "Paste TSV, CSV, or JSON. You can also drop a text file onto this textarea."
+    )
+    copy_template = dialog.locator(".row-edit-copy-template")
+    assert copy_template.inner_text() == "Copy spreadsheet template"
+    copy_template.click()
+    page.wait_for_function(
+        """() => document.querySelector(".row-edit-copy-template").textContent === "Copied" """
+    )
+    assert page.evaluate("navigator.clipboard.readText()") == (
+        "title\tmetadata\tlogo\tnotes\tscore"
+    )
+    textarea = dialog.locator(".row-edit-bulk-textarea")
+    textarea.fill("title\tmetadata\nFrom TSV\t{}")
+    assert textarea.input_value() == "title\tmetadata\nFrom TSV\t{}"
+    dropped_value = textarea.evaluate("""node => new Promise((resolve) => {
+            node.addEventListener("input", () => resolve(node.value), { once: true });
+            const file = new File(["\\n\\ntitle,metadata\\nFrom CSV,{}\\n,\\n  ,  \\n"], "rows.csv", { type: "text/csv" });
+            const dataTransfer = new DataTransfer();
+            dataTransfer.items.add(file);
+            node.dispatchEvent(new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer }));
+            node.dispatchEvent(new DragEvent("dragover", { bubbles: true, cancelable: true, dataTransfer }));
+            node.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer }));
+        })""")
+    assert dropped_value == "\n\ntitle,metadata\nFrom CSV,{}\n,\n  ,  \n"
+    dialog.locator(".row-edit-save").click()
+    assert dialog.evaluate("node => node.open")
+    assert dialog.locator(".row-edit-bulk-textarea").is_hidden()
+    assert dialog.locator(".row-edit-save").inner_text() == "Insert these rows"
+    assert dialog.locator(".row-edit-bulk-preview-summary").inner_text() == (
+        "Previewing 1 row."
+    )
+    preview_text = dialog.locator(".row-edit-bulk-preview-table").inner_text()
+    assert "title" in preview_text
+    assert "metadata" in preview_text
+    assert "id" not in preview_text
+    assert "From CSV" in preview_text
+    assert "null" in preview_text
+    assert dialog.locator(".row-edit-cancel").inner_text() == "Back"
+    dialog.locator(".row-edit-cancel").click()
+    assert dialog.evaluate("node => node.open")
+    assert dialog.locator(".row-edit-bulk-textarea").is_visible()
+    assert dialog.locator(".row-edit-bulk-textarea").input_value() == (
+        "\n\ntitle,metadata\nFrom CSV,{}\n,\n  ,  \n"
+    )
+    assert dialog.locator(".row-edit-save").inner_text() == "Preview rows"
+    single_insert = dialog.locator(".row-edit-single-insert")
+    assert single_insert.inner_text() == "Insert single row"
+    single_insert.click()
+    assert dialog.locator(".row-edit-bulk").is_hidden()
+    assert dialog.locator(".row-edit-fields").is_visible()
+    assert dialog.locator(".row-edit-save").inner_text() == "Insert row"
     dialog.locator('input[name="title"]').fill("Launch Datasette Cloud")
     dialog.locator('textarea[name="metadata"]').fill(
         '{"ok": false, "source": "playwright"}'
@@ -836,12 +902,63 @@ def test_insert_row_flow_uses_custom_column_field(page, datasette_server):
 
 
 @pytest.mark.playwright
+def test_bulk_insert_preview_inserts_rows(page, datasette_server):
+    page.goto(f"{datasette_server}data/projects")
+    page.locator('button[data-table-action="insert-row"]').click()
+
+    dialog = page.locator("#row-edit-dialog")
+    dialog.wait_for()
+    dialog.locator(".row-edit-bulk-insert").click()
+    dialog.locator(".row-edit-bulk-textarea").fill(
+        "title\tmetadata\nBulk one\t{}\n\nBulk two\t{}"
+    )
+    dialog.locator(".row-edit-save").click()
+    assert dialog.locator(".row-edit-save").inner_text() == "Insert these rows"
+    dialog.locator(".row-edit-save").click()
+    dialog.locator(
+        ".row-edit-bulk-progress-status", has_text="2 rows inserted."
+    ).wait_for()
+    assert dialog.locator(".row-edit-cancel").inner_text() == "Close and view table"
+    dialog.locator(".row-edit-cancel").click()
+    page.wait_for_load_state("domcontentloaded")
+    assert page.url == f"{datasette_server}data/projects"
+
+    assert project_rows(datasette_server, title="Bulk one")
+    assert project_rows(datasette_server, title="Bulk two")
+
+
+@pytest.mark.playwright
+def test_bulk_insert_preview_accepts_single_column_input(page, datasette_server):
+    page.goto(f"{datasette_server}data/projects")
+    page.locator('button[data-table-action="insert-row"]').click()
+
+    dialog = page.locator("#row-edit-dialog")
+    dialog.wait_for()
+    dialog.locator(".row-edit-bulk-insert").click()
+    dialog.locator(".row-edit-bulk-textarea").fill("title\none\ntwo\nthree")
+    dialog.locator(".row-edit-save").click()
+
+    assert dialog.locator(".row-edit-save").inner_text() == "Insert these rows"
+    assert dialog.locator(".row-edit-bulk-preview-summary").inner_text() == (
+        "Previewing 3 rows."
+    )
+    preview_text = dialog.locator(".row-edit-bulk-preview-table").inner_text()
+    assert "one" in preview_text
+    assert "two" in preview_text
+    assert "three" in preview_text
+    assert "null" in preview_text
+
+
+@pytest.mark.playwright
 def test_edit_row_flow_validates_json_and_saves_changes(page, datasette_server):
     page.goto(f"{datasette_server}data/projects")
     page.locator('tr[data-row="1"] button[data-row-action="edit"]').click()
 
     dialog = page.locator("#row-edit-dialog")
     dialog.wait_for()
+    assert dialog.locator(".row-edit-bulk-insert").is_hidden()
+    assert dialog.locator(".row-edit-single-insert").is_hidden()
+    assert dialog.locator(".row-edit-bulk").is_hidden()
     title = dialog.locator('input[name="title"]')
     title.wait_for()
     title.fill("Build Datasette, edited")

--- a/tests/test_table_html.py
+++ b/tests/test_table_html.py
@@ -1316,6 +1316,7 @@ async def test_table_insert_action_button_and_data():
         assert insert_data["path"] == "/data/items/-/insert"
         assert insert_data["tableName"] == "items"
         assert insert_data["primaryKeys"] == ["id"]
+        assert insert_data["maxInsertRows"] == 100
         assert [column["name"] for column in insert_data["columns"]] == [
             "name",
             "score",

--- a/tests/test_table_html.py
+++ b/tests/test_table_html.py
@@ -1027,6 +1027,7 @@ async def test_database_create_table_action_button_and_data():
                 "databaseName": "data",
                 "columnTypes": ["text", "integer", "float", "blob"],
                 "defaultExpressions": DEFAULT_EXPRESSION_OPTIONS,
+                "canInsertRows": False,
             },
         }
         assert "customColumnTypes" not in database_data_from_soup(soup)["createTable"]
@@ -1046,6 +1047,40 @@ async def test_database_create_table_action_button_and_data():
             "_datasetteDatabaseData" in (script.string or "")
             for script in soup_without_permission.find_all("script")
         )
+    finally:
+        ds.close()
+
+
+@pytest.mark.asyncio
+async def test_database_create_table_data_includes_insert_row_permission():
+    ds = Datasette(
+        [],
+        config={
+            "databases": {
+                "data": {
+                    "permissions": {
+                        "create-table": {"id": "root"},
+                        "insert-row": {"id": "root"},
+                    },
+                },
+            },
+        },
+    )
+    try:
+        db = ds.add_database(
+            Database(ds, memory_name="test_database_create_table_insert_permission"),
+            name="data",
+        )
+        await db.execute_write_script("""
+            create table items (id integer primary key, name text);
+            """)
+
+        response = await ds.client.get("/data", actor={"id": "root"})
+        assert response.status_code == 200
+        create_table_data = database_data_from_soup(Soup(response.text, "html.parser"))[
+            "createTable"
+        ]
+        assert create_table_data["canInsertRows"] is True
     finally:
         ds.close()
 


### PR DESCRIPTION
- Click "Insert multiple rows" from the insert dialog
- Paste in JSON or TSV or CSV - or drop on a file
- Preview table showing what will be inserted
- Rows get inserted via the JSON API
- If data includes primary keys and user has `update-rows` permission they can upsert instead
- Same UI is also available on create table, as "create table from rows", using existing API.

It's effectively https://github.com/datasette/datasette-import as a core feature.