### PR TITLE
/-/plugins.json is now an array of objects again

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -2575,7 +2575,7 @@ class Datasette:
             JsonDataView.as_view(
                 self,
                 "plugins.json",
-                lambda request: {"plugins": self._plugins(request)},
+                self._plugins,
                 needs_request=True,
             ),
             r"/-/plugins(\.(?P<format>json))?$",

--- a/docs/introspection.rst
+++ b/docs/introspection.rst
@@ -80,18 +80,15 @@ Shows a list of currently installed plugins and their versions. `Plugins example
 
 .. code-block:: json
 
-    {
-        "ok": true,
-        "plugins": [
-            {
-                "name": "datasette_cluster_map",
-                "static": true,
-                "templates": false,
-                "version": "0.10",
-                "hooks": ["extra_css_urls", "extra_js_urls", "extra_body_script"]
-            }
-        ]
-    }
+    [
+        {
+            "name": "datasette_cluster_map",
+            "static": true,
+            "templates": false,
+            "version": "0.10",
+            "hooks": ["extra_css_urls", "extra_js_urls", "extra_body_script"]
+        }
+    ]
 
 Add ``?all=1`` to include details of the default plugins baked into Datasette.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -614,13 +614,13 @@ async def test_plugins_json(ds_client):
     response = await ds_client.get("/-/plugins.json")
     # Filter out TrackEventPlugin
     actual_plugins = sorted(
-        [p for p in response.json()["plugins"] if p["name"] != "TrackEventPlugin"],
+        [p for p in response.json() if p["name"] != "TrackEventPlugin"],
         key=lambda p: p["name"],
     )
     assert EXPECTED_PLUGINS == actual_plugins
     # Try with ?all=1
     response = await ds_client.get("/-/plugins.json?all=1")
-    names = {p["name"] for p in response.json()["plugins"]}
+    names = {p["name"] for p in response.json()}
     assert names.issuperset(p["name"] for p in EXPECTED_PLUGINS)
     assert names.issuperset(DEFAULT_PLUGINS)
 

--- a/tests/test_config_dir.py
+++ b/tests/test_config_dir.py
@@ -109,7 +109,7 @@ def test_settings(config_dir_client):
 def test_plugins(config_dir_client):
     response = config_dir_client.get("/-/plugins.json")
     assert 200 == response.status
-    plugins = response.json["plugins"]
+    plugins = response.json
     assert "hooray.py" in {p["name"] for p in plugins}
     assert "non_py_file.txt" not in {p["name"] for p in plugins}
     assert "mypy_cache" not in {p["name"] for p in plugins}

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1482,7 +1482,7 @@ async def test_plugin_is_installed():
         datasette.pm.register(DummyPlugin(), name="DummyPlugin")
         response = await datasette.client.get("/-/plugins.json")
         assert response.status_code == 200
-        installed_plugins = {p["name"] for p in response.json()["plugins"]}
+        installed_plugins = {p["name"] for p in response.json()}
         assert "DummyPlugin" in installed_plugins
 
     finally:

--- a/tests/test_success_envelope.py
+++ b/tests/test_success_envelope.py
@@ -2,8 +2,8 @@
 Tests for the canonical JSON success envelope.
 
 Every JSON object returned by a Datasette endpoint on success should include
-"ok": true. (Endpoints that return a top-level array are being converted to
-objects separately - see /-/plugins, /-/databases, /-/actions.)
+"ok": true. /-/plugins intentionally returns a top-level array instead, while
+/-/databases and /-/actions use the object envelope.
 """
 
 import pytest
@@ -79,17 +79,16 @@ async def test_permissions_post_success_has_ok_true(ds_envelope):
 
 
 @pytest.mark.asyncio
-async def test_plugins_json_is_object(ds_client):
+async def test_plugins_json_is_array(ds_client):
     response = await ds_client.get("/-/plugins.json")
     assert response.status_code == 200
     data = response.json()
-    assert set(data.keys()) == {"ok", "plugins"}
-    assert data["ok"] is True
-    assert isinstance(data["plugins"], list)
+    assert isinstance(data, list)
+    assert all(isinstance(plugin, dict) for plugin in data)
     # ?all=1 should include Datasette's default plugins in the same shape
     response_all = await ds_client.get("/-/plugins.json?all=1")
-    all_plugins = response_all.json()["plugins"]
-    assert len(all_plugins) > len(data["plugins"])
+    all_plugins = response_all.json()
+    assert len(all_plugins) > len(data)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reverts the object envelope introduced in 1.0a36 for this endpoint -
it once again returns a top-level JSON array of plugin objects.

Closes #2842

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012TYc1NTBK4zEjabB3u2zqu