### PR TITLE
Escape identifiers in arraycontains/arraynotcontains filters (refs #2431)

### DIFF
--- a/datasette/filters.py
+++ b/datasette/filters.py
@@ -209,7 +209,16 @@ class TemplatedFilter(Filter):
             kwargs = {"c": column}
             converted = None
         else:
-            kwargs = {"c": column, "p": f"p{param_counter}", "t": table}
+            kwargs = {
+                "c": column,
+                "p": f"p{param_counter}",
+                "t": table,
+                # Properly quoted identifiers for templates that reference the
+                # table/column directly (e.g. json_each()). Bracket quoting
+                # cannot escape a "]" in a name, so use escape_sqlite() instead.
+                "c_escaped": escape_sqlite(column),
+                "t_escaped": escape_sqlite(table) if table is not None else "",
+            }
         return self.sql_template.format(**kwargs), converted
 
     def human_clause(self, column, value):
@@ -322,13 +331,13 @@ class Filters:
                 TemplatedFilter(
                     "arraycontains",
                     "array contains",
-                    """:{p} in (select value from json_each([{t}].[{c}]))""",
+                    """:{p} in (select value from json_each({t_escaped}.{c_escaped}))""",
                     '{c} contains "{v}"',
                 ),
                 TemplatedFilter(
                     "arraynotcontains",
                     "array does not contain",
-                    """:{p} not in (select value from json_each([{t}].[{c}]))""",
+                    """:{p} not in (select value from json_each({t_escaped}.{c_escaped}))""",
                     '{c} does not contain "{v}"',
                 ),
             ]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -65,12 +65,24 @@ import pytest
         # JSON arraycontains, arraynotcontains
         (
             (("Availability+Info__arraycontains", "yes"),),
-            [":p0 in (select value from json_each([table].[Availability+Info]))"],
+            [':p0 in (select value from json_each("table"."Availability+Info"))'],
             ["yes"],
         ),
         (
             (("Availability+Info__arraynotcontains", "yes"),),
-            [":p0 not in (select value from json_each([table].[Availability+Info]))"],
+            [':p0 not in (select value from json_each("table"."Availability+Info"))'],
+            ["yes"],
+        ),
+        # A column name containing "]" must be escaped with escape_sqlite() -
+        # bracket quoting would produce invalid SQL, see refs #2431
+        (
+            (("ta]gs__arraycontains", "yes"),),
+            [':p0 in (select value from json_each("table"."ta]gs"))'],
+            ["yes"],
+        ),
+        (
+            (("ta]gs__arraynotcontains", "yes"),),
+            [':p0 not in (select value from json_each("table"."ta]gs"))'],
             ["yes"],
         ),
     ],


### PR DESCRIPTION
The `arraycontains` / `arraynotcontains` filters build their SQL with literal bracket quoting:

```python
":{p} in (select value from json_each([{t}].[{c}]))"
```

Bracket quoting can't escape a `]` inside an identifier, so filtering a JSON-array column whose table or column name contains `]` produces malformed SQL and fails, even though the table page itself loads fine:

```
GET /data/normal.json?ta%5Dgs__arraycontains=x
-> 400  near "gs": syntax error
   (generated SQL: ... json_each([normal].[ta]gs]) ...)
```

### Fix

Use `escape_sqlite()` (already imported) for the table and column identifiers — the same approach #2846 used for the array **facet** SQL, which fixed this bug class for facets but left the array **filters** untouched. After the fix the generated SQL is `... json_each("normal"."ta]gs") ...` and the filter returns the correct rows.

Refs #2431.

### Tests

Updated the two exact-SQL assertions in `tests/test_filters.py` to the escaped form and added `]`-in-name regression cases. `pytest tests/test_filters.py tests/test_facets.py tests/test_table_api.py` passes; `black`/`ruff` clean.

### Related follow-ups (not in this PR)

Other literal `[{...}]` identifier-quoting sites remain (per #2431): `app.py` `ATTACH DATABASE`, and a few in `views/table.py` (label/autocomplete, drop-table confirm, keyset-pagination fallback). Happy to follow up on those separately if you'd like.
