### PR TITLE
Fix duplicated words in documentation

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -293,7 +293,7 @@ This will create the HTML version of the documentation in ``docs/_build/html``. 
 
 Any time you make changes to a ``.rst`` file you can re-run ``make html`` to update the built documents, then refresh them in your browser.
 
-For added productivity, you can use use `sphinx-autobuild <https://pypi.org/project/sphinx-autobuild/>`__ to run Sphinx in auto-build mode. This will run a local webserver serving the docs that automatically rebuilds them and refreshes the page any time you hit save in your editor.
+For added productivity, you can use `sphinx-autobuild <https://pypi.org/project/sphinx-autobuild/>`__ to run Sphinx in auto-build mode. This will run a local webserver serving the docs that automatically rebuilds them and refreshes the page any time you hit save in your editor.
 
 ``sphinx-autobuild`` is included in the development dependency group. In your ``docs/`` directory you can start the server by running the following::
 

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -966,7 +966,7 @@ await .set_instance_metadata(self, key, value)
 
 Adds a new metadata entry for the entire Datasette instance.
 Any previous instance-level metadata entry with the same ``key`` will be overwritten.
-Internally upserts the value into the  the ``metadata_instance`` table inside the :ref:`internal database <internals_internal>`.
+Internally upserts the value into the ``metadata_instance`` table inside the :ref:`internal database <internals_internal>`.
 
 .. _datasette_set_database_metadata:
 
@@ -982,7 +982,7 @@ await .set_database_metadata(self, database_name, key, value)
 
 Adds a new metadata entry for the specified database.
 Any previous database-level metadata entry with the same ``key`` will be overwritten.
-Internally upserts the value into the  the ``metadata_databases`` table inside the :ref:`internal database <internals_internal>`.
+Internally upserts the value into the ``metadata_databases`` table inside the :ref:`internal database <internals_internal>`.
 
 .. _datasette_set_resource_metadata:
 
@@ -1000,7 +1000,7 @@ await .set_resource_metadata(self, database_name, resource_name, key, value)
 
 Adds a new metadata entry for the specified "resource".
 Any previous resource-level metadata entry with the same ``key`` will be overwritten.
-Internally upserts the value into the  the ``metadata_resources`` table inside the :ref:`internal database <internals_internal>`.
+Internally upserts the value into the ``metadata_resources`` table inside the :ref:`internal database <internals_internal>`.
 
 .. _datasette_set_column_metadata:
 
@@ -1020,7 +1020,7 @@ await .set_column_metadata(self, database_name, resource_name, column_name, key,
 
 Adds a new metadata entry for the specified column.
 Any previous column-level metadata entry with the same ``key`` will be overwritten.
-Internally upserts the value into the  the ``metadata_columns`` table inside the :ref:`internal database <internals_internal>`.
+Internally upserts the value into the ``metadata_columns`` table inside the :ref:`internal database <internals_internal>`.
 
 .. _datasette_stored_queries:
 

--- a/docs/plugin_hooks.rst
+++ b/docs/plugin_hooks.rst
@@ -223,7 +223,7 @@ Dictionary
     If you return a dictionary its keys and values will be merged into the template context.
 
 Function that returns a dictionary
-    If you return a function it will be executed. If it returns a dictionary those values will will be merged into the template context.
+    If you return a function it will be executed. If it returns a dictionary those values will be merged into the template context.
 
 Function that returns an awaitable function that returns a dictionary
     You can also return a function which returns an awaitable function which returns a dictionary.
@@ -1739,7 +1739,7 @@ This hook is called any time an unexpected exception is raised. You can use it t
 
 If your handler returns a ``Response`` object it will be returned to the client in place of the default Datasette error page.
 
-The handler can return a response directly, or it can return return an awaitable function that returns a response.
+The handler can return a response directly, or it can return an awaitable function that returns a response.
 
 This example logs an error to `Sentry <https://sentry.io/>`__ and then renders a custom error page:
 


### PR DESCRIPTION
A few duplicated words in the docs prose:

- `docs/internals.rst`: "into the  the ``metadata_*`` table" -> "into the ``metadata_*`` table" (4 parallel method docstrings: instance/databases/resources/columns).
- `docs/plugin_hooks.rst`: "those values will will be merged" -> "will be merged"; and "it can return return an awaitable" -> "return an awaitable".
- `docs/contributing.rst`: "you can use use `sphinx-autobuild`" -> "you can use".

Documentation only.
