### PR TITLE
Fix ad hoc query form action

### DIFF
--- a/datasette/templates/query.html
+++ b/datasette/templates/query.html
@@ -37,7 +37,7 @@
 
 {% block description_source_license %}{% include "_description_source_license.html" %}{% endblock %}
 
-<form class="sql core" action="{{ urls.database(database) }}{% if stored_query %}/{{ stored_query }}{% endif %}" method="{% if stored_query_write %}post{% else %}get{% endif %}" data-parameters-url="{{ urls.database(database) }}/-/query/parameters">
+<form class="sql core" action="{{ urls.database(database) }}{% if stored_query %}/{{ stored_query }}{% else %}/-/query{% endif %}" method="{% if stored_query_write %}post{% else %}get{% endif %}" data-parameters-url="{{ urls.database(database) }}/-/query/parameters">
     <h3>Custom SQL query{% if display_rows %} returning {% if truncated %}more than {% endif %}{{ "{:,}".format(display_rows|length) }} row{% if display_rows|length == 1 %}{% else %}s{% endif %}{% endif %}{% if not query_error %}
         <span class="show-hide-sql">(<a href="{{ show_hide_link }}">{{ show_hide_text }}</a>)</span>
     {% endif %}</h3>

--- a/tests/test_query_form_action.py
+++ b/tests/test_query_form_action.py
@@ -1,0 +1,12 @@
+import pytest
+from bs4 import BeautifulSoup as Soup
+
+
+@pytest.mark.asyncio
+async def test_ad_hoc_query_form_posts_to_query_route(ds_client):
+    response = await ds_client.get("/fixtures/-/query?sql=select+1")
+    assert response.status_code == 200
+
+    form = Soup(response.text, "html.parser").select_one("form.sql.core")
+    assert form is not None
+    assert form["action"] == "/fixtures/-/query"


### PR DESCRIPTION
Fixes #2487.

The ad hoc query page currently submits its SQL form to the database root, while the initial query form uses the dedicated `/-/query` route. This updates `query.html` so non-stored queries consistently submit to `/<database>/-/query`, while preserving the existing stored-query action.

Includes a focused regression test asserting the rendered ad hoc query form targets `/fixtures/-/query`.

I could not run the test suite locally in this automation environment because the local runtime does not have a usable GitHub checkout/network path, so CI is the verification path for this change.