### PR TITLE
Document customizing breadcrumbs

### DIFF
--- a/docs/custom_templates.rst
+++ b/docs/custom_templates.rst
@@ -302,6 +302,20 @@ content you can do so by creating a ``row.html`` template like this:
 Note the ``default:row.html`` template name, which ensures Jinja will inherit
 from the default template.
 
+Customizing breadcrumbs
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The default ``base.html`` template provides a ``crumbs`` block inside its
+navigation block. Override ``crumbs`` to customize the breadcrumbs without
+replacing the rest of the navigation. The imported ``crumbs.nav()`` macro
+renders Datasette's permission-aware breadcrumbs:
+
+.. code-block:: jinja
+
+    {% block crumbs %}
+    {{ crumbs.nav(request=request, database=database, table=table) }}
+    {% endblock %}
+
 The ``_table.html`` template is included by both the row and the table pages,
 and a list of rows. The default ``_table.html`` template renders them as an
 HTML template and `can be seen here <https://github.com/simonw/datasette/blob/main/datasette/templates/_table.html>`_.


### PR DESCRIPTION
Fixes #1902

Documents the nested `crumbs` template block and shows how plugin authors can reuse `crumbs.nav()` to preserve Datasette's permission-aware breadcrumbs without replacing the rest of the navigation.

## Tests

- `sphinx-build -W -b html docs /tmp/datasette-1902-docs-build`
- `codespell docs/custom_templates.rst`
- `blacken-docs --check docs/custom_templates.rst`
- `pytest -q tests/test_docs.py` — 13 passed, 141 subtests passed
