### PR TITLE
Show the dismiss X for facets applied as ?column__exact=value

### DIFF
--- a/datasette/facets.py
+++ b/datasette/facets.py
@@ -264,6 +264,10 @@ class ColumnFacet(Facet):
                     column_qs = column
                     if column.startswith("_"):
                         column_qs = f"{column}__exact"
+                    # ?column=x and ?column__exact=x are equivalent filters,
+                    # so check for both, https://github.com/simonw/datasette/issues/2011
+                    if (f"{column}__exact", str(row["value"])) in qs_pairs:
+                        column_qs = f"{column}__exact"
                     selected = (column_qs, str(row["value"])) in qs_pairs
                     if selected:
                         toggle_path = path_with_removed_args(

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -152,6 +152,54 @@ async def test_column_facet_results(ds_client):
 
 
 @pytest.mark.asyncio
+async def test_column_facet_results_selected_by_exact_filter(ds_client):
+    # The filter form produces ?column__exact=x rather than ?column=x -
+    # both should mark the matching facet value as selected
+    # https://github.com/simonw/datasette/issues/2011
+    facet = ColumnFacet(
+        ds_client.ds,
+        Request.fake("/?_facet=state&state__exact=MI"),
+        database="fixtures",
+        sql="select * from facetable",
+        table="facetable",
+    )
+    buckets, timed_out = await facet.facet_results()
+    assert [] == timed_out
+    assert buckets == [
+        {
+            "name": "state",
+            "type": "column",
+            "hideable": True,
+            "toggle_url": "/?state__exact=MI",
+            "results": [
+                {
+                    "value": "CA",
+                    "label": "CA",
+                    "count": 10,
+                    "toggle_url": "http://localhost/?_facet=state&state__exact=MI&state=CA",
+                    "selected": False,
+                },
+                {
+                    "value": "MI",
+                    "label": "MI",
+                    "count": 4,
+                    "toggle_url": "http://localhost/?_facet=state",
+                    "selected": True,
+                },
+                {
+                    "value": "MC",
+                    "label": "MC",
+                    "count": 1,
+                    "toggle_url": "http://localhost/?_facet=state&state__exact=MI&state=MC",
+                    "selected": False,
+                },
+            ],
+            "truncated": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_column_facet_results_column_starts_with_underscore(ds_client):
     facet = ColumnFacet(
         ds_client.ds,


### PR DESCRIPTION
Closes #2011.

The filter form always redirects to `?column__exact=value` (`filters_should_redirect` defaults the op to `exact`), but `ColumnFacet` only looked for `?column=value` when deciding if a facet value was selected, so a facet applied that way rendered as a plain link with no X to remove it. That matches the screenshot on the issue: `Sole Source` was applied by clicking the facet, so it gets an X, while `Contract Type` came from the filter form and doesn't. The spaces and punctuation in the value turned out to be a red herring.

Facet values now match either form of the querystring, and the toggle link removes whichever key is actually in the URL. One thing I left alone: when a `__exact` filter is present, the links for the *other* values in that facet still append `?column=value` next to it, same as before this change.

Added a regression test, the 19 tests in `tests/test_facets.py` pass.