### PR TITLE
[codex] Add Prettier check to lint recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -33,10 +33,11 @@ export DATASETTE_SECRET := "not_a_secret"
   uv run codespell datasette -S datasette/static --ignore-words docs/codespell-ignore-words.txt
   uv run codespell tests --ignore-words docs/codespell-ignore-words.txt
 
-# Run linters: black, ruff, cog
+# Run linters: black, ruff, prettier, cog
 @lint: codespell
   uv run black datasette tests --check
   uv run ruff check datasette tests
+  npm run prettier -- --check
   uv run cog --check README.md docs/*.rst
 
 # Apply ruff fixes


### PR DESCRIPTION
## Summary

Adds the existing npm Prettier check to the `lint` recipe so `just` verifies JavaScript formatting alongside codespell, Black, Ruff, and Cog.

## Impact

`just` now fails when files covered by the existing `npm run prettier` script are not formatted with Prettier. The existing `prettier` and `format` recipes remain responsible for applying formatting changes.

## Validation

- `just`

<!-- readthedocs-preview datasette start -->
----
📚 Documentation preview 📚: https://datasette--2821.org.readthedocs.build/en/2821/

<!-- readthedocs-preview datasette end -->