### PR TITLE
Include SQLite version in datasette --version output

### DIFF
--- a/datasette/cli.py
+++ b/datasette/cli.py
@@ -122,8 +122,29 @@ def sqlite_extensions(fn):
     return wrapped
 
 
+def _print_version(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+    sqlite_version = (
+        sqlite3.connect(":memory:").execute("select sqlite_version()").fetchone()[0]
+    )
+    click.echo(
+        "{}, version {} (SQLite {})".format(
+            ctx.find_root().info_name, __version__, sqlite_version
+        )
+    )
+    ctx.exit()
+
+
 @click.group(cls=DefaultGroup, default="serve", default_if_no_args=True)
-@click.version_option(version=__version__)
+@click.option(
+    "--version",
+    is_flag=True,
+    expose_value=False,
+    is_eager=True,
+    callback=_print_version,
+    help="Show the version and exit.",
+)
 def cli():
     """
     Datasette is an open source multi-tool for exploring and publishing data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -231,7 +231,13 @@ def test_uninstall(run_module):
 def test_version():
     runner = CliRunner()
     result = runner.invoke(cli, ["--version"])
-    assert result.output == f"cli, version {__version__}\n"
+    expected_sqlite_version = (
+        sqlite3.connect(":memory:").execute("select sqlite_version()").fetchone()[0]
+    )
+    assert (
+        result.output
+        == f"cli, version {__version__} (SQLite {expected_sqlite_version})\n"
+    )
 
 
 @pytest.mark.parametrize("invalid_port", ["-1", "0.5", "dog", "65536"])


### PR DESCRIPTION
Closes #1998.

`datasette --version` now includes the SQLite version alongside the Datasette version:

```
$ datasette --version
datasette, version 1.0a38 (SQLite 3.46.1)
```

This makes it easy to see which SQLite version a given Datasette install is running against without having to start the server and load `/-/versions`.

Following the approach you sketched out in the issue, this replaces the `@click.version_option` decorator on the `cli` group with a small custom eager `--version` option. The SQLite version is only queried when `--version` is actually passed, so there's no cost on normal startup. The existing `test_version` test is updated to assert the new format.
