### PR TITLE
Document to_css_class as a supported internal

### DIFF
--- a/datasette/utils/__init__.py
+++ b/datasette/utils/__init__.py
@@ -830,6 +830,7 @@ css_class_re = re.compile(r"^[a-zA-Z]+[_a-zA-Z0-9-]*$")
 css_invalid_chars_re = re.compile(r"[^a-zA-Z0-9_\-]")
 
 
+@documented
 def to_css_class(s):
     """
     Given a string (e.g. a table name) returns a valid unique CSS class.

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -2531,6 +2531,19 @@ Derive the list of ``:named`` parameters referenced in a SQL query.
 
 .. autofunction:: datasette.utils.named_parameters
 
+.. _internals_utils_to_css_class:
+
+to_css_class(value)
+-------------------
+
+Returns a string that can be used as a unique CSS class.
+
+Strings that already start with a letter and contain only letters, numbers, underscores or hyphens are returned unchanged. Other strings are normalized in this order: leading underscores are removed, then leading hyphens are removed, whitespace is replaced with hyphens and any remaining invalid characters are discarded. A six-character hash is appended to normalized values to avoid collisions.
+
+For example, ``to_css_class("MixedCase")`` returns ``"MixedCase"``, while ``to_css_class("no spaces")`` returns ``"no-spaces-7088d7"``.
+
+.. autofunction:: datasette.utils.to_css_class
+
 .. _internals_tilde_encoding:
 
 Tilde encoding


### PR DESCRIPTION
## What

Document `datasette.utils.to_css_class()` as a supported internal utility and register it with Datasette's `@documented` safeguard.

## Why

Plugins already use this helper, but it was absent from the documented internals. That left its support status unclear and meant the documentation registry could not protect its API section from accidental removal.

Fixes #1743

## Details

- describes unchanged inputs, ordered normalization, and collision-resistant suffixes
- includes examples matching the existing behavior tests
- uses the standard `internals_utils_to_css_class` anchor and decorator registration

## Testing

- `uv run pytest -n auto -m 'not serial'` (2269 passed, 40 skipped, 6 xfailed, 15 xpassed)
- `uv run pytest -m serial` (36 passed)
- `uv run pytest tests/test_docs.py::test_functions_marked_with_documented_are_documented`
- `uv run pytest tests/test_utils.py -k to_css_class`
- warning-as-error Sphinx build
- Cog, blacken-docs, codespell, Black, and `git diff --check`
