### PR TITLE
Fix transaction wrapping for sqlite-utils 4.0 compatibility

### DIFF
--- a/datasette/database.py
+++ b/datasette/database.py
@@ -349,9 +349,19 @@ class Database:
                 self._write_connection = self.connect(write=True)
                 self.ds._prepare_connection(self._write_connection, self.name)
             if transaction:
-                with self._write_connection:
-                    self._write_connection.execute("BEGIN IMMEDIATE")
+                # Use explicit BEGIN IMMEDIATE so that conn.in_transaction is
+                # True during fn(), allowing sqlite-utils 4.0 to detect the
+                # outer transaction and use savepoints instead of auto-committing
+                # each individual write. Use conn.commit()/conn.rollback() rather
+                # than conn.execute("COMMIT"/"ROLLBACK") so that calls are no-ops
+                # when the inner function has already committed or rolled back.
+                self._write_connection.execute("BEGIN IMMEDIATE")
+                try:
                     result = fn(self._write_connection)
+                    self._write_connection.commit()
+                except BaseException:
+                    self._write_connection.rollback()
+                    raise
             else:
                 result = fn(self._write_connection)
         else:
@@ -481,9 +491,21 @@ class Database:
             else:
                 try:
                     if task.transaction:
-                        with conn:
-                            conn.execute("BEGIN IMMEDIATE")
+                        # Use explicit BEGIN IMMEDIATE so that conn.in_transaction
+                        # is True during task.fn(), allowing sqlite-utils 4.0 to
+                        # detect the outer transaction and use savepoints instead
+                        # of auto-committing each individual write. Use
+                        # conn.commit()/conn.rollback() rather than
+                        # conn.execute("COMMIT"/"ROLLBACK") so that calls are
+                        # no-ops when the inner function has already committed
+                        # or rolled back.
+                        conn.execute("BEGIN IMMEDIATE")
+                        try:
                             result = task.fn(conn)
+                            conn.commit()
+                        except BaseException:
+                            conn.rollback()
+                            raise
                     else:
                         result = task.fn(conn)
                 except Exception as e:  # noqa: BLE001


### PR DESCRIPTION
## Problem

sqlite-utils 4.0 changed transaction behaviour: every write (`insert_all`, `upsert_all`, `execute`, etc.) now checks `conn.in_transaction` at call-time. If that flag is `False`, sqlite-utils opens and immediately commits its **own** transaction, bypassing Datasette's outer `BEGIN IMMEDIATE`. A subsequent failure leaves the committed rows behind with no rollback path.

The old Datasette pattern:

```python
with conn:
    conn.execute("BEGIN IMMEDIATE")
    result = fn(conn)
```

relies on Python's `sqlite3.Connection` context manager calling `conn.commit()` on exit. This is fragile: it does not guarantee that `conn.in_transaction` is `True` during `fn()`, and if an inner `with conn:` inside the write function already committed, the outer `with conn:` exit becomes a no-op commit on a closed transaction.

## Fix

Replace both the non-threaded path (`database.py:352`) and the write-thread path (`database.py:491`) with an explicit `try/except`:

```python
conn.execute("BEGIN IMMEDIATE")
try:
    result = fn(conn)
    conn.commit()
except BaseException:
    conn.rollback()
    raise
```

Key properties:
- `conn.in_transaction` is `True` from `BEGIN IMMEDIATE` until `commit()`/`rollback()`, so sqlite-utils 4.0 correctly detects the outer transaction and uses `SAVEPOINT` instead of auto-commit
- Python's `conn.commit()` / `conn.rollback()` are idempotent no-ops when no transaction is active, so write functions that manage their own inner `with conn:` (e.g. `alter_table`) continue to work

## Testing

- All 147 `test_api_write.py` tests pass
- All 67 `test_internals_database.py` tests pass

Closes #2831