### PR TITLE
README: minimum Python is 3.10, not 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can also install it using `pip` or `pipx`:
 
     pip install datasette
 
-Datasette requires Python 3.8 or higher. We also have [detailed installation instructions](https://docs.datasette.io/en/stable/installation.html) covering other options such as Docker.
+Datasette requires Python 3.10 or higher. We also have [detailed installation instructions](https://docs.datasette.io/en/stable/installation.html) covering other options such as Docker.
 
 ## Basic usage
 


### PR DESCRIPTION
The README's installation section still says:

> Datasette requires Python 3.8 or higher.

but the actual floor is 3.10:

- `pyproject.toml` has `requires-python = ">=3.10"` (set in ce4b079)
- the 0.65 release notes (2024-10-07) say "Dropped support for Python 3.8"
- `docs/contributing.rst` already says "If you have Python 3.10 or higher"

A user on 3.8 or 3.9 who follows the README gets pip's `Requires-Python` refusal at install time. One-word fix; no other live doc makes the 3.8 claim (the changelog mentions are history and correct as written).

Found with [docproof](https://github.com/melbinjp/docproof), which checks what documentation claims against what the repository actually contains.
