### PR TITLE
build(pyproject): drop unused setuptools runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "itsdangerous>=1.1",
     "sqlite-utils>=4.0",
     "asyncinject>=0.7",
-    "setuptools",
     "pip",
     "pydantic>=2",
 ]


### PR DESCRIPTION
setuptools became a dependency in commit 249fcf8e3e2a ("Add setuptools to dependencies") because app.py imported pkg_resources and Rye-managed virtualenvs do not ship setuptools. That import was replaced in commit 852f50148539 ("Switch from pkg_resources to importlib.metadata in app.py, refs #2057"), so nothing in Datasette has consumed the dependency since. pluggy's load_setuptools_entrypoints() reads entry points through importlib.metadata despite its name, and the publish/package Dockerfile templates never reference setuptools.

Discovered using `pyproject-udeps` [[1]].

[1]: https://github.com/lukehsiao/pyproject-udeps

Tested: in a fresh uv venv, which ships without setuptools:

    $ uv venv t && uv pip install --python t/bin/python .
    $ t/bin/python -c "import setuptools"
    ModuleNotFoundError: No module named 'setuptools'
    $ t/bin/datasette --version
    datasette, version 1.0a36
    $ t/bin/datasette plugins
    []
    $ t/bin/datasette --get /-/versions.json
    {"ok": true, ...}

Ref: https://github.com/simonw/datasette/issues/2065
Ref: https://github.com/simonw/datasette/issues/2057