### PR TITLE
Give each non-blocking write a distinct task id

### DIFF
--- a/datasette/database.py
+++ b/datasette/database.py
@@ -354,6 +354,15 @@ class Database:
                     result = fn(self._write_connection)
             else:
                 result = fn(self._write_connection)
+            if not block:
+                # There is no write thread here, so the write has already
+                # finished. Hand back the same (task_id, reply_future) shape
+                # _send_to_write_thread() returns, with the future already
+                # resolved, so the block=False path below is identical in
+                # both modes.
+                reply_future = asyncio.get_running_loop().create_future()
+                reply_future.set_result(result)
+                result = (uuid.uuid4(), reply_future)
         else:
             result = await self._send_to_write_thread(
                 fn, block=block, transaction=transaction
@@ -425,7 +434,7 @@ class Database:
             )
             self._write_thread.name = f"_execute_writes for database {self.name}"
             self._write_thread.start()
-        task_id = uuid.uuid5(uuid.NAMESPACE_DNS, "datasette.io")
+        task_id = uuid.uuid4()
         loop = asyncio.get_running_loop()
         reply_future = loop.create_future()
         self._write_queue.put(

--- a/tests/test_internals_database.py
+++ b/tests/test_internals_database.py
@@ -706,6 +706,33 @@ async def test_execute_write_fn_block_false(db):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("disable_threads", (False, True))
+async def test_execute_write_fn_block_false_returns_uuid(tmp_path, disable_threads):
+    # block=False is documented to return "a UUID representing the queued task".
+    # With num_sql_threads=0 there is no write thread, so the non-threaded branch
+    # has to satisfy the same contract as the threaded one.
+    settings = {"num_sql_threads": 0} if disable_threads else {}
+    ds = Datasette([], memory=True, settings=settings)
+    await ds.invoke_startup()
+    db = ds.add_memory_database("test_block_false")
+    await db.execute_write(
+        "create table if not exists t (id integer primary key, v text)"
+    )
+
+    def write_fn(conn):
+        conn.execute("insert into t (v) values ('a')")
+        # Returns None, like most write functions.
+
+    task_id = await db.execute_write_fn(write_fn, block=False)
+
+    assert isinstance(task_id, uuid.UUID)
+    # Distinct per call, so a caller can tell two queued tasks apart.
+    second = await db.execute_write_fn(write_fn, block=False)
+    assert isinstance(second, uuid.UUID)
+    assert second != task_id
+
+
+@pytest.mark.asyncio
 async def test_execute_write_fn_block_true(db):
     def write_fn(conn):
         conn.execute("delete from roadside_attractions where pk = 1;")


### PR DESCRIPTION
Fixes two problems with `execute_write_fn(fn, block=False)`, both in the same method. Fixes #2859. Fixes #2860.

The docs describe the return value as:

> A UUID representing the queued task will be returned.

### #2860: the id was a constant

`_send_to_write_thread()` derived it from `uuid.uuid5(uuid.NAMESPACE_DNS, "datasette.io")`. `uuid5` is deterministic, so every non-blocking write in every database in every process returned `3f143baa-4e3d-5842-a36f-4fa2f683b72f`. A constant cannot identify a particular task, so a caller could not tell two queued writes apart.

Introduced in 4284c74bc133ab494bf4b6dcd4a20b97b05ebb83 (#2220, 2023-12-19), shipped since `1.0a10`.

### #2859: TypeError with `num_sql_threads=0`

With no write thread, `execute_write_fn` takes the synchronous branch, so `result` is the write function's return value, normally `None`. The `block=False` path then unpacked it unconditionally:

```python
task_id, reply_future = result
```

which raised `TypeError: cannot unpack non-iterable NoneType object`. Only `_send_to_write_thread` returns that pair.

The non-threaded branch now hands back the same `(task_id, reply_future)` shape with the future already resolved, since the write has already finished. Both modes share one code path from there, so the event-dispatch logic below is unchanged and does not need a mode check.

### Why the existing test did not catch either

`test_execute_write_fn_block_false` asserted only `isinstance(task_id, uuid.UUID)`. A constant satisfies that, and the test never ran in non-threaded mode.

The new test is parametrized over threaded and non-threaded, and asserts two calls return **different** ids. It fails on `main` in both modes: `AssertionError` for the constant, `TypeError` for the unpack.

### Scope

- Writes themselves were always correct. `WriteTask.task_id` is not used for dispatch, so nothing was misrouted and no data was lost.
- I found no in-core consumer of the returned id, so I am not claiming a user-facing break in shipped Datasette. The impact is on the documented plugin API.
- Exception behaviour is unchanged. In non-threaded mode a raising `fn` still propagates before the return path is reached, which differs from the threaded "silently swallowed" wording in the docs. That felt like a separate question, so I left it alone rather than widen this PR.

### Verification

- `pytest tests/test_internals_database.py tests/test_write_wrapper.py tests/test_api_write.py` → **244 passed, 2 xpassed**
- `black --check` and `ruff check` clean on both changed files
- One `PermissionError: [WinError 32]` tempdir teardown error appears in `test_api_write.py` on my Windows machine. It reproduces on an unmodified checkout, so it is unrelated to this change.

Happy to split this into two PRs if you would rather review them separately, or to change the fix shape for #2859. I picked the option that keeps one code path rather than branching on `executor is None` twice.

---

*Disclosure: I used an AI coding assistant on this work. The reproductions, the test, and the verification runs above were executed and confirmed by me.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


