### PR TITLE
Exclude unsortable primary key from the sort menu

### DIFF
--- a/datasette/views/table.py
+++ b/datasette/views/table.py
@@ -901,7 +901,7 @@ async def display_columns_and_rows(
             columns = [col for col in columns if col["name"] != pks[0]]
             first_column = {
                 "name": pks[0],
-                "sortable": len(pks) == 1,
+                "sortable": pks[0] in sortable_columns,
                 "is_pk": True,
                 "type": column_details[pks[0]].type,
                 "notnull": column_details[pks[0]].notnull,

--- a/tests/test_table_html.py
+++ b/tests/test_table_html.py
@@ -398,6 +398,37 @@ async def test_sort_links(ds_client):
 
 
 @pytest.mark.asyncio
+async def test_sort_menu_excludes_unsortable_primary_key():
+    # https://github.com/simonw/datasette/issues/1980
+    ds = Datasette(
+        [],
+        metadata={
+            "databases": {
+                "data": {"tables": {"timezones": {"sortable_columns": ["tzid"]}}}
+            }
+        },
+    )
+    try:
+        db = ds.add_database(
+            Database(ds, memory_name="test_sort_menu_unsortable_pk"), name="data"
+        )
+        await db.execute_write_script("""
+            create table timezones (
+                id integer primary key,
+                tzid text
+            );
+            insert into timezones (id, tzid) values (133, 'Europe/London');
+        """)
+        response = await ds.client.get("/data/timezones")
+        assert response.status_code == 200
+        select = Soup(response.text, "html.parser").find("select", {"name": "_sort"})
+        options = [option["value"] for option in select.find_all("option")]
+        assert options == ["", "tzid"]
+    finally:
+        ds.close()
+
+
+@pytest.mark.asyncio
 async def test_facet_display(ds_client):
     response = await ds_client.get(
         "/fixtures/facetable?_facet=planet_int&_facet=_city_id&_facet=on_earth"


### PR DESCRIPTION
Closes #1980

When a table sets `sortable_columns` without the primary key, the sort dropdown still listed it, so picking it returned "Cannot sort table by id". `display_columns_and_rows()` rebuilds the pk as the leading link column and hardcoded `"sortable": len(pks) == 1` instead of checking `sortable_columns`; it now checks it like every other column.

New test in `tests/test_table_html.py` fails without the change and passes with it.