### PR TITLE
Make catalog refresh atomic

### DIFF
--- a/datasette/app.py
+++ b/datasette/app.py
@@ -753,19 +753,7 @@ class Datasette:
             # Compare schema versions to see if we should skip it
             if schema_version == current_schema_versions.get(database_name):
                 continue
-            placeholders = "(?, ?, ?, ?)"
-            values = [database_name, str(db.path), db.is_memory, schema_version]
-            if db.path is None:
-                placeholders = "(?, null, ?, ?)"
-                values = [database_name, db.is_memory, schema_version]
-            await internal_db.execute_write(
-                """
-                INSERT OR REPLACE INTO catalog_databases (database_name, path, is_memory, schema_version)
-                VALUES {}
-            """.format(placeholders),
-                values,
-            )
-            await populate_schema_tables(internal_db, db)
+            await populate_schema_tables(internal_db, db, schema_version)
 
     @property
     def urls(self):

--- a/datasette/utils/internal_db.py
+++ b/datasette/utils/internal_db.py
@@ -180,28 +180,8 @@ async def init_internal_db(db):
     await db.execute_write_fn(apply_migrations, transaction=False)
 
 
-async def populate_schema_tables(internal_db, db):
+async def populate_schema_tables(internal_db, db, schema_version):
     database_name = db.name
-
-    def delete_everything(conn):
-        conn.execute(
-            "DELETE FROM catalog_tables WHERE database_name = ?", [database_name]
-        )
-        conn.execute(
-            "DELETE FROM catalog_views WHERE database_name = ?", [database_name]
-        )
-        conn.execute(
-            "DELETE FROM catalog_columns WHERE database_name = ?", [database_name]
-        )
-        conn.execute(
-            "DELETE FROM catalog_foreign_keys WHERE database_name = ?",
-            [database_name],
-        )
-        conn.execute(
-            "DELETE FROM catalog_indexes WHERE database_name = ?", [database_name]
-        )
-
-    await internal_db.execute_write_fn(delete_everything)
 
     tables = (await db.execute("select * from sqlite_master WHERE type = 'table'")).rows
     views = (await db.execute("select * from sqlite_master WHERE type = 'view'")).rows
@@ -266,47 +246,76 @@ async def populate_schema_tables(internal_db, db):
         indexes_to_insert,
     ) = await db.execute_fn(collect_info)
 
-    await internal_db.execute_write_many(
-        """
-        INSERT INTO catalog_tables (database_name, table_name, rootpage, sql)
-        values (?, ?, ?, ?)
-    """,
-        tables_to_insert,
-    )
-    await internal_db.execute_write_many(
-        """
-        INSERT INTO catalog_views (database_name, view_name, rootpage, sql)
-        values (?, ?, ?, ?)
-    """,
-        views_to_insert,
-    )
-    await internal_db.execute_write_many(
-        """
-        INSERT INTO catalog_columns (
-            database_name, table_name, cid, name, type, "notnull", default_value, is_pk, hidden
-        ) VALUES (
-            :database_name, :table_name, :cid, :name, :type, :notnull, :default_value, :is_pk, :hidden
+    def replace_catalog(conn):
+        # Delete child rows before their catalog_tables parents so this also
+        # works if a prepare_connection plugin enables foreign key enforcement.
+        for table in (
+            "catalog_columns",
+            "catalog_foreign_keys",
+            "catalog_indexes",
+            "catalog_views",
+            "catalog_tables",
+        ):
+            conn.execute(
+                "DELETE FROM {} WHERE database_name = ?".format(table),
+                [database_name],
+            )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO catalog_databases (
+                database_name, path, is_memory, schema_version
+            ) VALUES (?, ?, ?, ?)
+            """,
+            [
+                database_name,
+                str(db.path) if db.path is not None else None,
+                db.is_memory,
+                schema_version,
+            ],
         )
-    """,
-        columns_to_insert,
-    )
-    await internal_db.execute_write_many(
-        """
-        INSERT INTO catalog_foreign_keys (
-            database_name, table_name, "id", seq, "table", "from", "to", on_update, on_delete, match
-        ) VALUES (
-            :database_name, :table_name, :id, :seq, :table, :from, :to, :on_update, :on_delete, :match
+        conn.executemany(
+            """
+            INSERT INTO catalog_tables (database_name, table_name, rootpage, sql)
+            values (?, ?, ?, ?)
+            """,
+            tables_to_insert,
         )
-    """,
-        foreign_keys_to_insert,
-    )
-    await internal_db.execute_write_many(
-        """
-        INSERT INTO catalog_indexes (
-            database_name, table_name, seq, name, "unique", origin, partial
-        ) VALUES (
-            :database_name, :table_name, :seq, :name, :unique, :origin, :partial
+        conn.executemany(
+            """
+            INSERT INTO catalog_views (database_name, view_name, rootpage, sql)
+            values (?, ?, ?, ?)
+            """,
+            views_to_insert,
         )
-    """,
-        indexes_to_insert,
-    )
+        conn.executemany(
+            """
+            INSERT INTO catalog_columns (
+                database_name, table_name, cid, name, type, "notnull", default_value, is_pk, hidden
+            ) VALUES (
+                :database_name, :table_name, :cid, :name, :type, :notnull, :default_value, :is_pk, :hidden
+            )
+            """,
+            columns_to_insert,
+        )
+        conn.executemany(
+            """
+            INSERT INTO catalog_foreign_keys (
+                database_name, table_name, "id", seq, "table", "from", "to", on_update, on_delete, match
+            ) VALUES (
+                :database_name, :table_name, :id, :seq, :table, :from, :to, :on_update, :on_delete, :match
+            )
+            """,
+            foreign_keys_to_insert,
+        )
+        conn.executemany(
+            """
+            INSERT INTO catalog_indexes (
+                database_name, table_name, seq, name, "unique", origin, partial
+            ) VALUES (
+                :database_name, :table_name, :seq, :name, :unique, :origin, :partial
+            )
+            """,
+            indexes_to_insert,
+        )
+
+    await internal_db.execute_write_fn(replace_catalog)


### PR DESCRIPTION
Refs:
- #2831

## Summary

- collect all schema metadata before mutating the internal catalog
- update `catalog_databases` and replace the five child catalog tables in one `execute_write_fn()` transaction
- delete child rows before parent rows so the operation remains valid if a `prepare_connection` plugin enables foreign-key enforcement

## Why

The previous refresh committed the `catalog_databases` update, catalog deletion, and five insertion batches separately. Readers could observe an updated schema version with empty or partially rebuilt catalog tables, and each refresh paid for seven transactions.

The new flow prepares the replacement rows first and then applies the complete per-database catalog update atomically. A failure restores the previous catalog through the outer transaction.

This implements the atomic catalog refresh recommendation from the [Datasette transaction report](https://gist.github.com/simonw/539ef461154ee0f5938f060a8475532d).

## Performance

A local microbenchmark used Python 3.14.3, a persistent internal database, repeated schema changes, and generated schemas; setup and schema mutation were excluded from timing.

| Tables | Baseline mean | New mean | Improvement |
| ---: | ---: | ---: | ---: |
| 150 | 7.96 ms | 5.68 ms | 28.7% |
| 300 | 12.80 ms | 10.02 ms | 21.7% |

For 300 tables, median improved 15.3% and p95 improved 41.9%. Measured transactions per refresh fell from seven to one.

## Validation

- `uv run pytest -q` — 2,294 passed, 40 skipped, 6 xfailed, 15 xpassed, 141 subtests passed
- `uv run pytest -q tests/test_internal_db.py` — 11 passed
- `uv run black --check datasette/app.py datasette/utils/internal_db.py tests/test_internal_db.py`
- `uv run ruff check datasette/app.py datasette/utils/internal_db.py tests/test_internal_db.py`
- `git diff --check`