### PR TITLE
Escape table names with [square] brackets, refs #2431

### DIFF
--- a/datasette/database.py
+++ b/datasette/database.py
@@ -17,6 +17,7 @@ from .utils import (
     detect_fts,
     detect_primary_keys,
     detect_spatialite,
+    escape_sqlite,
     get_all_foreign_keys,
     get_outbound_foreign_keys,
     md5_not_usedforsecurity,
@@ -608,7 +609,7 @@ class Database:
             try:
                 table_count = (
                     await self.execute(
-                        f"select count(*) from (select * from [{table}] limit {self.count_limit + 1})",
+                        f"select count(*) from (select * from {escape_sqlite(table)} limit {self.count_limit + 1})",
                         custom_time_limit=limit,
                     )
                 ).rows[0][0]

--- a/datasette/facets.py
+++ b/datasette/facets.py
@@ -85,7 +85,7 @@ class Facet:
         self.database = database
         # For foreign key expansion. Can be None for e.g. stored SQL queries:
         self.table = table
-        self.sql = sql or f"select * from [{table}]"
+        self.sql = sql or f"select * from {escape_sqlite(table)}"
         self.params = params or []
         self.table_config = table_config
         # row_count can be None, in which case we calculate it ourselves:

--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -636,7 +636,7 @@ def detect_primary_keys(conn, table):
 
 
 def get_outbound_foreign_keys(conn, table):
-    infos = conn.execute(f"PRAGMA foreign_key_list([{table}])").fetchall()
+    infos = conn.execute(f"PRAGMA foreign_key_list({escape_sqlite(table)})").fetchall()
     fks = []
     for info in infos:
         if info is not None:

--- a/datasette/utils/internal_db.py
+++ b/datasette/utils/internal_db.py
@@ -3,7 +3,7 @@ import textwrap
 from sqlite_utils import Database as SQLiteUtilsDatabase
 from sqlite_utils import Migrations
 
-from datasette.utils import table_column_details
+from datasette.utils import escape_sqlite, table_column_details
 
 INTERNAL_DB_SCHEMA_TABLES = {
     "catalog_databases",
@@ -233,7 +233,7 @@ async def populate_schema_tables(internal_db, db):
                 for column in columns
             )
             foreign_keys = conn.execute(
-                f"PRAGMA foreign_key_list([{table_name}])"
+                f"PRAGMA foreign_key_list({escape_sqlite(table_name)})"
             ).fetchall()
             foreign_keys_to_insert.extend(
                 {
@@ -242,7 +242,9 @@ async def populate_schema_tables(internal_db, db):
                 }
                 for foreign_key in foreign_keys
             )
-            indexes = conn.execute(f"PRAGMA index_list([{table_name}])").fetchall()
+            indexes = conn.execute(
+                f"PRAGMA index_list({escape_sqlite(table_name)})"
+            ).fetchall()
             indexes_to_insert.extend(
                 {
                     **{"database_name": database_name, "table_name": table_name},

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 from datasette.app import Datasette
 from datasette.plugins import DEFAULT_PLUGINS
-from datasette.utils import UNSTABLE_API_MESSAGE
+from datasette.utils import UNSTABLE_API_MESSAGE, escape_sqlite, tilde_encode
 from datasette.utils.sqlite import sqlite_version
 from datasette.version import __version__
 from .fixtures import make_app_client, EXPECTED_PLUGINS
@@ -928,6 +928,37 @@ async def test_tilde_encoded_database_names(db_name):
     # And the JSON for that database
     response2 = await ds.client.get(path + ".json")
     assert response2.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("table_name", ("[foo]", "foo]", "[foo]/bar"))
+async def test_table_with_reserved_characters_in_name(table_name):
+    # Table names containing characters such as "]" that cannot be escaped
+    # using SQLite [bracket] quoting used to break schema introspection and
+    # the table page - https://github.com/simonw/datasette/issues/2431
+    ds = Datasette()
+    db = ds.add_memory_database("test_reserved_table_names")
+    await db.execute_write(
+        "create table {} (id integer primary key, name text)".format(
+            escape_sqlite(table_name)
+        )
+    )
+    await db.execute_write(
+        "insert into {} (id, name) values (1, 'one')".format(escape_sqlite(table_name))
+    )
+    # Schema introspection (populate_schema_tables) must not crash:
+    db_response = await ds.client.get("/test_reserved_table_names.json")
+    assert db_response.status_code == 200
+    tables = {t["name"]: t for t in db_response.json()["tables"]}
+    assert tables[table_name]["count"] == 1
+    # And the table page itself must load and return the row:
+    table_response = await ds.client.get(
+        "/test_reserved_table_names/{}.json?_shape=array".format(
+            tilde_encode(table_name)
+        )
+    )
+    assert table_response.status_code == 200
+    assert table_response.json() == [{"id": 1, "name": "one"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes the still-reproducible part of #2431. A table whose name contains `]` (e.g. `[foo]` or `foo]`) currently crashes Datasette: several helpers quote the table name with SQLite `[bracket]` identifiers built from an f-string, and bracket quoting can't escape a `]`, giving `sqlite3.OperationalError: unrecognized token: "]"`. In practice this crashes schema introspection at startup (`internal_db.populate_schema_tables`) and 500s the table page.

These call sites now use the existing `escape_sqlite()` helper (`"double quote"` quoting with `""` escaping) — the same approach used elsewhere in the codebase and already used by `tests/test_internal_db.py` for these very PRAGMAs. Sites changed: `internal_db` `foreign_key_list`/`index_list` PRAGMAs, `get_outbound_foreign_keys`, `Database.table_counts` count query, and the default facet `select * from`.

Added a regression test (`test_table_with_reserved_characters_in_name`) parametrized over `[foo]`, `foo]`, `[foo]/bar` that asserts introspection and the table page both work.

Out of scope (happy to follow up): the `arraycontains` filter templates and the FTS-detection `LIKE` pattern.

AI-assisted (Claude), reviewed and verified locally by me — the affected test areas pass (test_api, internal_db, facets, table_api, internals_database) and Black is clean.
