### PR TITLE
Ensure primary keys created via the JSON API are NOT NULL

### DIFF
--- a/datasette/views/table_create_alter.py
+++ b/datasette/views/table_create_alter.py
@@ -900,7 +900,22 @@ class TableCreateView(BaseView):
                     rows, pk=pks or pk, ignore=ignore, replace=replace, alter=alter
                 )
             else:
-                not_null = [column.name for column in columns if column.not_null]
+                # Force primary key columns NOT NULL so the API cannot create
+                # NULL primary keys, which SQLite otherwise allows and which
+                # leaves rows that cannot be viewed, edited or deleted (see
+                # #2807). A single integer primary key aliases the rowid and is
+                # never NULL, so it needs no explicit constraint.
+                pk_names = set(pks) if pks else ({pk} if pk else set())
+                if len(pk_names) == 1 and any(
+                    column.name in pk_names and column.type == "integer"
+                    for column in columns
+                ):
+                    pk_names = set()
+                not_null = [
+                    column.name
+                    for column in columns
+                    if column.not_null or column.name in pk_names
+                ]
                 defaults = {}
                 for column in columns:
                     if "default_expr" in column.model_fields_set:

--- a/datasette/views/table_create_alter.py
+++ b/datasette/views/table_create_alter.py
@@ -905,16 +905,21 @@ class TableCreateView(BaseView):
                 # leaves rows that cannot be viewed, edited or deleted (see
                 # #2807). A single integer primary key aliases the rowid and is
                 # never NULL, so it needs no explicit constraint.
-                pk_names = set(pks) if pks else ({pk} if pk else set())
+                # Matched case-insensitively because SQLite resolves identifiers
+                # that way: pk "code" against a column named "Code" still creates
+                # that column as the primary key.
+                pk_names = {
+                    name.lower() for name in (pks if pks else ([pk] if pk else []))
+                }
                 if len(pk_names) == 1 and any(
-                    column.name in pk_names and column.type == "integer"
+                    column.name.lower() in pk_names and column.type == "integer"
                     for column in columns
                 ):
                     pk_names = set()
                 not_null = [
                     column.name
                     for column in columns
-                    if column.not_null or column.name in pk_names
+                    if column.not_null or column.name.lower() in pk_names
                 ]
                 defaults = {}
                 for column in columns:

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -2297,6 +2297,63 @@ async def test_create_table_with_column_constraints(ds_write):
 
 
 @pytest.mark.asyncio
+async def test_create_table_primary_keys_are_not_null(ds_write):
+    # Primary keys created via the JSON API must be NOT NULL - see #2807
+    token = write_token(ds_write)
+    db = ds_write.get_database("data")
+
+    # Single (non-integer) primary key
+    response = await ds_write.client.post(
+        "/data/-/create",
+        json={
+            "table": "pk_single",
+            "columns": [
+                {"name": "code", "type": "text"},
+                {"name": "name", "type": "text"},
+            ],
+            "pk": "code",
+        },
+        headers=_headers(token),
+    )
+    assert response.status_code == 201, response.text
+    assert "PRIMARY KEY NOT NULL" in response.json()["schema"]
+    columns = {
+        column["name"]: column
+        for column in (
+            await db.execute("select * from pragma_table_info('pk_single')")
+        ).dicts()
+    }
+    assert columns["code"]["pk"] == 1
+    assert columns["code"]["notnull"] == 1
+    assert columns["name"]["notnull"] == 0
+
+    # Composite primary key - every key column is NOT NULL
+    response = await ds_write.client.post(
+        "/data/-/create",
+        json={
+            "table": "pk_composite",
+            "columns": [
+                {"name": "a", "type": "text"},
+                {"name": "b", "type": "text"},
+                {"name": "value", "type": "text"},
+            ],
+            "pks": ["a", "b"],
+        },
+        headers=_headers(token),
+    )
+    assert response.status_code == 201, response.text
+    columns = {
+        column["name"]: column
+        for column in (
+            await db.execute("select * from pragma_table_info('pk_composite')")
+        ).dicts()
+    }
+    assert columns["a"]["notnull"] == 1
+    assert columns["b"]["notnull"] == 1
+    assert columns["value"]["notnull"] == 0
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "default_expr,minimum_value,expected_schema",
     (

--- a/tests/test_api_write.py
+++ b/tests/test_api_write.py
@@ -2352,6 +2352,56 @@ async def test_create_table_primary_keys_are_not_null(ds_write):
     assert columns["b"]["notnull"] == 1
     assert columns["value"]["notnull"] == 0
 
+    # Primary key named with different casing from the column. SQLite resolves
+    # identifiers case-insensitively, so this still creates "Code" as the primary
+    # key and it must pick up NOT NULL too.
+    response = await ds_write.client.post(
+        "/data/-/create",
+        json={
+            "table": "pk_mixed_case",
+            "columns": [
+                {"name": "Code", "type": "text"},
+                {"name": "name", "type": "text"},
+            ],
+            "pk": "code",
+        },
+        headers=_headers(token),
+    )
+    assert response.status_code == 201, response.text
+    columns = {
+        column["name"]: column
+        for column in (
+            await db.execute("select * from pragma_table_info('pk_mixed_case')")
+        ).dicts()
+    }
+    assert columns["Code"]["pk"] == 1
+    assert columns["Code"]["notnull"] == 1
+    assert columns["name"]["notnull"] == 0
+
+    # The integer-rowid-alias exemption is matched case-insensitively too, so an
+    # integer pk stays a plain rowid alias rather than gaining a constraint.
+    response = await ds_write.client.post(
+        "/data/-/create",
+        json={
+            "table": "pk_mixed_case_integer",
+            "columns": [
+                {"name": "Id", "type": "integer"},
+                {"name": "name", "type": "text"},
+            ],
+            "pk": "id",
+        },
+        headers=_headers(token),
+    )
+    assert response.status_code == 201, response.text
+    columns = {
+        column["name"]: column
+        for column in (
+            await db.execute("select * from pragma_table_info('pk_mixed_case_integer')")
+        ).dicts()
+    }
+    assert columns["Id"]["pk"] == 1
+    assert columns["Id"]["notnull"] == 0
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What was broken

The table-create JSON API (`/db/-/create`) builds its own `CREATE TABLE` (the explicit-columns path in `TableCreateView.create_table`) without marking primary key columns `NOT NULL`. So a **text** or **composite** primary key is created nullable:

```json
POST /data/-/create
{"table": "t", "columns": [{"name": "code", "type": "text"}], "pk": "code"}
```
→ `CREATE TABLE "t" ("code" TEXT PRIMARY KEY, ...)` — `code` can be `NULL`.

## Why it matters

SQLite permits a `NULL` value in any primary key that isn't a single-column `INTEGER PRIMARY KEY` (and lets multiple rows share the `NULL` key). As #2805 shows, such rows can't be viewed, edited or deleted through Datasette — the row URL resolves to `None`/`""`. #2807 asks to "stem the bleeding" by disallowing null primary keys for tables created via the JSON API.

## What the fix does

In the explicit-columns create path — the one Simon described as "any time we run our own CREATE TABLE we set not null on any primary key we create" — primary key columns are added to the `not_null` set passed to `table.create()`. A single-column `INTEGER PRIMARY KEY` is skipped because it aliases the rowid and can never be `NULL`, so no redundant constraint is emitted (and the common `id` schema is unchanged).

Result: `"code" TEXT PRIMARY KEY NOT NULL`; composite keys get `NOT NULL` on every key column.

## What it deliberately does not change

- Single-column `INTEGER PRIMARY KEY` output is untouched (still `INTEGER PRIMARY KEY`), so existing schemas/tests/docs are unaffected.
- The `rows`/`insert_all` inference path is **not** changed here. That path can also create a nullable text pk, but because its column types are inferred rather than declared, the single-integer-pk (rowid) exception can't be applied reliably in the same way. Happy to follow up on that path if you'd like it covered too — hence `Refs #2807` rather than `Fixes`.
- No dependency, API-shape, or validation changes.

## Testing

- New `test_create_table_primary_keys_are_not_null` covers a single text pk and a composite pk (schema + `pragma_table_info` `notnull`), and asserts non-pk columns stay nullable.
- `tests/test_api_write.py` (148 passed), plus `tests/test_schema_endpoints.py` and `tests/test_api.py`, all green; `black --check` and `ruff check` clean.

Refs #2807

Developed with Claude Code; reviewed and tested by Pranav before marking ready for review.
