### PR TITLE
Mention that filters_from_request can return an async function

### DIFF
--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -1419,6 +1419,8 @@ The arguments to the ``FilterArguments`` class constructor are as follows:
 ``extra_context`` - dictionary, optional
     Additional context variables that should be made available to the ``table.html`` template when it is rendered.
 
+The hook can also return an ``async def`` function, which Datasette will await. This is useful if you need to execute SQL queries or perform other asynchronous operations in order to build your filters. Datasette's own default implementations of this hook `use this pattern <https://github.com/simonw/datasette/blob/main/datasette/filters.py>`__.
+
 This example plugin causes 0 results to be returned if ``?_nothing=1`` is added to the URL:
 
 .. code-block:: python

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -59,6 +59,13 @@ def test_plugin_hooks_are_documented(plugin_hooks_content, subtests):
             ), f"Missing from plugin hook documentation: {expected}"
 
 
+def test_filters_from_request_async_function_documented(plugin_hooks_content):
+    section = plugin_hooks_content.split(".. _plugin_hook_filters_from_request:")[
+        -1
+    ].split(".. _plugin_hook_")[0]
+    assert "async def" in section
+
+
 @pytest.fixture(scope="session")
 def documented_views():
     view_labels = set()


### PR DESCRIPTION
Closes:
- #1638

The `filters_from_request` hook can return an `async def` function (Datasette calls it and awaits the result via `await_me_maybe`), so you can run SQL or other async work while building your filters. The docs didn't mention this, so I added a short note to the `filters_from_request` section pointing it out and linking to the default implementations in `datasette/filters.py`.

Also added a small `test_docs.py` check that the documented section mentions `async def`; it fails without the doc change and passes with it.